### PR TITLE
Add newlines after index and contents blocks

### DIFF
--- a/src/modules/Writers.jl
+++ b/src/modules/Writers.jl
@@ -138,6 +138,7 @@ function render(io::IO, ::MIME"text/plain", index::Expanders.IndexNode, page, do
         url = string(page, "#", Utilities.slugify(object))
         println(io, "- [`", object.binding, "`](", url, ")")
     end
+    println(io)
 end
 
 function render(io::IO, ::MIME"text/plain", contents::Expanders.ContentsNode, page, doc)
@@ -169,6 +170,7 @@ function render(io::IO, ::MIME"text/plain", contents::Expanders.ContentsNode, pa
             end
         end
     end
+    println(io)
 end
 
 function render(io::IO, mime::MIME"text/plain", node::Expanders.EvalNode, page, doc)


### PR DESCRIPTION
`ContentsNode`s and `IndexNode`s rendered in markdown should have a newline at the end, otherwise the lists crash into the stuff that follows, effectively merging lists and such, which I don't think is the intended behaviour.

I.e. right now, the following source

    # Section

    ```@index
    ```

    ```@contents
    ```

    ```@docs
    ==
    >=
    ```

    ## Subsection

renders as

```
<a id='Section-1'></a>

# Section

- [`Base.==`](index.md#Base.==)
- [`Base.>=`](index.md#Base.>=)
- [Section](index.md#Section-1)
    - [Subsection](index.md#Subsection-1)
<a id='Base.==' href='#Base.=='>#</a>
**`Base.==`** &mdash; *Function*.
[...]
```

With the PR, the lists become separated

```
<a id='Section-1'></a>

# Section

- [`Base.==`](index.md#Base.==)
- [`Base.>=`](index.md#Base.>=)

- [Section](index.md#Section-1)
    - [Subsection](index.md#Subsection-1)

<a id='Base.==' href='#Base.=='>#</a>
**`Base.==`** &mdash; *Function*.
```