### PR TITLE
Minor `Writers` refactoring

### DIFF
--- a/src/modules/CrossReferences.jl
+++ b/src/modules/CrossReferences.jl
@@ -69,7 +69,7 @@ function basicxref(link::Markdown.Link, meta, page, doc)
         # No `name` was provided, since given a `@ref`, so slugify the `.text` instead.
         text = strip(sprint(Markdown.plain, Markdown.Paragraph(link.text)))
         if ismatch(r"#[0-9]+", text)
-            issue_xref(link, text, meta, page, doc)
+            issue_xref(link, lstrip(text, '#'), meta, page, doc)
         else
             name = Utilities.slugify(text)
             namedxref(link, name, meta, page, doc)
@@ -134,18 +134,8 @@ end
 # Issues/PRs cross referencing.
 # -----------------------------
 
-if isdefined(Base, :LibGit2)
-    function issue_xref(link::Markdown.Link, num, meta, page, doc)
-        remote =
-            LibGit2.with(LibGit2.GitRepoExt(dirname(doc.user.root))) do repo
-                LibGit2.with(LibGit2.GitConfig(repo)) do cfg
-                    Utilities.getremote(cfg)
-                end
-            end
-        isnull(remote) || (link.url = "https://github.com/$(get(remote))/issues/$(num[2:end])")
-    end
-else
-    issue_xref(link::Markdown.Link, num, meta, page, doc) = nothing
+function issue_xref(link::Markdown.Link, num, meta, page, doc)
+    link.url = "https://github.com/$(doc.internal.remote)/issues/$num"
 end
 
 end

--- a/src/modules/CrossReferences.jl
+++ b/src/modules/CrossReferences.jl
@@ -100,6 +100,7 @@ function namedxref(link::Markdown.Link, slug, meta, page, doc)
             # Replace the `@ref` url with a path to the referenced header.
             anchor   = get(Anchors.anchor(headers, slug))
             path     = relpath(anchor.file, dirname(page.build))
+            path     = Formats.extension(doc.user.format, path)
             link.url = string(path, '#', slug, '-', anchor.nth)
         else
             Utilities.warn(page.source, "'$slug' is not unique.")
@@ -120,6 +121,7 @@ function docsxref(link::Markdown.Link, meta, page, doc)
         # Replace the `@ref` url with a path to the referenced docs.
         docsnode = doc.internal.objects[object]
         path     = relpath(docsnode.page.build, dirname(page.build))
+        path     = Formats.extension(doc.user.format, path)
         slug     = Utilities.slugify(object)
         link.url = string(path, '#', slug)
         # Fixup keyword ref text since they have a leading ':' char.

--- a/src/modules/Documents.jl
+++ b/src/modules/Documents.jl
@@ -149,13 +149,14 @@ immutable IndexNode
     end
 end
 
-function populate!(index::IndexNode, doc::Document)
+function populate!(index::IndexNode, document::Document)
     # Filtering valid index links.
-    for (object, doc) in doc.internal.objects
+    for (object, doc) in document.internal.objects
         page = relpath(doc.page.build, dirname(index.build))
         mod  = object.binding.mod
         cat  = Symbol(lowercase(Utilities.doccat(object)))
         if _isvalid(page, index.pages) && _isvalid(mod, index.modules) && _isvalid(cat, index.order)
+            page = Formats.extension(document.user.format, page)
             push!(index.elements, (object, doc, page, mod, cat))
         end
     end
@@ -194,13 +195,14 @@ immutable ContentsNode
     end
 end
 
-function populate!(contents::ContentsNode, doc::Document)
+function populate!(contents::ContentsNode, document::Document)
     # Filtering valid contents links.
-    for (id, filedict) in doc.internal.headers.map
+    for (id, filedict) in document.internal.headers.map
         for (file, anchors) in filedict
             for anchor in anchors
                 page = relpath(anchor.file, dirname(contents.build))
                 if _isvalid(page, contents.pages) && Utilities.header_level(anchor.object) ≤ contents.depth
+                    page = Formats.extension(document.user.format, page)
                     push!(contents.elements, (anchor.order, page, anchor))
                 end
             end

--- a/src/modules/Documents.jl
+++ b/src/modules/Documents.jl
@@ -67,6 +67,7 @@ Private state used to control the generation process.
 """
 immutable Internal
     assets  :: Compat.String
+    remote  :: Compat.String
     pages   :: Dict{Compat.String, Page}
     headers :: Anchors.AnchorMap
     docs    :: Anchors.AnchorMap
@@ -107,6 +108,7 @@ function Document(;
     )
     internal = Internal(
         Utilities.assetsdir(),
+        Utilities.getremote(root),
         Dict{Compat.String, Page}(),
         Anchors.AnchorMap(),
         Anchors.AnchorMap(),

--- a/src/modules/Formats.jl
+++ b/src/modules/Formats.jl
@@ -29,4 +29,16 @@ function mimetype(f::Format)
         error("unexpected format.")
 end
 
+function extension(f::Format, file)
+    path, _ = splitext(file)
+    string(path, extension(f))
+end
+
+function extension(f::Format)
+    f ≡ Markdown ? ".md"   :
+    f ≡ LaTeX    ? ".tex"  :
+    f ≡ HTML     ? ".html" :
+        error("unexpected format.")
+end
+
 end

--- a/src/modules/Writers.jl
+++ b/src/modules/Writers.jl
@@ -27,7 +27,7 @@ Writes a [`Documents.Document`](@ref) object to `build` directory in specified f
 function render(doc::Documents.Document)
     mime = Formats.mimetype(doc.user.format)
     for (src, page) in doc.internal.pages
-        open(page.build, "w") do io
+        open(Formats.extension(doc.user.format, page.build), "w") do io
             for elem in page.elements
                 node = page.mapping[elem]
                 render(io, mime, node, page, doc)
@@ -160,10 +160,15 @@ dropheaders(other) = other
 
 # TODO
 
+function render(io::IO, ::MIME"text/latex", node, page, doc)
+end
+
 # HTML Output.
 # ------------
 
 # TODO
 
+function render(io::IO, ::MIME"text/html", node, page, doc)
+end
 
 end

--- a/src/modules/Writers.jl
+++ b/src/modules/Writers.jl
@@ -161,6 +161,7 @@ dropheaders(other) = other
 # TODO
 
 function render(io::IO, ::MIME"text/latex", node, page, doc)
+    error("LaTeX rendering is unsupported.")
 end
 
 # HTML Output.
@@ -169,6 +170,7 @@ end
 # TODO
 
 function render(io::IO, ::MIME"text/html", node, page, doc)
+    error("HTML rendering is unsupported.")
 end
 
 end

--- a/src/modules/Writers.jl
+++ b/src/modules/Writers.jl
@@ -50,52 +50,51 @@ function render(io::IO, mime::MIME"text/plain", anchor::Anchors.Anchor, page, do
     render(io, mime, anchor.object, page, doc)
 end
 
+
+## Documentation Nodes.
+
 function render(io::IO, mime::MIME"text/plain", node::Expanders.DocsNodes, page, doc)
-    for doc in node.nodes
-        render(io, mime, doc, page, doc)
+    for node in node.nodes
+        render(io, mime, node, page, doc)
     end
 end
 
 function render(io::IO, mime::MIME"text/plain", node::Expanders.DocsNode, page, doc)
-    println(
-        io,
-        """
-        <a id='$(node.anchor.id)' href='#$(node.anchor.id)'>#</a>
-        **`$(node.object.binding)`** &mdash; *$(Utilities.doccat(node.object))*.
-
-        """
-    )
-    render(io, mime, dropheaders(source_urls(node.docstr)), page, doc)
+    # Docstring header based on the name of the binding and it's category.
+    anchor = "<a id='$(node.anchor.id)' href='#$(node.anchor.id)'>#</a>"
+    header = "**`$(node.object.binding)`** &mdash; *$(Utilities.doccat(node.object))*."
+    println(io, anchor, "\n", header, "\n\n")
+    # Body. May contain several concatenated docstrings.
+    renderdoc(io, mime, node.docstr, page, doc)
 end
 
-function source_urls(docstr::Base.Markdown.MD)
-    if haskey(docstr.meta, :results)
-        out = []
-        for (md, result) in zip(docstr.content, docstr.meta[:results])
-            push!(out, md)
-            url = Utilities.url(
-                result.data[:module],
-                result.data[:path],
-                linerange(result.text, result.data[:linenumber]),
-            )
-            isnull(url) || push!(
-                out, "\n<a target='_blank' href='$(get(url))' class='documenter-source'>source</a><br>\n"
-            )
+function renderdoc(io::IO, mime::MIME"text/plain", md::Markdown.MD, page, doc)
+    if haskey(md.meta, :results)
+        # The `:results` field contains a vector of `Docs.DocStr` objects associated with
+        # each markdown object. The `DocStr` contains data such as file and line info that
+        # we need for generating correct source links.
+        for (markdown, result) in zip(md.content, md.meta[:results])
+            render(io, mime, dropheaders(markdown), page, doc)
+            # When a source link is available then print the link.
+            Utilities.unwrap(Utilities.url(doc.internal.remote, result)) do url
+                link = "<a target='_blank' href='$url' class='documenter-source'>source</a><br>"
+                println(io, "\n", link, "\n")
+            end
         end
-        out
     else
-        docstr
+        # Docstrings with no `:results` metadata won't contain source locations so we don't
+        # try to print them out. Just print the basic docstring.
+        render(io, mime, dropheaders(md), page, doc)
     end
 end
-source_urls(other) = other
 
-function linerange(text, from)
-    lines = sum([isodd(n) ? newlines(s) : 0 for (n, s) in enumerate(text)])
-    lines > 0 ? string(from, '-', from + lines + 1) : string(from)
+function renderdoc(io::IO, mime::MIME"text/plain", other, page, doc)
+    # TODO: properly support non-markdown docstrings at some point.
+    render(io, mime, other, page, doc)
 end
 
-newlines(s::AbstractString) = count(c -> c === '\n', s)
-newlines(other) = 0
+
+## Index, Contents, and Eval Nodes.
 
 function render(io::IO, ::MIME"text/plain", index::Documents.IndexNode, page, doc)
     Documents.populate!(index, doc)
@@ -124,6 +123,9 @@ function render(io::IO, mime::MIME"text/plain", node::Expanders.EvalNode, page, 
     render(io, mime, node.result, page, doc)
 end
 
+
+## Basic Nodes. AKA: any other content that hasn't been handled yet.
+
 function render(io::IO, ::MIME"text/plain", other, page, doc)
     println(io)
     Markdown.plain(io, other)
@@ -132,7 +134,26 @@ end
 
 render(io::IO, ::MIME"text/plain", str::AbstractString, page, doc) = print(io, str)
 
+# Metadata Nodes get dropped from the final output for every format but are needed throughout
+# rest of the build and so we just leave them in place and print a blank line in their place.
 render(io::IO, ::MIME"text/plain", node::Expanders.MetaNode, page, doc) = println(io, "\n")
+
+
+## Markdown Utilities.
+
+# Remove all header nodes from a markdown object and replace them with bold font.
+# Only for use in `text/plain` output, since we'll use some css to make these less obtrusive
+# in the HTML rendering instead of using this hack.
+function dropheaders(md::Markdown.MD)
+    out = Markdown.MD()
+    out.meta = md.meta
+    out.content = map(dropheaders, md.content)
+    out
+end
+dropheaders(h::Markdown.Header) = Markdown.Paragraph(Markdown.Bold(h.text))
+dropheaders(v::Vector) = map(dropheaders, v)
+dropheaders(other) = other
+
 
 # LaTeX Output.
 # -------------
@@ -144,17 +165,5 @@ render(io::IO, ::MIME"text/plain", node::Expanders.MetaNode, page, doc) = printl
 
 # TODO
 
-# Utilities.
-# ----------
-
-function dropheaders(md::Markdown.MD)
-    out = Markdown.MD()
-    out.meta = md.meta
-    out.content = map(dropheaders, md.content)
-    out
-end
-dropheaders(h::Markdown.Header) = Markdown.Paragraph(Markdown.Bold(h.text))
-dropheaders(v::Vector) = map(dropheaders, v)
-dropheaders(other) = other
 
 end


### PR DESCRIPTION
Moves some non-rendering code into more suitable modules.

Only check for the git remote url once on construction of the `Document` object and then reuse that when needed.

Add `Utilties.unwrap` to call a function on the value wrapped by a `Nullable` if it exists.

cc @mortenpi, it's not a complete refactor of course, but let me know if there's other bits in particular you'd like to see fixed up.