### PR TITLE
Fix REPL multiline display

### DIFF
--- a/src/modules/DocChecks.jl
+++ b/src/modules/DocChecks.jl
@@ -211,9 +211,15 @@ end
 # Display doctesting results.
 
 function result_to_string(buf, value)
-    dis = Base.Multimedia.TextDisplay(buf)
+    dis = text_display(buf)
     value === nothing || display(dis, value)
     sanitise(buf)
+end
+
+if VERSION < v"0.5.0-dev+4305"
+    text_display(buf) = TextDisplay(buf)
+else
+    text_display(buf) = TextDisplay(IOContext(buf, multiline = true, limit = true))
 end
 
 function error_to_string(buf, er, bt)

--- a/test/examples/src/index.md
+++ b/test/examples/src/index.md
@@ -26,3 +26,17 @@ Pages = ["man/tutorial.md"]
 ```
 
 [#60](@ref) [#61](@ref)
+
+```@repl
+zeros(5, 5)
+zeros(50, 50)
+```
+
+```julia
+julia> [1.0, 2.0, 3.0]
+3-element Array{Float64,1}:
+ 1.0
+ 2.0
+ 3.0
+
+```


### PR DESCRIPTION
Needed due to changes in how `IOContext` objects display in the REPL in recent Julia 0.5-dev build.

Fixes #83.