### PR TITLE
Implement method lists

### DIFF
--- a/assets/Documenter.css
+++ b/assets/Documenter.css
@@ -5,3 +5,14 @@ div.wy-menu-vertical ul.current li.toctree-l3 a {
 a.documenter-source {
   float: right;
 }
+
+.documenter-methodtable pre {
+    margin-left: 0px;
+    margin-right: 0px;
+    margin-top:  0px;
+    padding:     0px;
+}
+
+.documenter-methodtable pre.documenter-inline {
+    display: inline;
+}

--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -82,6 +82,7 @@ Expanders.IndexBlocks
 Expanders.ContentsBlocks
 Expanders.ExampleBlocks
 Expanders.REPLBlocks
+Expanders.docsnode_methodlist
 ```
 
 ## Formats
@@ -128,6 +129,8 @@ Walkers.walk
 ```@docs
 Writers
 Writers.render
+Writers.join_decl
+Writers.span
 ```
 
 ## Utilities
@@ -149,4 +152,5 @@ Utilities.object
 Utilities.docs
 Utilities.doccat
 Utilities.nodocs
+Utilities.issubmodule
 ```

--- a/src/modules/Expanders.jl
+++ b/src/modules/Expanders.jl
@@ -261,16 +261,88 @@ end
 # @docs
 # -----
 
+immutable MethodNode
+    method  :: Method
+    visible :: Bool
+end
+
 immutable DocsNode
-    docstr :: Any
-    anchor :: Anchors.Anchor
-    object :: Utilities.Object
-    page   :: Documents.Page
+    docstr  :: Any
+    anchor  :: Anchors.Anchor
+    object  :: Utilities.Object
+    page    :: Documents.Page
+    """
+    Vector of methods associated with this `DocsNode`. Being nulled means that
+    conceptually the `DocsNode` has no table of method (as opposed to having
+    an empty table).
+    """
+    methods :: Nullable{Vector{MethodNode}}
 end
 
 immutable DocsNodes
     nodes :: Vector{DocsNode}
 end
+
+"""
+Returns a `Nullable{Vector{MethodNode}}` with the methods associated with the `object`.
+
+Null is returned if the object conceptually does not have a table of methods (e.g.
+modules). If instead the object should have a table of methods which just happens
+to be empty then it returns an empty vector.
+
+The methods are also filtered, with `MethodNode.visible` set to false for those
+methods not defined in this package. This allows the writers to choose how they
+want to treat trivial constructors, functions imported from `Base` and such.
+
+Due to differences between 0.4 and 0.5, only 0.5 is supported currently. On 0.4
+we always drop the methods table.
+"""
+function docsnode_methodlist end
+
+if VERSION > v"0.5-"
+    function docsnode_methodlist(object::Utilities.Object, page, doc)
+        if !isdefined(object.binding.mod, object.binding.var)
+            info("Unable to find $(object)")
+            return Nullable{Vector{MethodNode}}()
+        end
+
+        # Fetch the actual object and its category
+        object_deref = getfield(object.binding.mod, object.binding.var)
+        doccat = Utilities.doccat(object)
+
+        # We do not attach a method table to a `DocsNode` of an abstract type,
+        # except when it has 2 or more methods. While abstract types can not be
+        # constructed, they do have the default (::Type{T})(args..) method attached
+        # to them, but this is not very interesting to the user. However, it is
+        # possible to add additional methods to abstract types and if that is the
+        # case then we should display the method table, hence the "less than two"
+        # check.
+        if (doccat == "Type") && !isleaftype(object_deref) && length(methods(object_deref)) < 2
+            return Nullable{Vector{MethodNode}}()
+        end
+
+        # We only generate the method table for a Function, Type and Macro.
+        # The only other one with methods should be Method itself (e.g. defined
+        # with `foo(x,y)` in the @docs block), but in that case the user has
+        # already picked a method and we shouldn't generate a single element
+        # table.
+        if doccat == "Function" || doccat == "Type" || doccat == "Macro"
+            ms = map(methods(object_deref)) do m
+                # We filter out the methods not defined in this package.
+                # That is we only show the method if it is defined in any of the
+                # modules in `doc.user.modules`, which is derived from the `modules`
+                # setting in `makedocs`.
+                MethodNode(m, m.module in doc.user.modules)
+            end
+            return Nullable(ms)
+        else
+            return Nullable{Vector{MethodNode}}()
+        end
+    end
+else
+    docsnode_methodlist(args...) = Nullable{Vector{MethodNode}}()
+end
+
 
 function Selectors.runner(::Type{DocsBlocks}, x, page, doc)
     failed = false
@@ -303,7 +375,8 @@ function Selectors.runner(::Type{DocsBlocks}, x, page, doc)
         # Update `doc` with new object and anchor.
         docstr   = get(filtered)
         anchor   = Anchors.add!(doc.internal.docs, object, slug, page.build)
-        docsnode = DocsNode(docstr, anchor, object, page)
+        ms = docsnode_methodlist(object, page, doc)
+        docsnode = DocsNode(docstr, anchor, object, page, ms)
         doc.internal.objects[object] = docsnode
         push!(nodes, docsnode)
     end

--- a/src/modules/Utilities.jl
+++ b/src/modules/Utilities.jl
@@ -448,4 +448,20 @@ function withoutput(func, stream::CombinedStream, buffer::IOBuffer)
     end
 end
 
+"""
+    issubmodule(sub, mod)
+
+Checks whether `sub` is a submodule of `mod`. A module is also considered to be
+its own submodule.
+
+E.g. `A.B.C` is a submodule of `A`, `A.B` and `A.B.C`, but it is not a submodule
+of `D`, `A.D` nor `A.B.C.D`.
+"""
+function issubmodule(sub, mod)
+    if (sub === Main) && (mod !== Main)
+        return false
+    end
+    (sub === mod) || issubmodule(module_parent(sub), mod)
+end
+
 end

--- a/src/modules/Writers.jl
+++ b/src/modules/Writers.jl
@@ -59,6 +59,31 @@ function render(io::IO, mime::MIME"text/plain", node::Expanders.DocsNodes, page,
     end
 end
 
+"""Wrap a string `str` in a `<span class="<cls>">`."""
+span(cls,str) = "<span class=\"$(cls)\">$(str)</span>"
+
+"""
+Converts the function argument tuple `(name, type)` into a string.
+
+The tuple comes from the second return element of the `Base.arg_decl_parts(::Method)`
+and it seems they are always both `::String` (`::ASCIIString` in 0.4).
+It also appears that if the type is not declared for the method, `arg_decl_parts`
+returns an empty string.
+
+The returned string is `name::type` or just `name`, if the type is not declared.
+
+If the keyword argument `html` is true (default), then it also puts `<span>`s
+around the characters for code highlighting.
+"""
+function join_decl(decl; html::Bool=true)
+    n, t = decl
+    if html
+        isempty(t) ? span(:n,n) : span(:n,n) * span(:p,"::") * span(:n,t)
+    else
+        isempty(t) ? n : "$(n)::$(t)"
+    end
+end
+
 function render(io::IO, mime::MIME"text/plain", node::Expanders.DocsNode, page, doc)
     # Docstring header based on the name of the binding and it's category.
     anchor = "<a id='$(node.anchor.id)' href='#$(node.anchor.id)'>#</a>"
@@ -66,6 +91,90 @@ function render(io::IO, mime::MIME"text/plain", node::Expanders.DocsNode, page, 
     println(io, anchor, "\n", header, "\n\n")
     # Body. May contain several concatenated docstrings.
     renderdoc(io, mime, node.docstr, page, doc)
+
+    # Table of methods.
+    # If DocsNode.methods is nulled, then we assume that we should not render a
+    # table. However, if the list of methods is there but has no elements then
+    # we output an appropriate note saying that the name has no methods associated
+    # with it.
+    Utilities.unwrap(node.methods) do methodnodes
+        name = node.object.binding.var # name of the method without the modules
+
+        # We filter out the methods that are marked `visible`
+        ms = [m.method for m in filter(m -> m.visible, methodnodes)]
+
+        println(io, "<strong>Methods</strong>\n")
+
+        # We print a small notice of the methods table is completely empty,
+        # and an unordered list of methods if there are some to display.
+        if isempty(methodnodes)
+            println(io, "This function has no methods.\n")
+        elseif isempty(ms)
+            println(io, "This function has no methods to display.\n")
+        else
+            # A regexp to match filenames with an absolute path
+            r = Regex("$(Pkg.dir())/([A-Za-z0-9]+)/(.*)")
+
+            print(io, """
+            <ul class="documenter-methodtable">
+            """)
+
+            for m in ms
+                tv, decls, file, line = Base.arg_decl_parts(m)
+                decls = decls[2:end]
+                file = string(file)
+                url = get(Utilities.url(doc.internal.remote, m.module, file, line), "")
+                file_match = match(r, file)
+                if file_match !== nothing
+                    file = file_match.captures[2]
+                end
+                # We'll generate the HTML now.
+                #
+                # We also apply code highlighting that tries to be consistent with
+                # how the code blocks are highlighted in mkdocs. In a nutshell, all
+                # characters have to be wrapped in <span>s with specific classes.
+                # The classes seem to have the following semantics:
+                #
+                #   - p   punctuation, e.g. {} () :: ,.
+                #   - k   keyword, e.g. type, return
+                #   - nf  function name, in a function definition
+                #   - n   name (generally, as used in code)
+                #
+                # TODO: the type expressions (in typevars or after ::) are colored
+                #       as normal names, but it would be nice to have them properly
+                #       highlighted (e.g. if there's a string in the type name,
+                #       like in MIME"text/html")
+                #
+                tvars = isempty(tv) ? "" :
+                    span(:p,"{") * join([span(:n,t) for t in tv], span(:p,", ")) * span(:p,"}")
+                # If the list of arguments is too long (which can happen quite easily
+                # due to long type names), we will display them in a multiline block
+                # instead.
+                args_raw = join([join_decl(d, html=false) for d in decls], span(:p,", "))
+                args,preclass = if length(args_raw) <= 50
+                    join([join_decl(d) for d in decls], span(:p,", ")),
+                    " class=\"documenter-inline\""
+                else
+                    "\n" * join([(" "^4)*join_decl(d) for d in decls], span(:p,",\n")) * "\n",
+                    ""
+                end
+                print(io, """
+                <li>
+                    <pre$(preclass)>$(span(:nf,name))$(tvars)$(span(:p,"("))$(args)$(span(:p,")"))</pre>
+                    defined at
+                    <a target="_blank" href="$(url)">$(file):$(line)</a>
+                </li>
+                """)
+            end
+            print(io, "</ul>\n\n")
+        end
+
+        # we print a small notice if we are not displaying all the methods
+        nh = length(methodnodes)-length(ms) # number of hidden methods
+        if nh > 0
+            println(io, "_Hiding $(nh) method$(nh==1?"":"s") defined outside of this package._\n")
+        end
+    end
 end
 
 function renderdoc(io::IO, mime::MIME"text/plain", md::Markdown.MD, page, doc)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,6 +87,8 @@ using Compat
 
 module UnitTests
 
+module SubModule end
+
 type T end
 
 "Documenter unit tests."
@@ -108,6 +110,14 @@ let doc = @doc(length)
     @test !contains(stringmime("text/plain", get(c)), "Documenter unit tests.")
     @test isnull(d)
 end
+
+# Documenter.Utilities.issubmodule
+@test Documenter.Utilities.issubmodule(Main, Main) === true
+@test Documenter.Utilities.issubmodule(UnitTests, UnitTests) === true
+@test Documenter.Utilities.issubmodule(UnitTests.SubModule, Main) === true
+@test Documenter.Utilities.issubmodule(UnitTests.SubModule, UnitTests) === true
+@test Documenter.Utilities.issubmodule(UnitTests.SubModule, Base) === false
+@test Documenter.Utilities.issubmodule(UnitTests, UnitTests.SubModule) === false
 
 
 # Integration tests for module api.


### PR DESCRIPTION
Things left to do:
 - [x] Make it work with macros (fixed by getting rid of an `eval`)
 - [x] Fix 0.4 (-> don't support at the moment)
 - [x] Typevars
 - [x] The last Type method (`(::Type{T})`) (-> filtered out)
 - [x] Fix docstring source links (too much whitespace) (-> won't fix)
 - [x] Filtering by module.
 - [x] Documentation.

Decisions:
 - [x] Disabling the printing of method tables? (-> possibly implement this in the future)
 - [x] Don't print for abstract types? (-> implemented)

---

A preliminary version of method lists for the markdown output. It puts the methods from the `methods(obj)` function as an ordered list to the end to the docstring for every name that has methods.

Basically looks like this:
![typesigs](https://cloud.githubusercontent.com/assets/147757/15920808/0d298878-2e71-11e6-9ef0-bfdc42d08912.png)

Currently macros are not working since an `eval` fails. Also, due to differences between 0.4 and 0.5, 0.4 is currently not working. One option would be to disable this feature for 0.4 completely, but in principle it should be possible to work around the current problems.