### PR TITLE
Don't error on missing git remote

### DIFF
--- a/src/modules/CrossReferences.jl
+++ b/src/modules/CrossReferences.jl
@@ -137,7 +137,8 @@ end
 # -----------------------------
 
 function issue_xref(link::Markdown.Link, num, meta, page, doc)
-    link.url = "https://github.com/$(doc.internal.remote)/issues/$num"
+    link.url = isempty(doc.internal.remote) ? link.url :
+        "https://github.com/$(doc.internal.remote)/issues/$num"
 end
 
 end


### PR DESCRIPTION
When no `origin` is available or it doesn't match a GitHub URL then don't add source links to spliced docs and issues/PR autolinks.

Fixes #88.