### PR TITLE
Fixup redirected output

### DIFF
--- a/src/modules/Builder.jl
+++ b/src/modules/Builder.jl
@@ -138,6 +138,7 @@ function Selectors.runner(::Type{CheckDocument}, doc::Documents.Document)
 end
 
 function Selectors.runner(::Type{RenderDocument}, doc::Documents.Document)
+    Utilities.redirect_stream(doc.internal.stream)
     Utilities.log("rendering document.")
     Documenter.Writers.render(doc)
 end

--- a/src/modules/Documents.jl
+++ b/src/modules/Documents.jl
@@ -81,6 +81,7 @@ immutable Internal
     headers :: Anchors.AnchorMap         # See `modules/Anchors.jl`. Tracks `Markdown.Header` objects.
     docs    :: Anchors.AnchorMap         # See `modules/Anchors.jl`. Tracks `@docs` docstrings.
     objects :: ObjectIdDict              # Tracks which `Utilities.Objects` are included in the `Document`.
+    stream  :: Utilities.CombinedStream  # Redirected STDOUT and STDERR streams.
 end
 
 # Document.
@@ -122,6 +123,7 @@ function Document(;
         Anchors.AnchorMap(),
         Anchors.AnchorMap(),
         ObjectIdDict(),
+        Utilities.CombinedStream()
     )
     Document(user, internal)
 end

--- a/src/modules/Expanders.jl
+++ b/src/modules/Expanders.jl
@@ -395,7 +395,7 @@ function Selectors.runner(::Type{ExampleBlocks}, x, page, doc)
     result, buffer = nothing, IOBuffer()
     for (ex, str) in Utilities.parseblock(x.code)
         try
-            result = Documenter.DocChecks.withoutput(buffer) do
+            result = Utilities.withoutput(doc.internal.stream, buffer) do
                 # Evaluate within the build folder. Defines REPL-like `ans` binding as well.
                 cd(dirname(page.build)) do
                     eval(mod, :(ans = $(eval(mod, ex))))
@@ -436,7 +436,7 @@ function Selectors.runner(::Type{REPLBlocks}, x, page, doc)
         input  = droplines(str)
         output =
             try
-                result = Documenter.DocChecks.withoutput(buffer) do
+                result = Utilities.withoutput(doc.internal.stream, buffer) do
                     cd(dirname(page.build)) do
                         eval(mod, :(ans = $(eval(mod, ex))))
                     end


### PR DESCRIPTION
Don't create new tasks for each redirect and only redirect the `STDOUT` and `STDERR` streams once during `Document` construction.

Might help solve the OSX issues related to hanging and too many open files.

@lbenet, if you have the chance to test this out that would be great, might potentially help with #44.