### PR TITLE
Remove double path sep in URLs

### DIFF
--- a/src/modules/Utilities.jl
+++ b/src/modules/Utilities.jl
@@ -336,7 +336,7 @@ if VERSION >= v"0.5.0-dev+3442"
             if startswith(file, root)
                 base = "https://github.com/$remote/tree"
                 _, path = split(file, root; limit = 2)
-                Nullable{Compat.String}("$base/$commit/$path#L$line")
+                Nullable{Compat.String}("$base/$commit$path#L$line")
             else
                 Nullable{Compat.String}()
             end


### PR DESCRIPTION
URLs had a double `/` in source links. Browsers all seem to just discard it, but best to remove it here instead.