### PR TITLE
Add a simple HTML DSL

### DIFF
--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -165,3 +165,15 @@ Utilities.doccat
 Utilities.nodocs
 Utilities.issubmodule
 ```
+
+### DOM
+
+```@docs
+Utilities.DOM
+Utilities.DOM.@tags
+Utilities.DOM.Tag
+Utilities.DOM.Node
+Utilities.DOM.escapehtml
+Utilities.DOM.flatten!
+```
+

--- a/src/Utilities/DOM.jl
+++ b/src/Utilities/DOM.jl
@@ -1,0 +1,302 @@
+"""
+Provides a domain specific language for representing HTML documents.
+
+# Examples
+
+```julia
+using Documenter.Utilities.DOM
+
+# `DOM` does not export any HTML tags. Define the ones we actually need.
+@tags div p em strong ul li
+
+div(
+    p("This ", em("is"), " a ", strong("paragraph."),
+    p("And this is ", strong("another"), " one"),
+    ul(
+        li("and"),
+        li("an"),
+        li("unordered"),
+        li("list")
+    )
+)
+```
+
+*Notes*
+
+All the arguments passed to a node are flattened into a single vector rather
+than preserving any nested structure. This means that passing two vectors of
+nodes to a `div` will result in a `div` node with a single vector of children
+(the concatenation of the two vectors) rather than two vector children. The
+only arguments that are not flattened are nested nodes.
+
+String arguments are automatically converted into text nodes. Text nodes do not
+have any children or attributes and when displayed the string is escaped using
+[`escapehtml`](@ref).
+
+# Attributes
+
+As well as plain nodes shown in the previous example, nodes can have attributes
+added to them using the following syntax.
+
+```julia
+div[".my-class"](
+    img[:src => "foo.jpg"],
+    input[\"#my-id\", :disabled]
+)
+```
+
+In the above example we add a `class = "my-class"` attribute to the `div` node,
+a `src = "foo.jpg"` to the `img`, and `id = "my-id" disabled` attributes to the
+`input` node.
+
+The following syntax is supported within `[...]`:
+
+```julia
+tag[\"#id\"]
+tag[".class"]
+tag[\".class#id\"]
+tag[:disabled]
+tag[:src => "foo.jpg"]
+# ... or any combination of the above arguments.
+```
+
+# Internal Representation
+
+The [`@tags`](@ref) macro defines named [`Tag`](@ref) objects as follows
+
+```julia
+@tags div p em strong
+```
+
+expands to
+
+```julia
+const div, p, em, strong = Tag(:div), Tag(:p), Tag(:em), Tag(:strong)
+```
+
+These [`Tag`](@ref) objects are lightweight representations of empty HTML
+elements without any attributes and cannot be used to represent a complete
+document. To create an actual tree of HTML elements that can be rendered we
+need to add some attributes and/or child elements using `getindex` or `call`
+syntax. Applying either to a [`Tag`](@ref) object will construct a new
+[`Node`](@ref) object.
+
+```julia
+tag(...)      # No attributes.
+tag[...]      # No children.
+tag[...](...) # Has both attributes and children.
+```
+
+All three of the above syntaxes return a new [`Node`](@ref) object. Printing of
+`Node` objects is defined using the standard Julia display functions, so only
+needs a call to `print` to print out a valid HTML document with all nessesary
+text escaped.
+"""
+module DOM
+
+using Compat
+
+if VERSION < v"0.5.0-dev"
+    typealias String UTF8String
+    tostr(p::Pair) = p[1] => utf8(p[2])
+else
+    tostr(p::Pair) = p
+end
+
+export @tags
+
+#
+# The following sets are based on:
+#
+# - https://developer.mozilla.org/en/docs/Web/HTML/Block-level_elements
+# - https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements
+# - https://developer.mozilla.org/en-US/docs/Glossary/empty_element
+#
+const BLOCK_ELEMENTS = Set([
+    :address, :article, :aside, :blockquote, :canvas, :dd, :div, :dl,
+    :fieldset, :figcaption, :figure, :footer, :form, :h1, :h2, :h3, :h4, :h5,
+    :h6, :header, :hgroup, :hr, :li, :main, :nav, :noscript, :ol, :output, :p,
+    :pre, :section, :table, :tfoot, :ul, :video,
+])
+const INLINE_ELEMENTS = Set([
+    :a, :abbr, :acronym, :b, :bdo, :big, :br, :button, :cite, :code, :dfn, :em,
+    :i, :img, :input, :kbd, :label, :map, :object, :q, :samp, :script, :select,
+    :small, :span, :strong, :sub, :sup, :textarea, :time, :tt, :var,
+])
+const VOID_ELEMENTS = Set([
+    :area, :base, :br, :col, :command, :embed, :hr, :img, :input, :keygen,
+    :link, :meta, :param, :source, :track, :wbr,
+])
+const ALL_ELEMENTS = union(BLOCK_ELEMENTS, INLINE_ELEMENTS, VOID_ELEMENTS)
+
+#
+# Empty string as a constant to make equality checks slightly cheaper.
+#
+const EMPTY_STRING = ""
+const TEXT = Symbol(EMPTY_STRING)
+
+"""
+Represents a empty and attribute-less HTML element.
+
+Use [`@tags`](@ref) to define instances of this type rather than manually
+creating them via `Tag(:tagname)`.
+"""
+immutable Tag
+    name :: Symbol
+end
+
+Base.show(io::IO, t::Tag) = print(io, "<", t.name, ">")
+
+"""
+Define a collection of [`Tag`](@ref) objects and bind them to constants
+with the same names.
+
+# Examples
+
+Defined globally within a module:
+
+```julia
+@tags div ul li
+```
+
+Defined within the scope of a function to avoid cluttering the global namespace:
+
+```julia
+function template(args...)
+    @tags div ul li
+    # ...
+end
+```
+"""
+macro tags(args...) esc(tags(args)) end
+tags(s) = :(const ($(s...),) = $(map(Tag, s)))
+
+typealias Attributes Vector{Pair{Symbol, String}}
+
+"""
+Represents an element within an HTML document including any textual content,
+children `Node`s, and attributes.
+
+This type should not be constructed directly, but instead via `(...)` and
+`[...]` applied to a [`Tag`](@ref) or another [`Node`](@ref) object.
+"""
+immutable Node
+    name :: Symbol
+    text :: String
+    attributes :: Attributes
+    nodes :: Vector{Node}
+
+    Node(name::Symbol, attr::Attributes, data::Vector{Node}) = new(name, EMPTY_STRING, attr, data)
+    Node(text::AbstractString) = new(TEXT, text)
+end
+
+#
+# Syntax for defining `Node` objects from `Tag`s and other `Node` objects.
+#
+@compat (t::Tag)(args...) = Node(t.name, Attributes(), data(args))
+@compat (n::Node)(args...) = Node(n.name, n.attributes, data(args))
+Base.getindex(t::Tag, args...) = Node(t.name, attr(args), Node[])
+Base.getindex(n::Node, args...) = Node(n.name, attr(args), n.nodes)
+
+#
+# Helper methods for the above `Node` "pseudo-constructors".
+#
+data(args) = flatten!(nodes!, Node[], args)
+attr(args) = flatten!(attributes!, Attributes(), args)
+
+#
+# Types that must not be flattened when constructing a `Node`'s child vector.
+#
+typealias Atom Union{AbstractString, Node, Pair{Symbol, String}, Symbol}
+
+"""
+# Signatures
+
+```julia
+flatten!(f!, out, x::Atom)
+flatten!(f!, out, xs)
+```
+
+Flatten the contents the third argument into the second after applying the
+function `f!` to the element.
+"""
+flatten!(f!, out, x::Atom) = f!(out, x)
+flatten!(f!, out, xs)      = (for x in xs; flatten!(f!, out, x); end; out)
+
+#
+# Helper methods for handling flattening children elements in `Node` construction.
+#
+nodes!(out, s::AbstractString) = push!(out, Node(s))
+nodes!(out, n::Node)           = push!(out, n)
+
+#
+# Helper methods for handling flattening in construction of attribute vectors.
+#
+function attributes!(out, s::AbstractString)
+    class, id = IOBuffer(), IOBuffer()
+    for x in eachmatch(r"[#|\.]([\w\-]+)", s)
+        print(startswith(x.match, '.') ? class : id, x.captures[1], ' ')
+    end
+    position(class) === 0 || push!(out, tostr(:class => rstrip(takebuf_string(class))))
+    position(id)    === 0 || push!(out, tostr(:id    => rstrip(takebuf_string(id))))
+    return out
+end
+attributes!(out, s::Symbol) = push!(out, tostr(s => ""))
+attributes!(out, p::Pair)   = push!(out, tostr(p))
+
+function Base.show(io::IO, n::Node)
+    if n.name === TEXT
+        print(io, escapehtml(n.text))
+    else
+        print(io, '<', n.name)
+        for (name, value) in n.attributes
+            print(io, ' ', name)
+            isempty(value) || print(io, '=', repr(value))
+        end
+        if n.name in VOID_ELEMENTS
+            print(io, "/>")
+        else
+            print(io, '>')
+            if n.name === :script || n.name === :style
+                isempty(n.nodes) || print(io, n.nodes[1].text)
+            else
+                for each in n.nodes
+                    show(io, each)
+                end
+            end
+            print(io, "</", n.name, '>')
+        end
+    end
+end
+
+"""
+Escape characters in the provided string. This converts the following characters:
+
+- `<` to `&lt;`
+- `>` to `&gt;`
+- `&` to `&amp;`
+- `'` to `&#39;`
+- `\"` to `&quot;`
+
+When no escaping is needed then the same object is returned, otherwise a new
+string is constructed with the characters escaped. The returned object should
+always be treated as an immutable copy and compared using `==` rather than `===`.
+"""
+function escapehtml(text::AbstractString)
+    if ismatch(r"[<>&'\"]", text)
+        buffer = IOBuffer()
+        for char in text
+            char === '<'  ? write(buffer, "&lt;")   :
+            char === '>'  ? write(buffer, "&gt;")   :
+            char === '&'  ? write(buffer, "&amp;")  :
+            char === '\'' ? write(buffer, "&#39;")  :
+            char === '"'  ? write(buffer, "&quot;") : write(buffer, char)
+        end
+        takebuf_string(buffer)
+    else
+        text
+    end
+end
+
+end
+

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -67,7 +67,7 @@ end
 """
 Returns the path to the Documenter `assets` directory.
 """
-assetsdir() = normpath(joinpath(dirname(@__FILE__), "..", "assets"))
+assetsdir() = normpath(joinpath(dirname(@__FILE__), "..", "..", "assets"))
 
 cleandir(d::AbstractString) = (isdir(d) && rm(d, recursive = true); mkdir(d))
 
@@ -475,5 +475,7 @@ function issubmodule(sub, mod)
     end
     (sub === mod) || issubmodule(module_parent(sub), mod)
 end
+
+include("DOM.jl")
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -217,6 +217,83 @@ let b   = DocSystem.binding(DocSystem, :getdocs),
 end
 
 
+## DOM Tests.
+
+module DOMTests
+
+using Base.Test
+import Documenter.Utilities.DOM: DOM, @tags
+
+@tags div ul li p
+
+for tag in (:div, :ul, :li, :p)
+    TAG = getfield(current_module(), tag)
+    @test isdefined(tag)
+    @test isa(TAG, DOM.Tag)
+    @test TAG.name === tag
+end
+
+@test div().name === :div
+@test div().text == ""
+@test isempty(div().nodes)
+@test isempty(div().attributes)
+
+@test div("...").name === :div
+@test div("...").text == ""
+@test length(div("...").nodes) === 1
+@test div("...").nodes[1].text == "..."
+@test div("...").nodes[1].name === Symbol("")
+@test isempty(div("...").attributes)
+
+@test div[".class"]("...").name === :div
+@test div[".class"]("...").text == ""
+@test length(div[".class"]("...").nodes) === 1
+@test div[".class"]("...").nodes[1].text == "..."
+@test div[".class"]("...").nodes[1].name === Symbol("")
+@test length(div[".class"]("...").attributes) === 1
+@test div[".class"]("...").attributes[1] == (:class => "class")
+
+let d = div(ul(map(li, [string(n) for n = 1:10])))
+    @test d.name === :div
+    @test d.text == ""
+    @test isempty(d.attributes)
+    @test length(d.nodes) === 1
+    let u = d.nodes[1]
+        @test u.name === :ul
+        @test u.text == ""
+        @test isempty(u.attributes)
+        @test length(u.nodes) === 10
+        for n = 1:10
+            let v = u.nodes[n]
+                @test v.name === :li
+                @test v.text == ""
+                @test isempty(v.attributes)
+                @test length(v.nodes) === 1
+                @test v.nodes[1].name === Symbol("")
+                @test v.nodes[1].text == string(n)
+                @test !isdefined(v.nodes[1], :attributes)
+                @test !isdefined(v.nodes[1], :nodes)
+            end
+        end
+    end
+end
+
+function locally_defined()
+    @tags button
+    @test try
+        x = button
+        true
+    catch err
+        false
+    end
+end
+@test !isdefined(current_module(), :button)
+locally_defined()
+@test !isdefined(current_module(), :button)
+
+end
+
+
 # Integration tests for module api.
 
 # Error reporting.


### PR DESCRIPTION
A different approach than that taken by Hiccup.jl.

All nodes are the same type (`Node`) and no symbolic `tag` type
parameter. Each node's children are all also `Node`s and attributes are
a `Vector` rather than a `Dict` with concrete type parameters (`Symbol`
and `String`).

Also has a bit of syntax sugar:

```julia
div[".class#id"](
    ul(map(li, split("foo bar baz"))),
    img[:src => "path/to/file.jpg"]
)
```

No tags are exported at all. ~~They can just be defined when needed using~~

```julia
const div, ul, li, img = map(Tag, (:div, :ul, :li, :img))
```

~~We can add a macro to do that as well if we do use this.~~

Now with a `@tags` macro so the above is just

```julia
@tags div ul li img
```