### PR TITLE
Add try-catch blocks to `eval` code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 *.jl.mem
 
 test/examples/build/
+test/errors/build/
 docs/build/
 docs/site/

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -231,10 +231,10 @@ end
 
 ## Utilities.
 
-function buildnode(T::Type, block, page)
+function buildnode(T::Type, block, doc, page)
     mod  = get(page.globals.meta, :CurrentModule, current_module())
     dict = Dict{Symbol, Any}(:source => page.source, :build => page.build)
-    for (ex, str) in Utilities.parseblock(block.code)
+    for (ex, str) in Utilities.parseblock(block.code, doc, page)
         if Utilities.isassign(ex)
             dict[ex.args[1]] = eval(mod, ex.args[2])
         end

--- a/test/errors/make.jl
+++ b/test/errors/make.jl
@@ -1,0 +1,8 @@
+module ErrorsModule
+
+end
+
+using Documenter
+
+makedocs(modules = [ErrorsModule])
+

--- a/test/errors/src/index.md
+++ b/test/errors/src/index.md
@@ -1,0 +1,20 @@
+
+```@docs
+missing_doc
+```
+
+```@docs
+parse error
+```
+
+```@meta
+CurrentModule = NonExistantModule
+```
+
+```@autodocs
+Modules = [NonExistantModule]
+```
+
+```@eval
+NonExistantModule
+```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -219,6 +219,12 @@ end
 
 # Integration tests for module api.
 
+# Error reporting.
+
+info("The following errors are expected output.")
+include(joinpath("errors", "make.jl"))
+info("END of expected error output.")
+
 # Mock package docs:
 
 # setup


### PR DESCRIPTION
And thread the `doc` and `page` references through so we can print slightly better warnings.