### PR TITLE
Fix `submodules` skipping nested modules

### DIFF
--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -134,7 +134,7 @@ function submodules(root::Module, out = Set([root]))
             object = getfield(root, name)
             if isvalidmodule(root, object)
                 push!(out, object)
-                submodules(object)
+                submodules(object, out)
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -89,6 +89,16 @@ module UnitTests
 
 module SubModule end
 
+# Does `submodules` collect *all* the submodules?
+module A
+module B
+module C
+module D
+end
+end
+end
+end
+
 type T end
 
 "Documenter unit tests."
@@ -119,6 +129,10 @@ end
 @test Documenter.Utilities.issubmodule(UnitTests.SubModule, Base) === false
 @test Documenter.Utilities.issubmodule(UnitTests, UnitTests.SubModule) === false
 
+@test UnitTests.A in Documenter.Utilities.submodules(UnitTests.A)
+@test UnitTests.A.B in Documenter.Utilities.submodules(UnitTests.A)
+@test UnitTests.A.B.C in Documenter.Utilities.submodules(UnitTests.A)
+@test UnitTests.A.B.C.D in Documenter.Utilities.submodules(UnitTests.A)
 
 # DocSystem unit tests.
 


### PR DESCRIPTION
Only the first two levels of modules were actually returned. This resulted in missing docs errors when documenting modules with deeply nested submodules.