### PR TITLE
Make whitespace in doctests less relevant

### DIFF
--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -133,7 +133,7 @@ type Result
     bt     :: Vector     # Backtrace when an error is thrown.
 
     function Result(code, input, output)
-        new(code, input, strip(output, '\n'), nothing, false, IOBuffer())
+        new(code, input, rstrip(output, '\n'), nothing, false, IOBuffer())
     end
 end
 
@@ -192,7 +192,7 @@ function checkresult(result::Result)
     else
         value = result.hide ? nothing : result.value # `;` hides output.
         str   = result_to_string(result.stdout, value)
-        str == result.output || report(result, str)
+        strip(str) == strip(sanitise(IOBuffer(result.output))) || report(result, str)
     end
 end
 

--- a/test/examples/src/index.md
+++ b/test/examples/src/index.md
@@ -40,3 +40,19 @@ julia> [1.0, 2.0, 3.0]
  3.0
 
 ```
+
+```julia
+julia> println(" "^5)
+
+julia> "\nfoo\n\nbar\n\n\nbaz"
+"\nfoo\n\nbar\n\n\nbaz"
+
+julia> println(ans)
+
+foo
+
+bar
+
+
+baz
+```


### PR DESCRIPTION
Add some additional whitespace stripping in doctests to make passing tests somewhat easier to achieve.

All leading and trailing newlines are removed from both result and expected strings. Trailing whitespace on all lines is also removed.