### PR TITLE
Split Writers.jl into multiple files

### DIFF
--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -140,8 +140,11 @@ Walkers.walk
 ```@docs
 Writers
 Writers.render
-Writers.join_decl
-Writers.span
+Writers.MarkdownWriter
+Writers.MarkdownWriter.join_decl
+Writers.MarkdownWriter.span
+Writers.HTMLWriter
+Writers.LaTeXWriter
 ```
 
 ## Utilities
@@ -178,4 +181,3 @@ Utilities.DOM.flatten!
 Utilities.DOM.MarkdownConverter
 Utilities.DOM.MarkdownConverter.mdconvert(md)
 ```
-

--- a/src/Builder.jl
+++ b/src/Builder.jl
@@ -8,7 +8,6 @@ doctests, etc.
 module Builder
 
 import ..Documenter:
-
     Anchors,
     Selectors,
     Documents,

--- a/src/CrossReferences.jl
+++ b/src/CrossReferences.jl
@@ -4,7 +4,6 @@ Provides the [`crossref`](@ref) function used to automatically calculate link UR
 module CrossReferences
 
 import ..Documenter:
-
     Anchors,
     Builder,
     Documents,

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -4,7 +4,6 @@ Provides two functions, [`missingdocs`](@ref) and [`doctest`](@ref), for checkin
 module DocChecks
 
 import ..Documenter:
-
     Builder,
     Documents,
     Expanders,

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -10,7 +10,6 @@ Defines [`Document`](@ref) and its supporting types
 module Documents
 
 import ..Documenter:
-
     Anchors,
     Formats,
     Utilities

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -4,7 +4,6 @@ Defines node "expanders" that transform nodes from the parsed markdown files.
 module Expanders
 
 import ..Documenter:
-
     Anchors,
     Selectors,
     Builder,

--- a/src/Utilities/DOM.jl
+++ b/src/Utilities/DOM.jl
@@ -313,7 +313,6 @@ import ..DOM: @tags, Node, Tag
 
 
 import Base.Markdown:
-
     MD, BlockQuote, Bold, Code, Header, HorizontalRule,
     Image, Italic, LaTeX, LineBreak, Link, List, Paragraph, Table
 
@@ -377,4 +376,3 @@ end
 end
 
 end
-

--- a/src/Walkers.jl
+++ b/src/Walkers.jl
@@ -4,7 +4,6 @@ Provides the [`walk`](@ref) function.
 module Walkers
 
 import ..Documenter:
-
     Anchors,
     Builder,
     Documents,

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1,0 +1,24 @@
+"""
+Provides the [`render`](@ref) methods to write the documentation as HTML files
+(`MIME"text/html"`).
+"""
+module HTMLWriter
+
+import ...Documenter:
+    Anchors,
+    Builder,
+    Documents,
+    Expanders,
+    Formats,
+    Documenter,
+    Utilities
+
+import ..Writers: render
+
+# TODO
+
+function render(io::IO, ::MIME"text/html", node, page, doc)
+    error("HTML rendering is unsupported.")
+end
+
+end

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -1,0 +1,24 @@
+"""
+Provides the [`render`](@ref) methods to write the documentation as LaTeX files
+(`MIME"text/latex"`).
+"""
+module LaTeXWriter
+
+import ...Documenter:
+    Anchors,
+    Builder,
+    Documents,
+    Expanders,
+    Formats,
+    Documenter,
+    Utilities
+
+import ..Writers: render
+
+# TODO
+
+function render(io::IO, ::MIME"text/latex", node, page, doc)
+    error("LaTeX rendering is unsupported.")
+end
+
+end

--- a/src/Writers/MarkdownWriter.jl
+++ b/src/Writers/MarkdownWriter.jl
@@ -1,13 +1,10 @@
 """
-Provides a rendering function, [`render`](@ref), for writing each supported
-[`Formats.Format`](@ref) to file.
-
-Note that currently `Formats.Markdown` is the **only** supported format.
+Provides the [`render`](@ref) methods to write the documentation as Markdown files
+(`MIME"text/plain"`).
 """
-module Writers
+module MarkdownWriter
 
-import ..Documenter:
-
+import ...Documenter:
     Anchors,
     Builder,
     Documents,
@@ -16,28 +13,7 @@ import ..Documenter:
     Documenter,
     Utilities
 
-using Compat
-
-# Driver method for document rendering.
-# -------------------------------------
-
-"""
-Writes a [`Documents.Document`](@ref) object to `build` directory in specified file format.
-"""
-function render(doc::Documents.Document)
-    mime = Formats.mimetype(doc.user.format)
-    for (src, page) in doc.internal.pages
-        open(Formats.extension(doc.user.format, page.build), "w") do io
-            for elem in page.elements
-                node = page.mapping[elem]
-                render(io, mime, node, page, doc)
-            end
-        end
-    end
-end
-
-# Markdown Output.
-# ----------------
+import ..Writers: render
 
 function render(io::IO, mime::MIME"text/plain", vec::Vector, page, doc)
     for each in vec
@@ -262,24 +238,5 @@ end
 dropheaders(h::Markdown.Header) = Markdown.Paragraph(Markdown.Bold(h.text))
 dropheaders(v::Vector) = map(dropheaders, v)
 dropheaders(other) = other
-
-
-# LaTeX Output.
-# -------------
-
-# TODO
-
-function render(io::IO, ::MIME"text/latex", node, page, doc)
-    error("LaTeX rendering is unsupported.")
-end
-
-# HTML Output.
-# ------------
-
-# TODO
-
-function render(io::IO, ::MIME"text/html", node, page, doc)
-    error("HTML rendering is unsupported.")
-end
 
 end

--- a/src/Writers/Writers.jl
+++ b/src/Writers/Writers.jl
@@ -1,0 +1,43 @@
+"""
+Provides a rendering function, [`render`](@ref), for writing each supported
+[`Formats.Format`](@ref) to file.
+
+Note that currently `Formats.Markdown` is the **only** supported format.
+
+"""
+module Writers
+
+import ..Documenter:
+    Anchors,
+    Builder,
+    Documents,
+    Expanders,
+    Formats,
+    Documenter,
+    Utilities
+
+using Compat
+
+# Driver method for document rendering.
+# -------------------------------------
+
+"""
+Writes a [`Documents.Document`](@ref) object to `build` directory in specified file format.
+"""
+function render(doc::Documents.Document)
+    mime = Formats.mimetype(doc.user.format)
+    for (src, page) in doc.internal.pages
+        open(Formats.extension(doc.user.format, page.build), "w") do io
+            for elem in page.elements
+                node = page.mapping[elem]
+                render(io, mime, node, page, doc)
+            end
+        end
+    end
+end
+
+include("MarkdownWriter.jl")
+include("HTMLWriter.jl")
+include("LaTeXWriter.jl")
+
+end


### PR DESCRIPTION
In order accommodate multiple output formats the Writers module should
be in multiple files. Futhermore, in order for the internal code for
each format not to conflict with other code, they should each be
wrapped in submodules as well.

A couple of questionable decisions currently though:

  - Having the suffix `W`, even though it is not per say necessary.
  - While each format is a module, I like having just one line per format in `Writers.jl`. Hence the fact that the files are not named after the modules and that there is an `using` statement in them.