### PR TITLE
Move stream redirection later in pipeline

### DIFF
--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -36,9 +36,11 @@ Builder
 Builder.DocumentPipeline
 Builder.SetupBuildDirectory
 Builder.CopyAssetsDirectory
+Builder.RedirectOutputStreams
 Builder.ExpandTemplates
 Builder.CrossReferences
 Builder.CheckDocument
+Builder.RestoreOutputStreams
 Builder.RenderDocument
 ```
 

--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -91,9 +91,11 @@ When you run that you should see the following output
 ```
 Documenter: setting up build directory.
 Documenter: copying assets to build directory.
+Documenter: redirecting output streams.
 Documenter: expanding markdown templates.
 Documenter: building cross-references.
 Documenter: running document checks.
+Documenter: restoring output streams.
 Documenter: rendering document.
 ```
 


### PR DESCRIPTION
Should help make output redirection less visible and easier to debug.

@mortenpi this *might* solve your `julia -i file.jl` troubles.