### PR TITLE
Remove custom Binding definition.

### DIFF
--- a/src/CrossReferences.jl
+++ b/src/CrossReferences.jl
@@ -124,7 +124,7 @@ function docsxref(link::Markdown.Link, meta, page, doc)
         slug     = Utilities.slugify(object)
         link.url = string(path, '#', slug)
         # Fixup keyword ref text since they have a leading ':' char.
-        if object.binding.mod === Utilities.Keywords
+        if object.binding.mod === Main && haskey(Base.Docs.keywords, object.binding.var)
             link.text[1].code = lstrip(code, ':')
         end
     else

--- a/src/Generator.jl
+++ b/src/Generator.jl
@@ -51,16 +51,7 @@ function gitignore()
     """
 end
 
-
-macro mkdocs_default(name,value,default)
-    quote
-        if $value===nothing
-            "#"*$name*$default
-        else
-            $name*$value
-        end
-    end
-end
+mkdocs_default(name, value, default) = value == nothing ? "#$name$default" : "$name$value"
 
 """
 Contents of the default `mkdocs.yml` file.
@@ -75,9 +66,9 @@ function mkdocs(pkgname;
     #   http://www.mkdocs.org/user-guide/configuration/
 
     site_name:        $(pkgname).jl
-    $(@mkdocs_default "repo_url:         " url "https://github.com/USER_NAME/PACKAGE_NAME.jl")
-    $(@mkdocs_default "site_description: " description "Description...")
-    $(@mkdocs_default "site_author:      " author "USER_NAME")
+    $(mkdocs_default("repo_url:         ", url, "https://github.com/USER_NAME/PACKAGE_NAME.jl"))
+    $(mkdocs_default("site_description: ", description, "Description..."))
+    $(mkdocs_default("site_author:      ", author, "USER_NAME"))
 
     theme: readthedocs
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -432,45 +432,20 @@ end
 
 rm(joinpath(Documenter_root, "build"); recursive = true)
 
-# Try generating documentation with generate()
-
-pkg_generate = if VERSION >= v"0.5-"
-    isdir(Pkg.dir("PkgDev")) || Pkg.add("PkgDev")
-    import PkgDev
-    PkgDev.generate
-else
-    Pkg.generate
-end
-
-const testpkgname = "DocumenterTestPackage"
-
-function check_generated_files(path)
-    @test isdir(path)
-    @test isfile(joinpath(path, "mkdocs.yml"))
-    @test isfile(joinpath(path, ".gitignore"))
-    @test isfile(joinpath(path, "make.jl"))
-    @test isdir(joinpath(path, "src"))
-    @test isfile(joinpath(path, "src", "index.md"))
-end
-
-if ispath(Pkg.dir(testpkgname))
-    error("A package is already installed at $(Pkg.dir(testpkgname))")
-else
-    try
-        pkg_generate(testpkgname,"MIT",config=Dict("user.name"=>"Julia Test", "user.email"=>"tests@docs.julia"))
-        Documenter.generate(testpkgname)
-        check_generated_files(Pkg.dir(testpkgname,"docs"))
-    finally
-        Pkg.rm(testpkgname)
+mktempdir() do root
+    let path = joinpath(root, "docs")
+        Documenter.generate("DocumenterTestPackage", dir = path)
+        @test isdir(path)
+        @test isfile(joinpath(path, "mkdocs.yml"))
+        @test isfile(joinpath(path, ".gitignore"))
+        @test isfile(joinpath(path, "make.jl"))
+        @test isdir(joinpath(path, "src"))
+        @test isfile(joinpath(path, "src", "index.md"))
     end
 end
 
-# try generating at a custom location
-let path = joinpath(Pkg.dir("Documenter"), "test", "docs")
-    Documenter.generate(testpkgname, dir=path)
-    check_generated_files(path)
-    rm(path,recursive=true)
-end
+@test_throws ErrorException Documenter.generate("Documenter")
+@test_throws ErrorException Documenter.generate(randstring())
 
 end
 


### PR DESCRIPTION
Use the real one defined in `Base.Docs`.

Also remove `Keywords` module. Just use `Main` instead and assume that no one defines a binding with the same name as a keyword.

Remove PkgDev dep, we can possibly add it back once we can safely put `PkgDev` into `test/REQUIRE`. Just test against a mock package. Also test that `generate` throws errors on bad input. Replace macro `mkdocs_defaults` with a function.