### PR TITLE
Move populate! calls to a separate Builder step

### DIFF
--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -40,6 +40,7 @@ Builder.ExpandTemplates
 Builder.CrossReferences
 Builder.CheckDocument
 Builder.RestoreOutputStreams
+Builder.Populate
 Builder.RenderDocument
 ```
 
@@ -78,6 +79,7 @@ Documents.Page
 Documents.User
 Documents.Internal
 Documents.Globals
+Documents.populate!
 ```
 
 ## Expanders

--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -96,6 +96,7 @@ Documenter: building cross-references.
 Documenter: running document checks.
 Documenter: restoring output streams.
 Documenter: rendering document.
+Documenter: populating indices.
 Documenter: copying assets to build directory.
 ```
 

--- a/src/Builder.jl
+++ b/src/Builder.jl
@@ -28,6 +28,7 @@ The default document processing "pipeline", which consists of the following acti
 - [`CrossReferences`](@ref)
 - [`CheckDocument`](@ref)
 - [`RestoreOutputStreams`](@ref)
+- [`Populate`](@ref)
 - [`RenderDocument`](@ref)
 
 """
@@ -65,6 +66,11 @@ Switch back to the real `STDOUT` and `STDERR` that were changed in [`RedirectOut
 abstract RestoreOutputStreams <: DocumentPipeline
 
 """
+Populates the `ContentsNode`s and `IndexNode`s with links.
+"""
+abstract Populate <: DocumentPipeline
+
+"""
 Writes the document tree to the `build` directory.
 """
 abstract RenderDocument <: DocumentPipeline
@@ -75,7 +81,8 @@ Selectors.order(::Type{ExpandTemplates})       = 3.0
 Selectors.order(::Type{CrossReferences})       = 4.0
 Selectors.order(::Type{CheckDocument})         = 5.0
 Selectors.order(::Type{RestoreOutputStreams})  = 6.0
-Selectors.order(::Type{RenderDocument})        = 7.0
+Selectors.order(::Type{Populate})              = 7.0
+Selectors.order(::Type{RenderDocument})        = 8.0
 
 Selectors.matcher{T <: DocumentPipeline}(::Type{T}, doc::Documents.Document) = true
 
@@ -134,6 +141,11 @@ end
 function Selectors.runner(::Type{RestoreOutputStreams}, doc::Documents.Document)
     Utilities.log(doc, "restoring output streams.")
     Utilities.restore_output_stream!(doc.internal.stream)
+end
+
+function Selectors.runner(::Type{Populate}, doc::Documents.Document)
+    Utilities.log("populating indices.")
+    Documents.populate!(doc)
 end
 
 function Selectors.runner(::Type{RenderDocument}, doc::Documents.Document)

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -485,14 +485,18 @@ end
 # ------
 
 function Selectors.runner(::Type{IndexBlocks}, x, page, doc)
-    page.mapping[x] = Documents.buildnode(Documents.IndexNode, x, doc, page)
+    node = Documents.buildnode(Documents.IndexNode, x, doc, page)
+    push!(doc.internal.indexnodes, node)
+    page.mapping[x] = node
 end
 
 # @contents
 # ---------
 
 function Selectors.runner(::Type{ContentsBlocks}, x, page, doc)
-    page.mapping[x] = Documents.buildnode(Documents.ContentsNode, x, doc, page)
+    node = Documents.buildnode(Documents.ContentsNode, x, doc, page)
+    push!(doc.internal.contentsnodes, node)
+    page.mapping[x] = node
 end
 
 # @example

--- a/src/Writers/MarkdownWriter.jl
+++ b/src/Writers/MarkdownWriter.jl
@@ -212,7 +212,6 @@ end
 ## Index, Contents, and Eval Nodes.
 
 function render(io::IO, ::MIME"text/plain", index::Documents.IndexNode, page, doc)
-    Documents.populate!(index, doc)
     for (object, doc, page, mod, cat) in index.elements
         url = string(page, "#", Utilities.slugify(object))
         println(io, "- [`", object.binding, "`](", url, ")")
@@ -221,7 +220,6 @@ function render(io::IO, ::MIME"text/plain", index::Documents.IndexNode, page, do
 end
 
 function render(io::IO, ::MIME"text/plain", contents::Documents.ContentsNode, page, doc)
-    Documents.populate!(contents, doc)
     for (count, path, anchor) in contents.elements
         header = anchor.object
         url    = string(path, '#', anchor.id, '-', anchor.nth)


### PR DESCRIPTION
Currently the writer populates the `IndexNode`s and `ContentsNode`s with links, but that should be a separate step. This separates the `populate!` calls into a separate `Builder.Populate` step, which runs just before the `Builder.RenderDocument`.

It fixes the issue of duplicate links in `Index`/`ContentsNode`s when `Builder.RenderDocument` gets called multiple times after the document has been constructed by the previous steps in the pipeline.

---

I took the simplest route of moving the `populate!` calls to a separate step, where I just loop through the elements of a `Page`. This makes the implicit assumption that all the `Contents`/`IndexNode`s are in the top-level of the Markdown files, which seems like a bad assumption (e.g. the same nodes in docstrings?).

Potential options could be:

- Make a full walk in the `Populate`
- Store a list of `Index`/`ContentsNode`s in the `Document` in one of the previous steps and then just loop over that.
- Perhaps the `populate!` calls can be merged into an existing walk in the pipeline?

but I wanted to RFC this first, before going for anything more complicated.