### PR TITLE
Use `DocSystem` for `atdocs` blocks

### DIFF
--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -69,6 +69,22 @@ When a potential docstring is found in one of the listed modules, but does not m
 value from `Order` then it will be omitted from the document. Hence `Order` acts as a basic
 filter as well as sorter.
 
+In addition to `Order`, a `Pages` vector may be included in `@autodocs` to filter docstrings
+based on the source file in which they are defined:
+
+````markdown
+```@autodocs
+Modules = [Foo]
+Pages   = ["a.jl", "b.jl"]
+```
+````
+
+In the above example docstrings from module `Foo` found in source files that end in `a.jl`
+and `b.jl` are included. The page order provided by `Pages` is also used to sort the
+docstrings. Note that page matching is done using the end of the provided strings and so
+`a.jl` will be matched by *any* source file that ends in `a.jl`, i.e. `src/a.jl` or
+`src/foo/a.jl`.
+
 **Note**
 
 When more complex sorting and filtering is needed then use `@docs` to define it explicitly.

--- a/src/DocSystem.jl
+++ b/src/DocSystem.jl
@@ -343,5 +343,21 @@ end
 aliasof(s::Symbol, b) = binding(s)
 
 iskeyword(b::Docs.Binding) = b.mod === Main && haskey(Base.Docs.keywords, b.var)
+ismacro(b::Docs.Binding) = startswith(string(b.var), '@')
+
+
+function category(b::Docs.Binding)
+    if iskeyword(b)
+        :keyword
+    elseif ismacro(b)
+        :macro
+    else
+        category(resolve(b))
+    end
+end
+category(::Function) = :function
+category(::DataType) = :type
+category(::Module) = :module
+category(::Any) = :constant
 
 end

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -189,8 +189,6 @@ end
 splitexpr(s::Symbol) = :(current_module()), quot(s)
 splitexpr(other)     = error("Invalid @var syntax `$other`.")
 
-Base.Docs.signature(::Symbol) = :(Union{})
-
 """
     object(ex, str)
 

--- a/test/examples/src/lib/functions.md
+++ b/test/examples/src/lib/functions.md
@@ -19,7 +19,7 @@ T
 :ccall
 :for
 :while
-@time(x)
+@time
 @assert
 ```
 

--- a/test/examples/src/lib/functions.md
+++ b/test/examples/src/lib/functions.md
@@ -141,3 +141,16 @@ Order   = [:function, :module, :macro]
 Modules = [AutoDocs.A, AutoDocs.B]
 Order   = [:constant, :type]
 ```
+
+## Autodocs by Page
+
+```@autodocs
+Modules = [AutoDocs.Pages]
+Pages = ["a.jl", "b.jl"]
+```
+
+```@autodocs
+Modules = [AutoDocs.Pages]
+Pages = ["c.jl", "d.jl"]
+```
+

--- a/test/pages/a.jl
+++ b/test/pages/a.jl
@@ -1,0 +1,3 @@
+
+"`f` from page `a.jl`."
+f(x) = x

--- a/test/pages/b.jl
+++ b/test/pages/b.jl
@@ -1,0 +1,3 @@
+
+"`f` from page `b.jl`."
+f(x, y) = x + y

--- a/test/pages/c.jl
+++ b/test/pages/c.jl
@@ -1,0 +1,3 @@
+
+"`f` from page `c.jl`."
+f(x, y, z) = x + y + z

--- a/test/pages/d.jl
+++ b/test/pages/d.jl
@@ -1,0 +1,3 @@
+
+"`T` from page `d.jl`."
+type T end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,15 @@ end
 "`AutoDocs` module."
 module AutoDocs
 
+module Pages
+
+include("pages/a.jl")
+include("pages/b.jl")
+include("pages/c.jl")
+include("pages/d.jl")
+
+end
+
 "Function `f`."
 f(x) = x
 
@@ -397,7 +406,7 @@ let headers = doc.internal.headers
     end
 end
 
-@test length(doc.internal.objects) == 22
+@test length(doc.internal.objects) == 26
 
 # Documenter package docs:
 


### PR DESCRIPTION
... and enable `Pages` support in `at-autodocs` blocks.

Also re-implement `at-autodocs` using `DocSystem` rather than by calling `at-docs` with a generated code block.

Fixes #72.