### PR TITLE
Use "real" STDOUT for logging

### DIFF
--- a/src/Builder.jl
+++ b/src/Builder.jl
@@ -82,7 +82,7 @@ Selectors.matcher{T <: DocumentPipeline}(::Type{T}, doc::Documents.Document) = t
 Selectors.strict{T <: DocumentPipeline}(::Type{T}) = false
 
 function Selectors.runner(::Type{SetupBuildDirectory}, doc::Documents.Document)
-    Utilities.log("setting up build directory.")
+    Utilities.log(doc, "setting up build directory.")
     # Frequently used fields.
     build  = doc.user.build
     source = doc.user.source
@@ -111,33 +111,33 @@ function Selectors.runner(::Type{SetupBuildDirectory}, doc::Documents.Document)
 end
 
 function Selectors.runner(::Type{RedirectOutputStreams}, doc::Documents.Document)
-    Utilities.log("redirecting output streams.")
+    Utilities.log(doc, "redirecting output streams.")
     Utilities.redirect_output_stream!(doc.internal.stream)
 end
 
 function Selectors.runner(::Type{ExpandTemplates}, doc::Documents.Document)
-    Utilities.log("expanding markdown templates.")
+    Utilities.log(doc, "expanding markdown templates.")
     Documenter.Expanders.expand(doc)
 end
 
 function Selectors.runner(::Type{CrossReferences}, doc::Documents.Document)
-    Utilities.log("building cross-references.")
+    Utilities.log(doc, "building cross-references.")
     Documenter.CrossReferences.crossref(doc)
 end
 
 function Selectors.runner(::Type{CheckDocument}, doc::Documents.Document)
-    Utilities.log("running document checks.")
+    Utilities.log(doc, "running document checks.")
     Documenter.DocChecks.missingdocs(doc)
     Documenter.DocChecks.doctest(doc)
 end
 
 function Selectors.runner(::Type{RestoreOutputStreams}, doc::Documents.Document)
-    Utilities.log("restoring output streams.")
+    Utilities.log(doc, "restoring output streams.")
     Utilities.restore_output_stream!(doc.internal.stream)
 end
 
 function Selectors.runner(::Type{RenderDocument}, doc::Documents.Document)
-    Utilities.log("rendering document.")
+    Utilities.log(doc, "rendering document.")
     Documenter.Writers.render(doc)
 end
 

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -20,6 +20,14 @@ Format and print a message to the user.
 """
 log(msg) = __log__[] ? print_with_color(:magenta, STDOUT, "Documenter: ", msg, "\n") : nothing
 
+# Print logging output to the "real" STDOUT.
+function log(doc, msg)
+    local stdout = isdefined(doc.internal.stream, :out) ?
+        doc.internal.stream.out.real : STDOUT
+    __log__[] && print_with_color(:magenta, stdout, "Documenter: ", msg, "\n")
+    return nothing
+end
+
 debug(msg) = print_with_color(:green, " ?? ", msg, "\n")
 
 """

--- a/src/Writers/MarkdownWriter.jl
+++ b/src/Writers/MarkdownWriter.jl
@@ -29,7 +29,7 @@ function render(::Writer{Formats.Markdown}, doc::Documents.Document)
 end
 
 function copy_assets(doc::Documents.Document)
-    Utilities.log("copying assets to build directory.")
+    Utilities.log(doc, "copying assets to build directory.")
     assets = doc.internal.assets
     if isdir(assets)
         builddir = joinpath(doc.user.build, "assets")


### PR DESCRIPTION
Should help to stop logging output from getting mixed in with captured output from doctests. Fixes #130.