### PR TITLE
Link to source when repo is not hosted on GitHub

### DIFF
--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -60,6 +60,7 @@ export Deps, makedocs, deploydocs
         clean   = true,
         doctest = true,
         modules = Module[],
+        repo    = "",
     )
 
 Combines markdown files and inline docstrings into an interlinked document.
@@ -124,6 +125,22 @@ $(strip(readstring(joinpath(dirname(@__FILE__), "..", "docs", "make.jl"))))
 
 and so any docstring from the module `Documenter` that is not spliced into the generated
 documentation in `build` will raise a warning.
+
+**`repo`** specifies a template for the "link to source" feature. If you are
+using GitHub, this is automatically generated from the remote. If you are using
+a different host, you can use this option to tell Documenter how URLs should be
+generated. The following placeholders will be replaced with the respective
+value of the generated link:
+
+  - `{commit}` Git commit id
+  - `{path}` Path to the file in the repository
+  - `{line}` Line (or range of lines) in the source file
+
+For example if you are using GitLab.com, you could use
+
+```julia
+makedocs(repo = "https://gitlab.com/user/project/blob/{commit}{path}#L{line}")
+```
 
 # See Also
 

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -69,6 +69,7 @@ immutable User
     doctest :: Bool           # Run doctests?
     modules :: Set{Module}    # Which modules to check for missing docs?
     pages   :: Vector{Any}    # Ordering of document pages specified by the user.
+    repo    :: Compat.String  # Template for URL to source code repo
 end
 
 """
@@ -104,6 +105,7 @@ function Document(;
         doctest  :: Bool             = true,
         modules  :: Utilities.ModVec = Module[],
         pages    :: Vector           = Any[],
+        repo     :: AbstractString   = "",
         others...
     )
     Utilities.check_kwargs(others)
@@ -117,6 +119,7 @@ function Document(;
         doctest,
         Utilities.submodules(modules),
         pages,
+        repo,
     )
     internal = Internal(
         Utilities.assetsdir(),

--- a/src/Writers/MarkdownWriter.jl
+++ b/src/Writers/MarkdownWriter.jl
@@ -129,7 +129,7 @@ function render(io::IO, mime::MIME"text/plain", node::Documents.DocsNode, page, 
                 tv, decls, file, line = Base.arg_decl_parts(m)
                 decls = decls[2:end]
                 file = string(file)
-                url = get(Utilities.url(doc.internal.remote, m.module, file, line), "")
+                url = get(Utilities.url(doc.internal.remote, doc.user.repo, m.module, file, line), "")
                 file_match = match(r, file)
                 if file_match !== nothing
                     file = file_match.captures[2]
@@ -191,7 +191,7 @@ function renderdoc(io::IO, mime::MIME"text/plain", md::Markdown.MD, page, doc)
         for (markdown, result) in zip(md.content, md.meta[:results])
             render(io, mime, dropheaders(markdown), page, doc)
             # When a source link is available then print the link.
-            Utilities.unwrap(Utilities.url(doc.internal.remote, result)) do url
+            Utilities.unwrap(Utilities.url(doc.internal.remote, doc.user.repo, result)) do url
                 link = "<a target='_blank' href='$url' class='documenter-source'>source</a><br>"
                 println(io, "\n", link, "\n")
             end


### PR DESCRIPTION
You have nice links to the relevant part of the source in your docs which I wanted as well but my projects are hosted on an internal gitlab installation. This PR is my attempt at making that feature available to non-GitHub-hosted projects.
Let me know if you are unhappy with the name of the parameter or how it's implemented.