### PR TITLE
Bring back Windows testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Contributions are very welcome, as are feature requests and suggestions. Please 
 [travis-img]: https://travis-ci.org/JuliaDocs/Documenter.jl.svg?branch=master
 [travis-url]: https://travis-ci.org/JuliaDocs/Documenter.jl
 
-[appveyor-img]: https://ci.appveyor.com/api/projects/status/h227adt6ovd1u3sx/branch/master?svg=true
-[appveyor-url]: https://ci.appveyor.com/project/JuliaDocs/documenter-jl/branch/master
+[appveyor-img]: https://ci.appveyor.com/api/projects/status/egdu3hrptf3mnfc6/branch/master?svg=true
+[appveyor-url]: https://ci.appveyor.com/project/MichaelHatherly/documenter-jl-bqgcw/branch/master
 
 [codecov-img]: https://codecov.io/gh/JuliaDocs/Documenter.jl/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/JuliaDocs/Documenter.jl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,11 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:
     - master
-    - /release-.*/
 
 notifications:
   - provider: Email


### PR DESCRIPTION
During the repo move appveyor got lost. Re-enable it and change testing matrix to only test 64bit (0.4 and latest), since AppVeyor can sometimes take quite a while to finish.