### PR TITLE
Re-enable source links after refactoring lost them

### DIFF
--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -369,6 +369,7 @@ function Selectors.runner(::Type{DocsBlocks}, x, page, doc)
         end
         # Concatenate found docstrings into a single `MD` object.
         local docstr = Base.Markdown.MD(map(Documenter.DocSystem.parsedoc, docs))
+        docstr.meta[:results] = docs
 
         # Generate a unique name to be used in anchors and links for the docstring.
         local slug = Utilities.slugify(object)
@@ -449,7 +450,8 @@ function Selectors.runner(::Type{AutoDocsBlocks}, x, page, doc)
                 Utilities.warn(page.source, "Duplicate docs found for '$(binding)'.")
                 continue
             end
-            local markdown = Documenter.DocSystem.parsedoc(docstr)
+            local markdown = Markdown.MD(Documenter.DocSystem.parsedoc(docstr))
+            markdown.meta[:results] = [docstr]
             local slug = Utilities.slugify(object)
             local anchor = Anchors.add!(doc.internal.docs, object, slug, page.build)
             local docsnode = DocsNode(markdown, anchor, object, page, Nullable())


### PR DESCRIPTION
Source links were lost in 126498a due to switching to using `DocSystem` which doesn't store `:results` like `@doc` does.

(Note: only a bug on `0.5` since `0.4` doesn't include any source links anyway.)