### PR TITLE
More intelligent cross-references

### DIFF
--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -377,6 +377,9 @@ function Selectors.runner(::Type{DocsBlocks}, x, page, doc)
         local ms = docsnode_methodlist(object, page, doc)
         local docsnode = DocsNode(docstr, anchor, object, page, ms)
 
+        # Track the order of insertion of objects per-binding.
+        push!(get!(doc.internal.bindings, binding, Utilities.Object[]), object)
+
         doc.internal.objects[object] = docsnode
         push!(nodes, docsnode)
     end
@@ -455,6 +458,10 @@ function Selectors.runner(::Type{AutoDocsBlocks}, x, page, doc)
             local slug = Utilities.slugify(object)
             local anchor = Anchors.add!(doc.internal.docs, object, slug, page.build)
             local docsnode = DocsNode(markdown, anchor, object, page, Nullable())
+
+            # Track the order of insertion of objects per-binding.
+            push!(get!(doc.internal.bindings, object.binding, Utilities.Object[]), object)
+
             doc.internal.objects[object] = docsnode
             push!(nodes, docsnode)
         end

--- a/test/pages/a.jl
+++ b/test/pages/a.jl
@@ -1,3 +1,19 @@
 
-"`f` from page `a.jl`."
+"""
+`f` from page `a.jl`.
+
+Links:
+
+- [`:ccall`](@ref)
+- [`:while`](@ref)
+- [`@time(x)`](@ref)
+- [`T(x)`](@ref)
+- [`T(x, y)`](@ref)
+- [`f(::Integer)`](@ref)
+- [`f(::Any)`](@ref)
+- [`f(::Any, ::Any)`](@ref)
+- [`f(x, y, z)`](@ref)
+
+"""
 f(x) = x
+

--- a/test/pages/b.jl
+++ b/test/pages/b.jl
@@ -1,3 +1,17 @@
 
-"`f` from page `b.jl`."
+"""
+`f` from page `b.jl`.
+
+Links:
+
+- [`:ccall`](@ref)
+- [`:while`](@ref)
+- [`@time`](@ref)
+- [`T`](@ref)
+- [`f`](@ref)
+- [`f(::Any)`](@ref)
+- [`f(::Any, ::Any)`](@ref)
+- [`f(::Any, ::Any, ::Any)`](@ref)
+
+"""
 f(x, y) = x + y

--- a/test/pages/c.jl
+++ b/test/pages/c.jl
@@ -1,3 +1,17 @@
 
-"`f` from page `c.jl`."
+"""
+`f` from page `c.jl`.
+
+Links:
+
+- [`:ccall`](@ref)
+- [`:while`](@ref)
+- [`@time`](@ref)
+- [`T`](@ref)
+- [`f`](@ref)
+- [`f(::Any)`](@ref)
+- [`f(::Any, ::Any)`](@ref)
+- [`f(::Any, ::Any, ::Any)`](@ref)
+
+"""
 f(x, y, z) = x + y + z

--- a/test/pages/d.jl
+++ b/test/pages/d.jl
@@ -1,3 +1,57 @@
 
-"`T` from page `d.jl`."
+"""
+`T` from page `d.jl`.
+
+Links:
+
+- [`:ccall`](@ref)
+- [`:while`](@ref)
+- [`@time`](@ref)
+- [`T`](@ref)
+- [`f`](@ref)
+- [`f(x)`](@ref)
+- [`f(x, y)`](@ref)
+- [`f(::Any, ::Any, ::Any)`](@ref)
+
+"""
 type T end
+
+
+"""
+`T` from page `d.jl`.
+
+Links:
+
+- [`:ccall`](@ref)
+- [`:while`](@ref)
+- [`@time`](@ref)
+- [`T(x)`](@ref)
+- [`T(x, y)`](@ref)
+- [`T(x, y, z)`](@ref)
+- [`f`](@ref)
+- [`f(x)`](@ref)
+- [`f(x, y)`](@ref)
+- [`f(::Any, ::Any, ::Any)`](@ref)
+
+"""
+T(x) = T()
+
+"""
+`T` from page `d.jl`.
+
+Links:
+
+- [`:ccall`](@ref)
+- [`:while`](@ref)
+- [`@time`](@ref)
+- [`T()`](@ref)
+- [`T(x)`](@ref)
+- [`T(x, y)`](@ref)
+- [`T(x, y, z)`](@ref)
+- [`f`](@ref)
+- [`f(x)`](@ref)
+- [`f(x, y)`](@ref)
+- [`f(::Any, ::Any, ::Any)`](@ref)
+
+"""
+T(x, y) = T()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -406,7 +406,7 @@ let headers = doc.internal.headers
     end
 end
 
-@test length(doc.internal.objects) == 26
+@test length(doc.internal.objects) == 28
 
 # Documenter package docs:
 


### PR DESCRIPTION
Fixes #138 by including category `:method` in `at-index` blocks and improving the cross-reference heuristic to allow for finding non-exact matching signatures.

---

@tribut, if you'd be able to test this fixes #138 for you that would be great, thanks.