### PR TITLE
Use a `Pipe` for output redirection

### DIFF
--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -35,11 +35,9 @@ Anchors.isunique
 Builder
 Builder.DocumentPipeline
 Builder.SetupBuildDirectory
-Builder.RedirectOutputStreams
 Builder.ExpandTemplates
 Builder.CrossReferences
 Builder.CheckDocument
-Builder.RestoreOutputStreams
 Builder.Populate
 Builder.RenderDocument
 ```
@@ -172,6 +170,7 @@ Utilities.docs
 Utilities.doccat
 Utilities.nodocs
 Utilities.issubmodule
+Utilities.withoutput
 ```
 
 ### DOM

--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -90,11 +90,9 @@ When you run that you should see the following output
 
 ```
 Documenter: setting up build directory.
-Documenter: redirecting output streams.
 Documenter: expanding markdown templates.
 Documenter: building cross-references.
 Documenter: running document checks.
-Documenter: restoring output streams.
 Documenter: rendering document.
 Documenter: populating indices.
 Documenter: copying assets to build directory.

--- a/src/Builder.jl
+++ b/src/Builder.jl
@@ -23,11 +23,9 @@ using Compat
 The default document processing "pipeline", which consists of the following actions:
 
 - [`SetupBuildDirectory`](@ref)
-- [`RedirectOutputStreams`](@ref)
 - [`ExpandTemplates`](@ref)
 - [`CrossReferences`](@ref)
 - [`CheckDocument`](@ref)
-- [`RestoreOutputStreams`](@ref)
 - [`Populate`](@ref)
 - [`RenderDocument`](@ref)
 
@@ -38,11 +36,6 @@ abstract DocumentPipeline <: Selectors.AbstractSelector
 Creates the correct directory layout within the `build` folder and parses markdown files.
 """
 abstract SetupBuildDirectory <: DocumentPipeline
-
-"""
-Replace `STDOUT` and `STDERR` streams with a single stream to capture doctest output.
-"""
-abstract RedirectOutputStreams <: DocumentPipeline
 
 """
 Executes a sequence of actions on each node of the parsed markdown files in turn.
@@ -61,11 +54,6 @@ valid Julia code blocks.
 abstract CheckDocument <: DocumentPipeline
 
 """
-Switch back to the real `STDOUT` and `STDERR` that were changed in [`RedirectOutputStreams`](@ref).
-"""
-abstract RestoreOutputStreams <: DocumentPipeline
-
-"""
 Populates the `ContentsNode`s and `IndexNode`s with links.
 """
 abstract Populate <: DocumentPipeline
@@ -76,13 +64,11 @@ Writes the document tree to the `build` directory.
 abstract RenderDocument <: DocumentPipeline
 
 Selectors.order(::Type{SetupBuildDirectory})   = 1.0
-Selectors.order(::Type{RedirectOutputStreams}) = 2.0
-Selectors.order(::Type{ExpandTemplates})       = 3.0
-Selectors.order(::Type{CrossReferences})       = 4.0
-Selectors.order(::Type{CheckDocument})         = 5.0
-Selectors.order(::Type{RestoreOutputStreams})  = 6.0
-Selectors.order(::Type{Populate})              = 7.0
-Selectors.order(::Type{RenderDocument})        = 8.0
+Selectors.order(::Type{ExpandTemplates})       = 2.0
+Selectors.order(::Type{CrossReferences})       = 3.0
+Selectors.order(::Type{CheckDocument})         = 4.0
+Selectors.order(::Type{Populate})              = 5.0
+Selectors.order(::Type{RenderDocument})        = 6.0
 
 Selectors.matcher{T <: DocumentPipeline}(::Type{T}, doc::Documents.Document) = true
 
@@ -117,11 +103,6 @@ function Selectors.runner(::Type{SetupBuildDirectory}, doc::Documents.Document)
     end
 end
 
-function Selectors.runner(::Type{RedirectOutputStreams}, doc::Documents.Document)
-    Utilities.log(doc, "redirecting output streams.")
-    Utilities.redirect_output_stream!(doc.internal.stream)
-end
-
 function Selectors.runner(::Type{ExpandTemplates}, doc::Documents.Document)
     Utilities.log(doc, "expanding markdown templates.")
     Documenter.Expanders.expand(doc)
@@ -136,11 +117,6 @@ function Selectors.runner(::Type{CheckDocument}, doc::Documents.Document)
     Utilities.log(doc, "running document checks.")
     Documenter.DocChecks.missingdocs(doc)
     Documenter.DocChecks.doctest(doc)
-end
-
-function Selectors.runner(::Type{RestoreOutputStreams}, doc::Documents.Document)
-    Utilities.log(doc, "restoring output streams.")
-    Utilities.restore_output_stream!(doc.internal.stream)
 end
 
 function Selectors.runner(::Type{Populate}, doc::Documents.Document)

--- a/src/CrossReferences.jl
+++ b/src/CrossReferences.jl
@@ -23,12 +23,7 @@ function crossref(doc::Documents.Document)
     for (src, page) in doc.internal.pages
         empty!(page.globals.meta)
         for element in page.elements
-            try
-                crossref(page.mapping[element], page, doc)
-            catch err
-                Utilities.restore_output_stream!(doc.internal.stream)
-                rethrow(err)
-            end
+            crossref(page.mapping[element], page, doc)
         end
     end
 end

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -163,7 +163,6 @@ immutable Internal
     docs    :: Anchors.AnchorMap         # See `modules/Anchors.jl`. Tracks `@docs` docstrings.
     bindings:: ObjectIdDict              # Tracks insertion order of object per-binding.
     objects :: ObjectIdDict              # Tracks which `Utilities.Objects` are included in the `Document`.
-    stream  :: Utilities.CombinedStream  # Redirected STDOUT and STDERR streams.
     contentsnodes :: Vector{ContentsNode}
     indexnodes    :: Vector{IndexNode}
 end
@@ -212,7 +211,6 @@ function Document(;
         Anchors.AnchorMap(),
         ObjectIdDict(),
         ObjectIdDict(),
-        Utilities.CombinedStream(),
         [],
         []
     )

--- a/test/examples/src/index.md
+++ b/test/examples/src/index.md
@@ -56,3 +56,10 @@ bar
 
 baz
 ```
+
+```julia
+julia> info("...")
+INFO: ...
+
+```
+


### PR DESCRIPTION
(Sorry @mortenpi, I kind of just got carried away here... hope you hadn't already started on this as well.)

`Pipe`s *seem* to work fine, though this will need some extensive checks on travis with some of the packages that were giving problems before the change to `CombinedStream` etc., hence this is very WIP at the moment.

This returns to the original method of output redirection of only changing streams without the `withoutput` `do` block rather than globally in the `Document` object with some changes.

No `at-async` to combine the output streams. To deal with `STDOUT`/`STDERR` interleaving we use a `Pipe` and call `Base.link_pipe` (unexported) to redirect both `STDOUT` and `STDERR`.

Interestingly, the tests all passed without any problems: so either good, or very bad 😆. As a nice side-effect the single `info` calls that were previously getting lost are now captured correctly.