### PR TITLE
Add footnote checking

### DIFF
--- a/src/Builder.jl
+++ b/src/Builder.jl
@@ -117,6 +117,7 @@ function Selectors.runner(::Type{CheckDocument}, doc::Documents.Document)
     Utilities.log(doc, "running document checks.")
     Documenter.DocChecks.missingdocs(doc)
     Documenter.DocChecks.doctest(doc)
+    Documenter.DocChecks.footnotes(doc)
 end
 
 function Selectors.runner(::Type{Populate}, doc::Documents.Document)

--- a/src/Walkers.jl
+++ b/src/Walkers.jl
@@ -33,7 +33,7 @@ end
 
 function walk(f, meta, block::Vector)
     for each in block
-        f(each) && walk(f, meta, each)
+        walk(f, meta, each)
     end
 end
 

--- a/test/errors/src/index.md
+++ b/test/errors/src/index.md
@@ -18,3 +18,20 @@ Modules = [NonExistantModule]
 ```@eval
 NonExistantModule
 ```
+
+This is the footnote [^1]. And [^another] [^another].
+
+[^1]: one
+
+    [^nested]: a nested footnote
+
+[^another_one]:
+
+    Things! [^1]. [^2].
+
+[^nested]
+
+[^nested]:
+
+    Duplicate [^1] nested footnote.
+

--- a/test/examples/src/lib/functions.md
+++ b/test/examples/src/lib/functions.md
@@ -154,3 +154,5 @@ Modules = [AutoDocs.Pages]
 Pages = ["c.jl", "d.jl"]
 ```
 
+A footnote reference [^footnote].
+

--- a/test/pages/a.jl
+++ b/test/pages/a.jl
@@ -14,6 +14,10 @@ Links:
 - [`f(::Any, ::Any)`](@ref)
 - [`f(x, y, z)`](@ref)
 
+[^footnote]:
+
+    Footnote contents. [^footnote]
+
 """
 f(x) = x
 


### PR DESCRIPTION
Checks whether all footnotes and references have matching partners.

Warnings are printed when:

  * duplicate footnotes are found;
  * footnote references don't have a matching footnote;
  * a footnote is unused within a page.

Uncovered a bug in `walk` where walking a `Vector` would walk each node of the vector twice.