### PR TITLE
Drop colon from keywords

### DIFF
--- a/src/CrossReferences.jl
+++ b/src/CrossReferences.jl
@@ -115,7 +115,8 @@ end
 function docsxref(link::Markdown.Link, meta, page, doc)
     # Parse the link text and find current module.
     local code = link.text[1].code
-    local ex = parse(code)
+    local keyword = Symbol(strip(code))
+    local ex = haskey(Docs.keywords, keyword) ? QuoteNode(keyword) : parse(code)
     local mod = get(meta, :CurrentModule, current_module())
     # Find binding and type signature associated with the link.
     local binding = Documenter.DocSystem.binding(mod, ex)
@@ -130,10 +131,6 @@ function docsxref(link::Markdown.Link, meta, page, doc)
         path     = Formats.extension(doc.user.format, path)
         slug     = Utilities.slugify(object)
         link.url = string(path, '#', slug)
-        # Fixup keyword ref text since they have a leading ':' char.
-        if object.binding.mod === Main && haskey(Base.Docs.keywords, object.binding.var)
-            link.text[1].code = lstrip(code, ':')
-        end
     else
         Utilities.warn(page.source, "No doc found for reference '[`$code`](@ref)'.")
     end

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -97,19 +97,31 @@ Returns a vector of parsed expressions and their corresponding raw strings.
 
 The keyword argument `skip = N` drops the leading `N` lines from the input string.
 """
-function parseblock(code, doc, page; skip = 0)
+function parseblock(code::AbstractString, doc, page; skip = 0)
+    # Drop `skip` leading lines from the code block. Needed for deprecated `{docs}` syntax.
     code = string(code, '\n')
     code = last(split(code, '\n', limit = skip + 1))
-    results, cursor = [], 1
-    while cursor < length(code)
-        ex, ncursor =
-            try
-                parse(code, cursor)
-            catch err
-                Utilities.warn(doc, page, "Failed to parse expression.", err)
-                break
+    # Check whether we have windows-style line endings.
+    local offset = contains(code, "\n\r") ? 2 : 1
+    local strlen = length(code)
+    local results = []
+    local cursor = 1
+    while cursor < strlen
+        # Check for keywords first since they will throw parse errors if we `parse` them.
+        local line = match(r"^(.+)$"m, SubString(code, cursor, strlen)).captures[1]
+        local keyword = Symbol(strip(line))
+        (ex, ncursor) =
+            if haskey(Docs.keywords, keyword)
+                (QuoteNode(keyword), cursor + length(line) + offset)
+            else
+                try
+                    parse(code, cursor)
+                catch err
+                    Utilities.warn(doc, page, "Failed to parse expression.", err)
+                    break
+                end
             end
-        push!(results, (ex, code[cursor:ncursor-1]))
+        push!(results, (ex, SubString(code, cursor, ncursor - 1)))
         cursor = ncursor
     end
     results

--- a/test/examples/src/lib/functions.md
+++ b/test/examples/src/lib/functions.md
@@ -11,14 +11,14 @@ Pages = ["lib/functions.md"]
 
 # Functions
 
-[`:ccall`](@ref), [`func(x)`](@ref), [`T`](@ref), [`:for`](@ref), and [`:while`](@ref).
+[`ccall`](@ref), [`func(x)`](@ref), [`T`](@ref), [`for`](@ref), and [`while`](@ref).
 
 ```@docs
 func(x)
 T
-:ccall
-:for
-:while
+ccall
+for
+while
 @time
 @assert
 ```

--- a/test/pages/a.jl
+++ b/test/pages/a.jl
@@ -4,8 +4,8 @@
 
 Links:
 
-- [`:ccall`](@ref)
-- [`:while`](@ref)
+- [`ccall`](@ref)
+- [`while`](@ref)
 - [`@time(x)`](@ref)
 - [`T(x)`](@ref)
 - [`T(x, y)`](@ref)

--- a/test/pages/b.jl
+++ b/test/pages/b.jl
@@ -4,8 +4,8 @@
 
 Links:
 
-- [`:ccall`](@ref)
-- [`:while`](@ref)
+- [`ccall`](@ref)
+- [`while`](@ref)
 - [`@time`](@ref)
 - [`T`](@ref)
 - [`f`](@ref)

--- a/test/pages/c.jl
+++ b/test/pages/c.jl
@@ -4,8 +4,8 @@
 
 Links:
 
-- [`:ccall`](@ref)
-- [`:while`](@ref)
+- [`ccall`](@ref)
+- [`while`](@ref)
 - [`@time`](@ref)
 - [`T`](@ref)
 - [`f`](@ref)

--- a/test/pages/d.jl
+++ b/test/pages/d.jl
@@ -4,8 +4,8 @@
 
 Links:
 
-- [`:ccall`](@ref)
-- [`:while`](@ref)
+- [`ccall`](@ref)
+- [`while`](@ref)
 - [`@time`](@ref)
 - [`T`](@ref)
 - [`f`](@ref)
@@ -22,8 +22,8 @@ type T end
 
 Links:
 
-- [`:ccall`](@ref)
-- [`:while`](@ref)
+- [`ccall`](@ref)
+- [`while`](@ref)
 - [`@time`](@ref)
 - [`T(x)`](@ref)
 - [`T(x, y)`](@ref)
@@ -41,8 +41,8 @@ T(x) = T()
 
 Links:
 
-- [`:ccall`](@ref)
-- [`:while`](@ref)
+- [`ccall`](@ref)
+- [`while`](@ref)
 - [`@time`](@ref)
 - [`T()`](@ref)
 - [`T(x)`](@ref)


### PR DESCRIPTION
Removes `:` syntax needed for referencing keywords.