### PR TITLE
Handle relative paths correctly in method list URLs

### DIFF
--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -340,7 +340,10 @@ url(remote, repo, doc) = url(remote, repo, doc.data[:module], doc.data[:path], l
 if VERSION >= v"0.5.0-dev+3442"
     function url(remote, repo, mod, file, line)
         isempty(remote) && isempty(repo) && return Nullable{Compat.String}()
-        if inbase(mod)
+        # Macro-generated methods such as those produced by `@deprecate` list their file as
+        # `deprecated.jl` since that is where the macro is defined. Use that to help
+        # determine the correct URL.
+        if inbase(mod) || !isabspath(file)
             base = "https://github.com/JuliaLang/julia/tree"
             dest = "base/$file#L$line"
             Nullable{Compat.String}(

--- a/src/Writers/MarkdownWriter.jl
+++ b/src/Writers/MarkdownWriter.jl
@@ -129,10 +129,6 @@ function render(io::IO, mime::MIME"text/plain", node::Documents.DocsNode, page, 
                 tv, decls, file, line = Base.arg_decl_parts(m)
                 decls = decls[2:end]
                 file = string(file)
-                if !isfile(file)
-                    println("Skipping ", m, " (file not found; method may be deprecated)")
-                    continue
-                end
                 url = get(Utilities.url(doc.internal.remote, doc.user.repo, m.module, file, line), "")
                 file_match = match(r, file)
                 if file_match !== nothing


### PR DESCRIPTION
Methods that have been deprecated using `at-deprecate` will have their `.file` point to `deprecated.jl` but their `.module` point to the correct module where they were defined. This was confusing `Utilities.url`.