### PR TITLE
Parse doc.user.pages

### DIFF
--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -156,6 +156,7 @@ Writers.LaTeXWriter
 Utilities
 Utilities.currentdir
 Utilities.assetsdir
+Utilities.srcpath
 Utilities.check_kwargs
 Utilities.slugify
 Utilities.parseblock

--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -40,6 +40,7 @@ Builder.CrossReferences
 Builder.CheckDocument
 Builder.Populate
 Builder.RenderDocument
+Builder.walk_navpages
 ```
 
 ## CrossReferences
@@ -78,6 +79,8 @@ Documents.User
 Documents.Internal
 Documents.Globals
 Documents.populate!
+Documents.NavNode
+Documents.navpath
 ```
 
 ## Expanders

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -221,9 +221,8 @@ end
 
 function addpage!(doc::Document, src::AbstractString, dst::AbstractString)
     page = Page(src, dst)
-    # the page's name is determined from the file system path, but we need
-    # the path relative to `doc.user.source` and must drop the extension
-    name = first(splitext(normpath(relpath(src, doc.user.source))))
+    # page's identifier is the path relative to the `doc.user.source` directory
+    name = normpath(relpath(src, doc.user.source))
     doc.internal.pages[name] = page
 end
 

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -85,6 +85,14 @@ assetsdir() = normpath(joinpath(dirname(@__FILE__), "..", "..", "assets"))
 
 cleandir(d::AbstractString) = (isdir(d) && rm(d, recursive = true); mkdir(d))
 
+"""
+Find the path of a file relative to the `source` directory. `root` is the path
+to the directory containing the file `file`.
+
+It is meant to be used with `walkdir(source)`.
+"""
+srcpath(source, root, file) = normpath(joinpath(relpath(root, source), file))
+
 # Slugify text.
 
 """

--- a/test/navnode.jl
+++ b/test/navnode.jl
@@ -1,0 +1,57 @@
+module NavNodeTests
+
+using Base.Test
+using Compat
+import Documenter: Documents, Builder
+import Documenter.Documents: NavNode
+
+type FakeDocumentInternal
+    pages   :: Dict{Compat.String, Void}
+    navlist :: Vector{NavNode}
+    FakeDocumentInternal() = new(Dict(), [])
+end
+type FakeDocument
+    internal :: FakeDocumentInternal
+    FakeDocument() = new(FakeDocumentInternal())
+end
+@test fieldtype(FakeDocumentInternal, :navlist) == fieldtype(Documents.Internal, :navlist)
+
+pages = [
+    "page1.md",
+    "Page2" => "page2.md",
+    "Section" => [
+        "page3.md",
+        "Page4" => "page4.md",
+        "Subsection" => [
+            "page5.md",
+        ],
+    ],
+    "page6.md",
+]
+doc = FakeDocument()
+doc.internal.pages = Dict(map(i -> "page$i.md" => nothing, 1:8))
+navtree = Builder.walk_navpages(pages, nothing, doc)
+navlist = doc.internal.navlist
+
+@test length(navlist) == 6
+for (i,navnode) in enumerate(navlist)
+    @test get(navnode.page) == "page$i.md"
+end
+
+@test isa(navtree, Vector{NavNode})
+@test length(navtree) == 4
+@test navtree[1] === navlist[1]
+@test navtree[2] === navlist[2]
+@test navtree[4] === navlist[6]
+
+section = navtree[3]
+@test get(section.title_override) == "Section"
+@test isnull(section.page)
+@test length(section.children) == 3
+
+navpath = Documents.navpath(navlist[5])
+@test length(navpath) == 3
+@test navpath[1] === section
+@test navpath[3] === navlist[5]
+
+end # module NavNodeTests

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -144,6 +144,10 @@ end
 @test UnitTests.A.B.C in Documenter.Utilities.submodules(UnitTests.A)
 @test UnitTests.A.B.C.D in Documenter.Utilities.submodules(UnitTests.A)
 
+## NavNode tests
+
+include("navnode.jl")
+
 # DocSystem unit tests.
 
 import Documenter: DocSystem


### PR DESCRIPTION
Proposing a way of parsing `doc.user.pages` and storing it into a convenient data structure. Necessary for #3 and #4, opening it up for discussion.

In a nutshell: `doc.internal.navtree` allows for walking across the tree for a tree-like navbar (like in HTML, but also probably in LaTeX), `doc.user.navlist` is useful for sequential things only on pages. `NavNode`'s `.next`, `.prev` etc. are useful for other navlinks.

~~**TODO:** It could probably use a few tests as well.~~

**`UTF8String`:** One thing I am doing is using `Compat.UTF8String` instead of `Compat.String` for type fields (which goes against the previous practice), but should actually be the correct one, if I interpret [Compat.jl's documentation](https://github.com/JuliaLang/Compat.jl#type-aliases) correctly. Specifically:

> Compat also provides an unexported `Compat.String` /--/ It should **not** be used as the default type for variables or fields holding strings, as it introduces type-instability in Julia 0.3 and 0.4: use Compat.UTF8String or Compat.ASCIIString instead.

In 0.4 `Compat.String = ByteString = Union{ASCIIString,UTF8String}`.

I am thinking that maybe we should have a `String = Compat.UTF8String` under every `using Compat` to get uniform behaviour and then use just `String` in fields. In this PR I could change back to `Compat.String` though, for consistency.