### PR TITLE
Add option to hide names in autodocs

### DIFF
--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -85,6 +85,28 @@ docstrings. Note that page matching is done using the end of the provided string
 `a.jl` will be matched by *any* source file that ends in `a.jl`, i.e. `src/a.jl` or
 `src/foo/a.jl`.
 
+To include only the exported names from the modules listed in `Modules` use `Private = false`.
+In a similar way `Public = false` can be used to only show the unexported names. By
+default both of these are set to `true` so that all names will be shown.
+
+````markdown
+Functions exported from `Foo`:
+
+```@autodocs
+Modules = [Foo]
+Private = false
+Order = [:function]
+```
+
+Private types in module `Foo`:
+
+```@autodocs
+Modules = [Foo]
+Public = false
+Order = [:type]
+```
+````
+
 !!! note
 
     When more complex sorting and filtering is needed then use `@docs` to define it

--- a/test/examples/mkdocs.yml
+++ b/test/examples/mkdocs.yml
@@ -31,3 +31,4 @@ pages:
   - Tutorial: man/tutorial.md
 - Library:
   - Functions: lib/functions.md
+  - AutoDocs: lib/autodocs.md

--- a/test/examples/src/lib/autodocs.md
+++ b/test/examples/src/lib/autodocs.md
@@ -1,0 +1,52 @@
+# `@autodocs` tests
+
+```@meta
+CurrentModule = Main
+```
+
+## Public
+
+Should include docs for
+
+  * [`AutoDocs.Pages.E.f_1`](@ref)
+  * [`AutoDocs.Pages.E.f_2`](@ref)
+  * [`AutoDocs.Pages.E.f_3`](@ref)
+
+in that order.
+
+```@autodocs
+Modules = [AutoDocs.Pages.E]
+Private = false
+Order = [:function]
+```
+
+## Private
+
+Should include docs for
+
+  * [`AutoDocs.Pages.E.g_1`](@ref)
+  * [`AutoDocs.Pages.E.g_2`](@ref)
+  * [`AutoDocs.Pages.E.g_3`](@ref)
+
+in that order.
+
+```@autodocs
+Modules = [AutoDocs.Pages.E]
+Public = false
+Order = [:function]
+```
+
+## Ordering of Public and Private
+
+Should include docs for
+
+  * [`AutoDocs.Pages.E.T_1`](@ref)
+  * [`AutoDocs.Pages.E.T_2`](@ref)
+
+in that order.
+
+```@autodocs
+Modules = [AutoDocs.Pages.E]
+Order = [:type]
+```
+

--- a/test/pages/e.jl
+++ b/test/pages/e.jl
@@ -1,0 +1,32 @@
+module E
+
+export f_1, f_2, f_3
+
+"f_1"
+f_1(x) = x
+
+"f_2"
+f_2(x) = x
+
+"f_3"
+f_3(x) = x
+
+
+"g_1"
+g_1(x) = x
+
+"g_2"
+g_2(x) = x
+
+"g_3"
+g_3(x) = x
+
+export T_1
+
+"T_1"
+type T_1 end
+
+"T_2"
+type T_2 end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,7 @@ include("pages/a.jl")
 include("pages/b.jl")
 include("pages/c.jl")
 include("pages/d.jl")
+include("pages/e.jl")
 
 end
 
@@ -387,7 +388,7 @@ end
 
 @test doc.internal.assets == normpath(joinpath(dirname(@__FILE__), "..", "assets"))
 
-@test length(doc.internal.pages) == 3
+@test length(doc.internal.pages) == 4
 
 let headers = doc.internal.headers
     @test Documenter.Anchors.exists(headers, "Documentation")
@@ -409,7 +410,7 @@ let headers = doc.internal.headers
     end
 end
 
-@test length(doc.internal.objects) == 28
+@test length(doc.internal.objects) == 36
 
 # Documenter package docs:
 


### PR DESCRIPTION
New options added to `at-autodocs` for hiding either the exported or the unexported symbols in the `Modules` list.

Fixes #169.