### PR TITLE
Change to using `jldoctest` for doctests only

### DIFF
--- a/docs/src/man/doctests.md
+++ b/docs/src/man/doctests.md
@@ -1,6 +1,6 @@
 # Doctests
 
-Documenter will, by default, try to run Julia code blocks that it finds in the generated
+Documenter will, by default, try to run `jldoctest` code blocks that it finds in the generated
 documentation. This can help to avoid documentation examples from becoming outdated,
 incorrect, or misleading. It's recommended that as many of a package's examples be runnable
 by Documenter's doctest.
@@ -14,7 +14,7 @@ The first, of two, types of doctests is the "script" code block. To make Documen
 this kind of code block the following format must be used:
 
 ````markdown
-```julia
+```jldoctest
 a = 1
 b = 2
 a + b
@@ -25,7 +25,7 @@ a + b
 ```
 ````
 
-The code block's "language" must be `julia` and must include a line containing the text `#
+The code block's "language" must be `jldoctest` and must include a line containing the text `#
 output`. The text before this line is the contents of the script which is run. The text that
 appears after `# output` is the textual representation that would be shown in the Julia REPL
 if the script had been `include`d.
@@ -42,7 +42,7 @@ The other kind of doctest is a simulated Julia REPL session. The following forma
 detected by Documenter as a REPL doctest:
 
 ````markdown
-```julia
+```jldoctest
 julia> a = 1
 1
 
@@ -56,7 +56,7 @@ julia> a + b + c
 ```
 ````
 
-As with script doctests, the code block must have it's language set to `julia`. When a code
+As with script doctests, the code block must have it's language set to `jldoctest`. When a code
 block contains one or more `julia> ` at the start of a line then it is assumed to be a REPL
 doctest. Semi-colons, `;`, at the end of a line works in the same way as in the Julia REPL
 and will suppress the output, although the line is still evaluated.
@@ -76,7 +76,7 @@ example, but that should not be displayed in the final documentation. It could a
 several separate doctests require the same definitions. For both of these cases a `@meta`
 block containing a `DocTestSetup = ...` value can be used as follows:
 
-    ```julia
+    ```jldoctest
     julia> using DataFrames
 
     julia> df = DataFrame(A = 1:10, B = 2:2:20);
@@ -92,14 +92,14 @@ block containing a `DocTestSetup = ...` value can be used as follows:
     end
     ```
 
-    ```julia
+    ```jldoctest
     julia> df[1, 1]
     1
     ```
 
     Some more text...
 
-    ```julia
+    ```jldoctest
     julia> df[1, :]
     1x2 DataFrames.DataFrame
     | Row | A | B |

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -50,11 +50,15 @@ Deploy keys provide push access to a *single* repository.
 
 Open a Julia REPL and import [`Documenter`](@ref).
 
-    julia> using Documenter
+```jlcon
+julia> using Documenter
+```
 
 Then call the [`Travis.genkeys`](@ref) function as follows:
 
-    julia> Travis.genkeys("MyPackage")
+```jlcon
+julia> Travis.genkeys("MyPackage")
+```
 
 where `"MyPackage"` is the name of the package you would like to create deploy keys for.
 

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -202,7 +202,7 @@ Order   = [:function, :type]
 When `Pages` or `Modules` are not provided then all pages or modules are included. `Order`
 defaults to
 
-```
+```julia
 [:module, :constant, :type, :function, :macro]
 ```
 

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -75,7 +75,9 @@ makedocs(
 
 which is then run from the command line with:
 
-    \$ julia make.jl
+```sh
+\$ julia make.jl
+```
 
 The folder structure that [`makedocs`](@ref) expects looks like:
 
@@ -194,7 +196,9 @@ default value is `"site"`.
 keyword *must* be set and will throw an error when left undefined. For example this package
 uses the following `repo` value:
 
-    repo = "github.com/JuliaDocs/Documenter.jl.git"
+```julia
+repo = "github.com/JuliaDocs/Documenter.jl.git"
+```
 
 **`branch`** is the branch where the generated documentation is pushed. By default this
 value is set to `"gh-pages"`.
@@ -214,7 +218,9 @@ section of the `.travis.yml` configuration file.
 documentation. By default this function installs `pygments` and `mkdocs` using the
 [`Deps.pip`](@ref) function:
 
-    deps = Deps.pip("pygments", "mkdocs")
+```julia
+deps = Deps.pip("pygments", "mkdocs")
+```
 
 **`make`** is the function used to convert the markdown files to HTML. By default this just
 runs `mkdocs build` which populates the `target` directory.
@@ -422,10 +428,12 @@ following command lines programs to be installed:
 
 # Examples
 
-    julia> using Documenter
+```jlcon
+julia> using Documenter
 
-    julia> Travis.genkeys("MyPackageName")
-    [ ... output ... ]
+julia> Travis.genkeys("MyPackageName")
+[ ... output ... ]
+```
 
 """
 function genkeys(package)
@@ -508,11 +516,12 @@ It defaults to `<package directory>/docs`. The directory must not exist.
 
 # Examples
 
-    julia> using Documenter
+```jlcon
+julia> using Documenter
 
-    julia> Documenter.generate("MyPackageName")
-    [ ... output ... ]
-
+julia> Documenter.generate("MyPackageName")
+[ ... output ... ]
+```
 """
 function generate(pkgname::AbstractString; dir=nothing)
     # TODO:

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -582,8 +582,7 @@ function Selectors.runner(::Type{REPLBlocks}, x, page, doc)
             println(out, output, "\n")
         end
     end
-    # Trailing whitespace in `"julia "` to avoid doctesting generated repl examples.
-    page.mapping[x] = Base.Markdown.Code("julia ", rstrip(takebuf_string(out)))
+    page.mapping[x] = Base.Markdown.Code("julia", rstrip(takebuf_string(out)))
 end
 
 # Utilities.

--- a/test/errors/make.jl
+++ b/test/errors/make.jl
@@ -1,10 +1,13 @@
 module ErrorsModule
 
 """
-```julia
+```jldoctest
 julia> a = 1
 2
 
+```
+
+```jldoctest
 ```
 """
 func(x) = x

--- a/test/errors/src/index.md
+++ b/test/errors/src/index.md
@@ -52,7 +52,7 @@ This is the footnote [^1]. And [^another] [^another].
 ErrorsModule.func
 ```
 
-```julia
+```jldoctest
 julia> b = 1
 2
 

--- a/test/examples/src/index.md
+++ b/test/examples/src/index.md
@@ -32,7 +32,7 @@ zeros(5, 5)
 zeros(50, 50)
 ```
 
-```julia
+```jldoctest
 julia> [1.0, 2.0, 3.0]
 3-element Array{Float64,1}:
  1.0
@@ -41,7 +41,7 @@ julia> [1.0, 2.0, 3.0]
 
 ```
 
-```julia
+```jldoctest
 julia> println(" "^5)
 
 julia> "\nfoo\n\nbar\n\n\nbaz"
@@ -57,7 +57,7 @@ bar
 baz
 ```
 
-```julia
+```jldoctest
 julia> info("...")
 INFO: ...
 

--- a/test/examples/src/man/tutorial.md
+++ b/test/examples/src/man/tutorial.md
@@ -10,7 +10,7 @@
 
 [`Main.Mod.T`](@ref)
 
-```julia
+```jldoctest
 julia> using Base.Meta # `nothing` shouldn't be displayed.
 
 julia> Meta
@@ -25,7 +25,7 @@ julia> a + b
 3
 ```
 
-```julia
+```jldoctest
 a = 1
 b = 2
 a + b
@@ -42,7 +42,7 @@ DocTestSetup =
     end
 ```
 
-```julia
+```jldoctest
 a = 1
 b = 2
 a / b
@@ -52,7 +52,7 @@ a / b
 0.5
 ```
 
-```julia
+```jldoctest
 julia> a = 1;
 
 julia> b = 2
@@ -67,7 +67,7 @@ code = string(sprint(Base.banner), "julia>")
 Markdown.Code(code)
 ```
 
-```julia
+```jldoctest
 julia> # First definition.
        function f(x, y)
            x + y
@@ -92,7 +92,7 @@ julia> !r
 false
 ```
 
-```julia
+```jldoctest
 julia> for i = 1:5
            println(i)
        end
@@ -131,7 +131,7 @@ a
 
 ```
 
-```julia
+```jldoctest
 a = 1
 b = 2; # Semi-colons don't affect script doctests.
 


### PR DESCRIPTION
Fixes #109.

This is a "non-breaking" breaking change in that doctests written in `julia` or `jlcon` code block will *not* be run after this is merged, though should not cause any doctest failures. `jldoctest` must be used to explicitly enable doctests for a block, as it is in `Base`.

This will warrant a minor version bump to 0.2, and so will push #3 onto a new 0.3 milestone, though without a due date change.