### PR TITLE
Remove autogenerated methodlists

### DIFF
--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -117,12 +117,6 @@ immutable DocsNode
     anchor  :: Anchors.Anchor
     object  :: Utilities.Object
     page    :: Documents.Page
-    """
-    Vector of methods associated with this `DocsNode`. Being nulled means that
-    conceptually the `DocsNode` has no table of method (as opposed to having
-    an empty table).
-    """
-    methods :: Nullable{Vector{MethodNode}}
 end
 
 immutable DocsNodes


### PR DESCRIPTION
Closes #163. These are now available in the DocStringExtensions package.

---

Appologies for taking this out @mortenpi, I should have probably thought ahead when you were initially implementing it. Sorry about that.

I do think it's definitely a good idea to decouple this kind of autogenerated content from Documenter so that it can be viewed in the REPL and elsewhere, and not just trapped in Documenter's output. If there's any improvements you'd like to see with the methodlists in DocStringExtensions please do go ahead and add/suggest them if you'd like to.
