### PR TITLE
Towards a unified doctree

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os:
   - osx
 
 julia:
-  - 0.4
   - 0.5
   - nightly
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.4
+AbstractTrees
 Compat 0.8
 DocStringExtensions 0.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/DocTrees/DocTrees.jl
+++ b/src/DocTrees/DocTrees.jl
@@ -1,0 +1,202 @@
+module DocTrees
+
+import AbstractTrees
+
+#
+# Constants.
+#
+
+const NULL_TAG = Symbol("#NULL#")
+const TEXT_TAG = Symbol("#TEXT#")
+
+const EMPTY_TEXT = ""
+
+const HEADER_TAGS = (:h1, :h2, :h3, :h4, :h5, :h6)
+
+
+#
+# Metadata and Attributes.
+#
+
+immutable Metadata
+    dict::Base.ImmutableDict{Symbol, Any}
+
+    function Metadata(args...)
+        local dict = Base.ImmutableDict{Symbol, Any}()
+        for (k, v) in args
+            dict = Base.ImmutableDict{Symbol, Any}(dict, k, v)
+        end
+        return new(dict)
+    end
+end
+
+immutable Attributes
+    dict::Base.ImmutableDict{Symbol, String}
+
+    function Attributes(args...)
+        local dict = Base.ImmutableDict{Symbol, String}()
+        for arg in args
+            dict = attributes(dict, arg)
+        end
+        return new(dict)
+    end
+
+    function attributes{D <: Base.ImmutableDict}(dict::D, str::AbstractString)
+        local class = IOBuffer()
+        local id = IOBuffer()
+        for each in eachmatch(r"[#|\.]([\w\-]+)", str)
+            local buffer = startswith(each.match, '.') ? class : id
+            print(buffer, position(buffer) === 0 ? "" : " ", each.captures[1])
+        end
+        dict = position(class) === 0 ? dict : D(dict, :class, takebuf_string(class))
+        dict = position(id) === 0 ? dict : D(dict, :id, takebuf_string(id))
+        return dict
+    end
+    attributes{D <: Base.ImmutableDict}(d::D, s::Symbol)       = D(d, s, "")
+    attributes{D <: Base.ImmutableDict}(d::D, p::Pair{Symbol}) = D(d, p.first, string(p.second))
+    attributes{D <: Base.ImmutableDict}(d::D, p::Pair)         = D(d, Symbol(p.first), string(p.second))
+end
+
+function Base.show(io::IO, data::Union{Attributes, Metadata})
+    (left, right) = isa(data, Attributes) ? ('{', '}') : ('[', ']')
+    print(io, left)
+    join(io, ("$k: $(repr(v))" for (k, v) in data.dict), ", ")
+    print(io, right)
+end
+
+#
+# Nodes.
+#
+
+immutable Node
+    tag::Symbol
+    text::String
+    attributes::Attributes
+    metadata::Metadata
+
+    nodes::Vector{Node}
+    index::Base.RefValue{Int}
+    parent::Base.RefValue{Node}
+
+    Node() = new(NULL_TAG)
+    Node(s::Symbol, args...) = link(s, EMPTY_TEXT, separate(args)...)
+    Node(t::AbstractString, args...) = link(TEXT_TAG, t, separate(args)...)
+
+    function link(tag, text, nodes, attrs, meta)
+        local this = new(tag, text, attrs, meta, nodes, Ref(0), Ref(Node()))
+        for (index, node) in enumerate(nodes)
+            node.index[] = index
+            node.parent[] = this
+        end
+        this.parent[] = this
+        return this
+    end
+
+    function separate(args::Tuple)
+        local nodes = Node[]
+        local attrs = Attributes()
+        local meta = Metadata()
+        for arg in args
+            isa(arg, Attributes) ? (attrs = arg) :
+            isa(arg, Metadata)   ? (meta  = arg) : flatten!(nodes, arg)
+        end
+        return (nodes, attrs, meta)
+    end
+
+    function flatten!(out, nodes)
+        for node in nodes
+            flatten!(out, node)
+        end
+        return out
+    end
+    flatten!(out, s::Union{Symbol, AbstractString}) = push!(out, Node(s))
+    flatten!(out, node::Node) = push!(out, node)
+end
+
+Base.show(io::IO, node::Node) = print(io, "(", node.tag, " ... )")
+
+#
+# Tags.
+#
+
+immutable Tag
+    name::Symbol
+end
+
+Base.show(io::IO, t::Tag) = print(io, "<", t.name, ">")
+
+macro tags(s...)
+    esc(:(const ($(s...),) = $(map(Tag, s))))
+end
+
+(t::Tag)(args...) = Node(t.name, args...)
+(n::Node)(args...) = Node(n.tag, n.attributes, n.metadata, args...)
+Base.getindex(t::Tag, args...) = Node(t.name, Attributes(args...))
+Base.getindex(n::Node, args...) = Node(n, Attributes(args...))
+
+#
+# Attribute and Metadata Queries.
+#
+
+attributes(n::Node) = n.attributes.dict
+metadata(n::Node) = n.metadata.dict
+
+getnull(a::Associative, key::Symbol, T) = Nullable{T}(haskey(a, key) ? a[key] : nothing)
+
+function querynull(n::Node, key::Symbol, T)
+    local dict = metadata(n)
+    if isroot(n)
+        return getnull(dict, key, T)
+    else
+        if haskey(dict, key)
+            return Nullable{T}(dict[key])
+        else
+            return querynull(parent(n), key, T)
+        end
+    end
+end
+
+function query{T}(n::Node, key::Symbol, default::T)
+    local results = querynull(n, key, T)
+    return isnull(results) ? default : get(results)
+end
+
+#
+# Node getters and predicates.
+#
+
+unwrap(f, n::Nullable) = (isnull(n) || f(get(n)); return nothing)
+
+parent(n::Node) = n.parent[]
+root(n::Node) = isroot(n) ? n : root(parent(n))
+index(n::Node) = n.index[]
+
+AbstractTrees.children(n::Node) = n.nodes
+
+depth(n::Node) = isroot(n) ? 0 : (1 + depth(parent(n)))
+
+isroot(n::Node) = parent(n) === n
+istext(n::Node) = n.tag === TEXT_TAG
+isadmonition(n::Node) = n.tag === :div && haskey(metadata(n), :admonition)
+isfootnote(n::Node) = n.tag === :div && haskey(metadata(n), :footnote)
+islist(n::Node) = n.tag === :ul || n.tag === :ol
+islatex(n::Node) = n.tag === :div && haskey(metadata(n), :latex)
+
+Base.isempty(n::Node) = isempty(n.nodes)
+
+isfirst(n::Node) = index(n) === 1
+islast(n::Node) = index(n) === length(parent(n).nodes)
+
+function sibling(n::Node, offset::Integer)
+    if isroot(n)
+        return Nullable{Node}()
+    else
+        local nth = index(n) + offset
+        local nodes = parent(n).nodes
+        return Nullable{Node}(nth in 1:length(nodes) ? nodes[nth] : nothing)
+    end
+end
+
+include("mdconvert.jl")
+
+end

--- a/src/DocTrees/mdconvert.jl
+++ b/src/DocTrees/mdconvert.jl
@@ -1,0 +1,105 @@
+module MarkdownConverter
+
+import ..DocTrees: Metadata, Node, @tags
+
+@tags div strong pre code hr img em span br a ol ul li p table th tr td blockquote
+
+import Base.Markdown:
+
+    Admonition,
+    BlockQuote,
+    Bold,
+    Code,
+    Footnote,
+    Header,
+    HorizontalRule,
+    Image,
+    Italic,
+    LaTeX,
+    LineBreak,
+    Link,
+    List,
+    MD,
+    Paragraph,
+    Table,
+    isordered
+
+# Entry point. Node `n` is it's own parent.
+mdconvert(n) = mdconvert(n, n)
+
+mdconvert(s::AbstractString, parent) = Node(s)
+
+mdconvert(v::Vector, parent) = [mdconvert(x, parent) for x in v]
+
+function mdconvert(m::MD, parent)
+    local metadata = Metadata(filter((k, v) -> !(k in (:config, :results)), m.meta)...)
+    div(metadata, mdconvert(m.content, m))
+end
+
+mdconvert(b::Bold, parent) = strong(mdconvert(b.text, b))
+
+function mdconvert(c::Code, ::MD)
+    local language = isempty(c.language) ? "none" : c.language
+    return pre(Metadata(:code => c.language), code[".language-$(language)"](c.code))
+end
+mdconvert(c::Code, parent) = code(c.code)
+
+mdconvert{N}(h::Header{N}, parent) = Node(Symbol(:h, N), mdconvert(h.text, h))
+
+mdconvert(::HorizontalRule, parent) = hr()
+
+mdconvert(i::Image, parent) = img[:src => i.url, :alt => i.alt]
+
+mdconvert(i::Italic, parent) = em(mdconvert(i.text, i))
+
+mdconvert(b::BlockQuote, parent) = blockquote(mdconvert(b.content, b))
+
+mdconvert(m::LaTeX, ::Paragraph) = span[".inline-math"]("\\($(m.formula)\\)")
+mdconvert(m::LaTeX, parent) = div[".display-math"]("\\[$(m.formula)\\]")
+
+mdconvert(::LineBreak, parent) = br()
+
+mdconvert(l::Link, parent) = a[:href => l.url](mdconvert(l.text, l))
+
+function mdconvert(l::List, parent)
+    local items = map(li, mdconvert(l.items, l))
+    if isordered(l)
+        return ol[:start => string(l.ordered)](
+            Metadata(:list => l.ordered), items
+        )
+    else
+        return ul(items)
+    end
+end
+
+mdconvert(t::Paragraph, parent) = p(mdconvert(t.content, t))
+
+function mdconvert(t::Table, parent)
+    local align = t.align
+    local header = tr(map(column -> th(mdconvert(column, t)), t.rows[1]))
+    local rows = Node[]
+    for row in t.rows[2:end]
+        push!(rows, tr(
+                [
+                    td[:style => "text-align:$(alignment(align[n]))"](mdconvert(column, t))
+                    for (n, column) in enumerate(row)
+                ]
+            )
+        )
+    end
+    return table(Metadata(:table => align), header, rows)
+end
+alignment(s::Symbol) = s === :l ? "left" : s === :r ? "right" : s === :c ? "center" : "left"
+
+mdconvert(f::Footnote, parent) = footnote(f.id, f.text, parent)
+footnote(id, ::Void, parent) = a[:href => "#footnote-$(id)"](Metadata(:footnote => id), "[$(id)]")
+footnote(id, text, parent) = div[".footnote#footnote-$(id)"](Metadata(:footnote => id), mdconvert(text, parent))
+
+mdconvert(a::Admonition, parent) =
+    div[".admonition.$(a.category)"](
+        Metadata(:admonition => (a.title, a.category)),
+        p[".admonition-title"](a.title),
+        mdconvert(a.content, a),
+    )
+
+end

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -31,6 +31,8 @@ for mod in [
     "Utilities",
     "DocSystem",
     "Selectors",
+    "DocTrees",
+    "Renderers",
     "Formats",
     "Anchors",
     "Documents",

--- a/src/Renderers/HTML.jl
+++ b/src/Renderers/HTML.jl
@@ -1,0 +1,53 @@
+module HTML
+
+import ...DocTrees
+import ..Renderers
+
+#
+# The following sets are based on:
+#
+# - https://developer.mozilla.org/en/docs/Web/HTML/Block-level_elements
+# - https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements
+# - https://developer.mozilla.org/en-US/docs/Glossary/empty_element
+#
+const BLOCK_ELEMENTS = Set([
+    :address, :article, :aside, :blockquote, :canvas, :dd, :div, :dl,
+    :fieldset, :figcaption, :figure, :footer, :form, :h1, :h2, :h3, :h4, :h5,
+    :h6, :header, :hgroup, :hr, :li, :main, :nav, :noscript, :ol, :output, :p,
+    :pre, :section, :table, :tfoot, :ul, :video,
+])
+const INLINE_ELEMENTS = Set([
+    :a, :abbr, :acronym, :b, :bdo, :big, :br, :button, :cite, :code, :dfn, :em,
+    :i, :img, :input, :kbd, :label, :map, :object, :q, :samp, :script, :select,
+    :small, :span, :strong, :sub, :sup, :textarea, :time, :tt, :var,
+])
+const VOID_ELEMENTS = Set([
+    :area, :base, :br, :col, :command, :embed, :hr, :img, :input, :keygen,
+    :link, :meta, :param, :source, :track, :wbr,
+])
+const ALL_ELEMENTS = union(BLOCK_ELEMENTS, INLINE_ELEMENTS, VOID_ELEMENTS)
+
+
+function Renderers.render(io::IO, mime::MIME"text/html", node::DocTrees.Node)
+    if DocTrees.istext(node)
+        Renderers.escape(io, mime, node.text)
+    else
+        print(io, '<', node.tag)
+        for (name, value) in Renderers.attributes(node, mime)
+            isempty(value) || print(io, ' ', name, '=', repr(value))
+        end
+        if node.tag in VOID_ELEMENTS
+            print(io, "/>")
+        else
+            print(io, '>')
+            if node.tag in (:script, :style)
+                isempty(node.nodes) || print(io, node.nodes[1].text)
+            else
+                Renderers.render(io, mime, node.nodes)
+            end
+            print(io, "</", node.tag, '>')
+        end
+    end
+end
+
+end

--- a/src/Renderers/LaTeX.jl
+++ b/src/Renderers/LaTeX.jl
@@ -1,0 +1,158 @@
+module LaTeX
+
+import ...DocTrees: DocTrees, Node
+import ...Selectors: runner
+import ..Renderers
+
+const TeX = MIME"text/latex"
+
+runner(::Type{Renderers.TextTag}, io::IO, m::TeX, n::Node) = print(io, n.text)
+
+function runner(::Type{Renderers.Header}, io::IO, m::TeX, n::Node)
+    print(io, "\\")
+    for _ in 2:findfirst(DocTrees.HEADER_TAGS, n.tag)
+        print(io, "sub")
+    end
+    print(io, "section{")
+    Renderers.render(io, m, n.nodes)
+    println(io, "}")
+end
+
+function runner(::Type{Renderers.Paragraph}, io::IO, m::TeX, n::Node)
+    println(io)
+    Renderers.render(io, m, n.nodes)
+    println(io)
+end
+
+function runner(::Type{Renderers.PreTag}, io::IO, m::TeX, n::Node)
+    local source = n.nodes[1].nodes[1].text
+    local language = get(DocTrees.metadata(n), :code, "")
+    println(io, "\\begin{minted}{", language, "}")
+    println(io, source)
+    println(io, "\\end{minted}")
+end
+
+function runner(::Type{Renderers.BlockQuote}, io::IO, m::TeX, n::Node)
+    println(io, "\\begin{quote}")
+    Renderers.render(io, m, n.nodes)
+    println(io, "\\end{quote}")
+end
+
+function runner(::Type{Renderers.CodeTag}, io::IO, m::TeX, n::Node)
+    print(io, "\\texttt{", n.nodes[1].text, "}")
+end
+
+runner(::Type{Renderers.SpanTag}, io::IO, m::TeX, n::Node) = Renderers.render(io, m, n.nodes)
+
+function runner(::Type{Renderers.StrongTag}, io::IO, m::TeX, n::Node)
+    print(io, "\\textbf{")
+    Renderers.render(io, m, n.nodes)
+    print(io, "}")
+end
+
+function runner(::Type{Renderers.EmTag}, io::IO, m::TeX, n::Node)
+    print(io, "\\emph{")
+    Renderers.render(io, m, n.nodes)
+    print(io, "}")
+end
+
+function runner(::Type{Renderers.Link}, io::IO, m::TeX, n::Node)
+    if haskey(DocTrees.metadata(n), :footnote)
+        print(io, "\\footnotemark[", get(DocTrees.metadata(n), :footnote, ""), "]")
+    else
+        print(io, "\\href{")
+        print(io, get(Renderers.attributes(n, m), :href, ""), "}{")
+        Renderers.render(io, m, n.nodes)
+        print(io, "}")
+    end
+end
+
+function runner(::Type{Renderers.Image}, io::IO, m::TeX, n::Node)
+    local src = get(DocTrees.attributes(n), :src, "")
+    print(io, "\\includegraphics{", src, "}")
+end
+
+function runner(::Type{Renderers.List}, io::IO, m::TeX, n::Node)
+    println(io, "\\begin{itemize}")
+    if n.tag === :ul
+        for node in n.nodes
+            print(io, "\\item[]")
+            let temp = IOBuffer()
+                Renderers.render(temp, m, node.nodes)
+                Renderers.indented(io, seekstart(temp), "    ")
+            end
+        end
+    elseif n.tag === :ol
+        local count = length(n.nodes)
+        local width = ndigits(count)
+        local offset = get(DocTrees.metadata(n), :list, 1) - 1
+        for (number, node) in enumerate(n.nodes)
+            print(io, "\\item[", lpad(number + offset, width), ". ]")
+            let temp = IOBuffer()
+                Renderers.render(temp, m, node.nodes)
+                Renderers.indented(io, seekstart(temp), "    ")
+            end
+        end
+    else
+        error("fatal error. Unhandled list type '$n'.")
+    end
+    println(io, "\\end{itemize}")
+end
+
+function runner(::Type{Renderers.HrTag}, io::IO, m::TeX, n::Node)
+    println(io, "\n\\begin{center}\\rule{0.5\\linewidth}{\\linethinkness}\\end{center}\n")
+end
+
+runner(::Type{Renderers.BrTag}, io::IO, m::TeX, n::Node) = println(io, "\\\\")
+
+# TODO: print with "correct" width for each column?
+function runner(::Type{Renderers.Table}, io::IO, m::TeX, n::Node)
+    print(io, "\\begin{longtable}[]{@{}")
+    join(io, DocTrees.metadata(n)[:table])
+    println(io, "@{}}")
+    println(io, "\\toprule")
+    for (nth, node) in enumerate(n.nodes[1].nodes)
+        nth > 1 && print(io, " & ")
+        Renderers.render(io, m, node.nodes)
+    end
+    println(io, "\\tabularnewline")
+    println(io, "\\midrule")
+    println(io, "\\endhead")
+
+    for row in n.nodes[2:end]
+        for (nth, node) in enumerate(row.nodes)
+            nth > 1 && print(io, " & ")
+            Renderers.render(io, m, node.nodes)
+        end
+        println(io, "\\tabularnewline")
+    end
+    println(io, "\\bottomrule")
+    println(io, "\\end{longtable}")
+end
+
+function runner(::Type{Renderers.Admonition}, io::IO, m::TeX, n::Node)
+    title, category = get(DocTrees.metadata(n), :admonition, ("", ""))
+    println(io)
+    println(io, "\\begin{admonition}{", category, "}{", title, "}")
+    let temp = IOBuffer()
+        Renderers.render(temp, m, n.nodes)
+        Renderers.indented(io, seekstart(temp), "    ")
+    end
+    println(io, "\\end{admonition}")
+end
+
+function runner(::Type{Renderers.Footnote}, io::IO, m::TeX, n::Node)
+    local id = get(DocTrees.metadata(n), :footnote, "")
+    println(io)
+    println(io, "\\footnotetext[", id, "]{")
+    Renderers.render(io, m, n.nodes)
+    println(io, "}")
+end
+
+function runner(::Type{Renderers.DivTag}, io::IO, m::TeX, n::Node)
+    println(io)
+    Renderers.render(io, m, n.nodes)
+    println(io)
+end
+
+end

--- a/src/Renderers/Markdown.jl
+++ b/src/Renderers/Markdown.jl
@@ -1,0 +1,186 @@
+module Markdown
+
+import ...DocTrees: DocTrees, Node
+import ...Selectors: runner
+import ..Renderers
+
+const MD = MIME"text/markdown"
+
+runner(::Type{Renderers.TextTag}, io::IO, m::MD, n::Node) = print(io, n.text)
+
+function runner(::Type{Renderers.Header}, io::IO, m::MD, n::Node)
+    for _ in 1:findfirst(DocTrees.HEADER_TAGS, n.tag)
+        print(io, '#')
+    end
+    print(io, ' ')
+    Renderers.render(io, m, n.nodes)
+    println(io)
+end
+
+function runner(::Type{Renderers.Paragraph}, io::IO, m::MD, n::Node)
+    println(io)
+    Renderers.render(io, m, n.nodes)
+    println(io)
+end
+
+function runner(::Type{Renderers.PreTag}, io::IO, m::MD, n::Node)
+    local source = n.nodes[1].nodes[1].text
+    local language = get(DocTrees.metadata(n), :code, "")
+    local count = mapreduce(length, max, 2, matchall(r"^(`+)"m, source)) + 1
+    println(io)
+    println(io, "`"^count, language)
+    println(io, source)
+    println(io, "`"^count)
+    println(io)
+end
+
+function runner(::Type{Renderers.BlockQuote}, io::IO, m::MD, n::Node)
+    let temp = IOBuffer()
+        Renderers.render(temp, m, n.nodes)
+        Renderers.indented(io, seekstart(temp), "> ")
+    end
+    println(io)
+end
+
+function runner(::Type{Renderers.CodeTag}, io::IO, m::MD, n::Node)
+    local source = n.nodes[1].text
+    local count = mapreduce(length, max, 0, matchall(r"`+", source)) + 1
+    print(io, "`"^count, source, "`"^count)
+end
+
+runner(::Type{Renderers.SpanTag}, io::IO, m::MD, n::Node) = Renderers.render(io, m, n.nodes)
+
+function runner(::Type{Renderers.StrongTag}, io::IO, m::MD, n::Node)
+    print(io, "**")
+    Renderers.render(io, m, n.nodes)
+    print(io, "**")
+end
+
+function runner(::Type{Renderers.EmTag}, io::IO, m::MD, n::Node)
+    print(io, "*")
+    Renderers.render(io, m, n.nodes)
+    print(io, "*")
+end
+
+function runner(::Type{Renderers.Link}, io::IO, m::MD, n::Node)
+    if haskey(DocTrees.metadata(n), :footnote)
+        print(io, "[^", get(DocTrees.metadata(n), :footnote, ""), "]")
+    else
+        print(io, "[")
+        Renderers.render(io, m, n.nodes)
+        print(io, "](", get(Renderers.attributes(n, m), :href, ""), ")")
+    end
+end
+
+function runner(::Type{Renderers.Image}, io::IO, m::MD, n::Node)
+    local alt = get(DocTrees.attributes(n), :alt, "")
+    local src = get(DocTrees.attributes(n), :src, "")
+    print(io, "![", alt, "](", src, ")")
+end
+
+function runner(::Type{Renderers.List}, io::IO, m::MD, n::Node)
+    if n.tag === :ul
+        local bullet = "  * "
+        for node in n.nodes
+            let temp = IOBuffer()
+                Renderers.render(temp, m, node.nodes)
+                Renderers.indented(io, seekstart(temp), " "^length(bullet), bullet)
+            end
+        end
+    elseif n.tag === :ol
+        local count = length(n.nodes)
+        local width = ndigits(count)
+        local offset = get(DocTrees.metadata(n), :list, 1) - 1
+        for (number, node) in enumerate(n.nodes)
+            number += offset
+            let temp = IOBuffer(),
+                bullet = string(lpad(number, width), ". ")
+                Renderers.render(temp, m, node.nodes)
+                Renderers.indented(io, seekstart(temp), " "^length(bullet), bullet)
+            end
+        end
+    else
+        error("fatal error. Unhandled list type '$n'.")
+    end
+end
+
+runner(::Type{Renderers.HrTag}, io::IO, m::MD, n::Node) = println(io, "\n---\n")
+
+runner(::Type{Renderers.BrTag}, io::IO, m::MD, n::Node) = println(io)
+
+function runner(::Type{Renderers.Table}, io::IO, m::MD, n::Node)
+    # Header.
+    local header = n.nodes[1]
+    print(io, "| ")
+    for (nth, node) in enumerate(header.nodes)
+        nth > 1 && print(io, " | ")
+        let temp = IOBuffer()
+            Renderers.render(temp, m, node.nodes)
+            seekstart(temp)
+            local range = Renderers.selection(temp, '\n', true, -1)
+            Renderers.writeto(io, temp, range)
+        end
+    end
+    println(io, " |")
+
+    # Alignment.
+    local align = DocTrees.metadata(n)[:table]
+    print(io, "|")
+    for (nth, sym) in enumerate(align)
+        nth > 1 && print(io, "|")
+        # Left side.
+        left = sym === :l || sym === :c
+        print(io, left ? ":" : " ")
+        # Bar.
+        print(io, "---")
+        # Right side.
+        right = sym === :r || sym === :c
+        print(io, right ? ":" : " ")
+    end
+    println(io, "|")
+
+    # Body.
+    for row in n.nodes[2:end]
+        print(io, "| ")
+        for (nth, node) in enumerate(row.nodes)
+            nth > 1 && print(io, " | ")
+            let temp = IOBuffer()
+                Renderers.render(temp, m, node.nodes)
+                seekstart(temp)
+                local range = Renderers.selection(temp, '\n', true, 0)
+                Renderers.writeto(io, temp, range)
+            end
+        end
+        println(io, " |")
+    end
+end
+
+function runner(::Type{Renderers.Admonition}, io::IO, m::MD, n::Node)
+    title, category = get(DocTrees.metadata(n), :admonition, ("", ""))
+    println(io)
+    println(io, "!!! ", category, " ", '"', title, '"')
+    let temp = IOBuffer()
+        Renderers.render(temp, m, n.nodes)
+        Renderers.indented(io, seekstart(temp), "    ")
+    end
+    println(io)
+end
+
+function runner(::Type{Renderers.Footnote}, io::IO, m::MD, n::Node)
+    local id = get(DocTrees.metadata(n), :footnote, "")
+    println(io)
+    println(io, "[^", id, "]:")
+    let temp = IOBuffer()
+        Renderers.render(temp, m, n.nodes)
+        Renderers.indented(io, seekstart(temp), "    ")
+    end
+    println(io)
+end
+
+function runner(::Type{Renderers.DivTag}, io::IO, m::MD, n::Node)
+    println(io)
+    Renderers.render(io, m, n.nodes)
+    println(io)
+end
+
+end

--- a/src/Renderers/Renderers.jl
+++ b/src/Renderers/Renderers.jl
@@ -1,0 +1,139 @@
+module Renderers
+
+import ..DocTrees: DocTrees, Node
+
+render(io, mime, node) = error("`render` not implemented for `$mime`.")
+
+# Overload to replace `@ref` with correct links.
+attributes(node::Node, mime) = DocTrees.attributes(node)
+
+
+include("HTML.jl")
+
+
+#
+# Non-HTML renderers.
+#
+
+import ..DocTrees: DocTrees, Node
+import ..Selectors: Selectors, AbstractSelector, order, matcher, runner
+
+
+#
+# `Selector` definitions needed for rendering non-HTML.
+#
+# This creates a jump table at compile time so that matching and rendering of tags
+# can be decoupled yet not have to rely on dynamic dispatch.
+#
+
+abstract Tag <: AbstractSelector
+
+const TAGS = (
+    :TextTag     => :(DocTrees.istext(n)),
+    :Header      => :(n.tag in DocTrees.HEADER_TAGS),
+    :Paragraph   => :(n.tag === :p),
+    :PreTag      => :(n.tag === :pre),
+    :BlockQuote  => :(n.tag === :blockquote),
+    :CodeTag     => :(n.tag === :code),
+    :SpanTag     => :(n.tag === :span),
+    :StrongTag   => :(n.tag === :strong),
+    :EmTag       => :(n.tag === :em),
+    :Link        => :(n.tag === :a),
+    :Image       => :(n.tag === :img),
+    :List        => :(DocTrees.islist(n)),
+    :HrTag       => :(n.tag === :hr),
+    :BrTag       => :(n.tag === :br),
+    :Table       => :(n.tag === :table),
+    :Admonition  => :(DocTrees.isadmonition(n)),
+    :Footnote    => :(DocTrees.isfootnote(n)),
+    :DivTag      => :(n.tag === :div),
+)
+for (nth, (tag, func)) in enumerate(TAGS)
+    @eval begin
+        immutable $tag <: Tag end
+        order(::Type{$tag}) = $nth
+        matcher(::Type{$tag}, io::IO, m::MIME, n::Node) = $func
+    end
+end
+
+# For debugging.
+function runner(::Type{Tag}, io::IO, m::MIME, n::Node)
+    error("rendering failed for '$m' '$n'.")
+end
+
+
+#
+# Common `render` definitions.
+#
+
+render(io::IO, m::MIME, n::DocTrees.Node) = Selectors.dispatch(Tag, io, m, n)
+
+function render(io::IO, m::MIME, v::Vector)
+    for each in v
+        render(io, m, each)
+    end
+end
+
+
+#
+# Formats.
+#
+
+include("Markdown.jl")
+include("LaTeX.jl")
+
+
+#
+# Buffer Utilties.
+#
+
+function escape(buffer::IO, ::MIME"text/html", text::AbstractString)
+    if ismatch(r"[<>&'\"]", text)
+        for char in text
+            char === '<' ? write(buffer, "&lt;") :
+            char === '>' ? write(buffer, "&gt;") :
+            char === '&' ? write(buffer, "&amp;") :
+            char === ''' ? write(buffer, "&#39;") :
+            char === '"' ? write(buffer, "&quot;") : write(buffer, char)
+        end
+    else
+        write(buffer, text)
+    end
+end
+
+function indented(io::IO, buffer::IOBuffer, indent::AbstractString, first = indent)
+    local pos = position(buffer)
+    local firstline = true
+    while !eof(buffer)
+        local range = selection(buffer, '\n', true)
+        if length(range) > 1
+            print(io, firstline ? first : indent)
+            firstline = false
+            writeto(io, buffer, range)
+        else
+            println(io)
+        end
+    end
+    seek(buffer, pos)
+    return nothing
+end
+
+function selection(buffer::IOBuffer, until::Char, eat::Bool = false, offset::Integer = 0)
+    local startof = position(buffer)
+    local finish = startof
+    while !eof(buffer)
+        finish += 1
+        read(buffer, Char) === until && break
+    end
+    eat || seek(buffer, startof)
+    return (startof + 1):(finish + offset)
+end
+
+function writeto(io::IO, buffer::IOBuffer, range::Range)
+    for index in range
+        write(io, buffer.data[index])
+    end
+end
+
+end
+


### PR DESCRIPTION
Ref #168.

Definitely not in a mergable/usable state at the moment and we'll need to
wait until the dust has settled after the HTML work is merged and tagged
before actually considering this refactoring.

What it does:

  * A single "doctree" node type, `Node`. Mostly immutable apart from links
    to parents and children nodes. HTML tag attributes and additional metadata
    are stored in `ImmutableDict`s, much better for our use case than `Dict`.

  * Since `Node` is immutable to set the correct autolink for `at-ref` links
    a `Documenter.Renderers.attributes` function is provided that can be overloaded
    to map the correct URLs during the rendering stage based on data collected
    during earlier stages.

  * The current `Documents.Document` type will be stored instead as `.metadata` in
    the root `Node` of the doctree. Every `Node` will have access to it by traversing
    their `.parent` nodes. This doesn't appear to be much of a bottleneck, so adding
    a direct `.root` `Node` doesn't seem worth it.

  * This uses the `Selectors` module to avoid dynamic dispatch when rendering doctrees
    rather than the current approach where we're looping over `Vector{Any}`s. Everything
    important appears to be type-stable as far as I can tell so far.

  * Using a single unified doctree structure *should* make it possible to add new outputs
    by simply adding a new `Renderers/<format>` module that matches the layout of the
    others. Adding a new input format should just need a new function like `mdconvert`
    that builds a tree of `Node`s from files. (Not that there are any other parsers yet...)

  * Throughout the rest of the internal stages, i.e. not the input or output stages, we
    should just be able to work with `Node` (and `Tag`) objects. Extra formatting can just
    be stripped by `Renderers` that can't handle them. This should mean we can remove all
    the markdown-specific bits that are used internally and replace them with just the
    parts in `HTMLWriter` that are currently being worked on.

  * "navtrees" and next/prev pages should be pretty easy to construct directly from the
    doctree without needing too much work, though I've not yet looked too carefully into
    that.

@mortenpi, if you have any questions/suggestions/concerns then you're very welcome to raise them here.