### PR TITLE
Get remote from current file

### DIFF
--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -363,6 +363,7 @@ url(remote, repo, doc) = url(remote, repo, doc.data[:module], doc.data[:path], l
 # Correct file and line info only available from this version onwards.
 if VERSION >= v"0.5.0-dev+3442"
     function url(remote, repo, mod, file, linerange)
+        remote = getremote(dirname(file))
         isempty(remote) && isempty(repo) && return Nullable{Compat.String}()
         # Format the line range.
         line = format_line(linerange)


### PR DESCRIPTION
Allows several packages to share the same documentation with links pointing to the correct remotes for each docstring.