### PR TITLE
Update Documentation referencing `Markdown.Image`

### DIFF
--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -423,8 +423,8 @@ evaluating each block the present working directory, `pwd`, is set to the direct
 `build` where the file will be written to.
 
 Also, instead of returning `nothing` in the example above we could have returned a new
-`Markdown.Image` object directly. This can be more appropriate when the filename is not
-known until evaluation of the block itself.
+`Markdown.MD` object through `Markdown.parse`. This can be more appropriate when the 
+filename is not known until evaluation of the block itself.
 
 !!! note
 

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -111,7 +111,7 @@ x = linspace(-π, π)
 y = sin(x)
 plot(x, y, color = "red")
 savefig("plot.svg")
-Markdown.Image("Plot", "plot.svg")
+Markdown.parse("![Plot](plot.svg)")
 ```
 ````
 """


### PR DESCRIPTION
Prefer to use `Markdown.Parse` instead of `Markdown.Image` in the documentation because `Markdown.Image` alone will not render images directly. See #191 