### PR TITLE
Allow `make` to be bypassed

### DIFF
--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -305,9 +305,12 @@ function deploydocs(;
         # Change to the root directory and try to deploy the docs.
         cd(root) do
             Utilities.log("setting up target directory.")
-            Utilities.cleandir(target)
-            Utilities.log("building documentation.")
-            make()
+            isdir(target) || mkpath(target)
+            # Run extra build steps defined in `make` if required.
+            if make !== nothing
+                Utilities.log("running extra build steps.")
+                make()
+            end
             Utilities.log("pushing new documentation to remote: $repo:$branch.")
             mktempdir() do temp
                 # Versioned docs directories.


### PR DESCRIPTION
Adds check for `make === nothing` to allow for extra build sets, i.e. `mkdocs`, to be skipped since HTML rendering doesn't require extra build steps.

Also removes `cleandir` call since `target` should either not exist or be the the directory where `makedocs` has output files to.