### PR TITLE
Normalise line endings for doctests

### DIFF
--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -116,7 +116,7 @@ end
 
 function doctest(block::Markdown.Code, meta::Dict, doc::Documents.Document, page)
     if block.language == "jldoctest"
-        code, sandbox = block.code, Module(:Main)
+        code, sandbox = replace(block.code, "\r\n", "\n"), Module(:Main)
         haskey(meta, :DocTestSetup) && eval(sandbox, meta[:DocTestSetup])
         if ismatch(r"^julia> "m, code)
             eval_repl(code, sandbox, meta, doc, page)

--- a/test/examples/src/lib/crlf.md
+++ b/test/examples/src/lib/crlf.md
@@ -1,0 +1,13 @@
+!!! warning
+
+    This file contains windows line endings. Do not edit.
+
+```jldoctest
+a = 1
+b = 2
+a + b
+
+# output
+
+3
+```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -392,7 +392,7 @@ end
 
 @test doc.internal.assets == normpath(joinpath(dirname(@__FILE__), "..", "assets"))
 
-@test length(doc.internal.pages) == 4
+@test length(doc.internal.pages) == 5
 
 let headers = doc.internal.headers
     @test Documenter.Anchors.exists(headers, "Documentation")


### PR DESCRIPTION
(cherry picked from commit 744a94bfffdba75549d7b6b73d1af6124794d100)