### PR TITLE
Fix mdconvert's link parsing

### DIFF
--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -574,10 +574,10 @@ function mdconvert(link::Markdown.Link, parent)
     if ismatch(ABSURL_REGEX, link.url)
         Tag(:a)[:href => link.url](mdconvert(link.text, link))
     else
-        s = split(link.url, "#", limit=1)
+        s = split(link.url, "#", limit = 2)
         path = first(s)
         path = endswith(path, ".md") ? Formats.extension(Formats.HTML, path) : path
-        url = (length(s) > 1) ? "$path#$(second(s))" : Compat.String(path)
+        url = (length(s) > 1) ? "$path#$(last(s))" : Compat.String(path)
         Tag(:a)[:href => url](mdconvert(link.text, link))
     end
 end


### PR DESCRIPTION
The link parsing wasn't working properly -- splitting was limited to zero splits, so it never actually split at a #, and it also hid the call to a non-existent `second` function.

This will also work around the broken links of #208, since the `mdconvert` gets called on the resolved docstring links, fixing the wrong extensions.