### PR TITLE
Enable AppVeyor on release-* branches

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
 branches:
   only:
     - master
+    - /^release-.*/
 
 notifications:
   - provider: Email


### PR DESCRIPTION
I added a `^` as well, so that it wouldn't match things like `mp/release-appveyor`.

If it works it should be forward-ported to `master` as well.