### PR TITLE
Add basic support for svg output

### DIFF
--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -128,6 +128,10 @@ immutable EvalNode
     result :: Any
 end
 
+immutable RawHTML
+    code::String
+end
+
 # Navigation
 # ----------------------
 

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -449,10 +449,15 @@ function Selectors.runner(::Type{ExampleBlocks}, x, page, doc)
     # Splice the input and output into the document.
     content = []
     input   = droplines(x.code)
-    output  = Documenter.DocChecks.result_to_string(buffer, result)
+
+    # Special-case support for displaying SVG graphics. TODO: make this more general.
+    output = mimewritable(MIME"image/svg+xml"(), result) ?
+        Documents.RawHTML(stringmime(MIME"image/svg+xml"(), result)) :
+        Markdown.Code(Documenter.DocChecks.result_to_string(buffer, result))
+
     # Only add content when there's actually something to add.
     isempty(input)  || push!(content, Markdown.Code("julia", input))
-    isempty(output) || push!(content, Markdown.Code(output))
+    isempty(output.code) || push!(content, output)
     # ... and finally map the original code block to the newly generated ones.
     page.mapping[x] = Markdown.MD(content)
 end

--- a/src/Utilities/DOM.jl
+++ b/src/Utilities/DOM.jl
@@ -245,7 +245,9 @@ attributes!(out, s::Symbol) = push!(out, tostr(s => ""))
 attributes!(out, p::Pair)   = push!(out, tostr(p))
 
 function Base.show(io::IO, n::Node)
-    if n.name === TEXT
+    if n.name === Symbol("#RAW#")
+        print(io, n.nodes[1].text)
+    elseif n.name === TEXT
         print(io, escapehtml(n.text))
     else
         print(io, '<', n.name)

--- a/src/Walkers.jl
+++ b/src/Walkers.jl
@@ -49,6 +49,8 @@ walk(f, meta, block::Expanders.DocsNode)  = walk(f, meta, block.docstr)
 
 walk(f, meta, block::Expanders.EvalNode) = walk(f, meta, block.result)
 
+walk(f, meta, block::Documents.RawHTML) = nothing
+
 walk(f, meta, block::Expanders.MetaNode) = (merge!(meta, block.dict); nothing)
 
 typealias MDTextElements Union{

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -684,4 +684,6 @@ else
     isordered(a::Markdown.List) = a.ordered::Bool
 end
 
+mdconvert(html::Documents.RawHTML, parent) = Tag(Symbol("#RAW#"))(html.code)
+
 end


### PR DESCRIPTION
Allow `image/svg+xml` output for `at-example` blocks when the object to be displayed is capable of output the format. Should help with #229, but is not yet a completely general solution.

---

@tlnagy could you check whether this will work at all for your needs, thanks. Should just need to do

    ```@example
    using Gadfly
    plot(x = 1:10, y = 1:10)
    ```

and it *should* display an embedded `svg` image. I'm not to sure how to get the interactive svg+js plots to work since I'm not familiar with Gadfly though.