### PR TITLE
Fix index ordering when extension changes

### DIFF
--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -286,7 +286,6 @@ function populate!(index::IndexNode, document::Document)
         # Include *all* signatures, whether they are `Union{}` or not.
         cat  = Symbol(lowercase(Utilities.doccat(object.binding, Union{})))
         if _isvalid(page, index.pages) && _isvalid(mod, index.modules) && _isvalid(cat, index.order)
-            page = Formats.extension(document.user.format, page)
             push!(index.elements, (object, doc, page, mod, cat))
         end
     end
@@ -311,7 +310,6 @@ function populate!(contents::ContentsNode, document::Document)
             for anchor in anchors
                 page = relpath(anchor.file, dirname(contents.build))
                 if _isvalid(page, contents.pages) && Utilities.header_level(anchor.object) ≤ contents.depth
-                    page = Formats.extension(document.user.format, page)
                     push!(contents.elements, (anchor.order, page, anchor))
                 end
             end

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -457,6 +457,7 @@ function domify(ctx, navnode, contents::Documents.ContentsNode)
     @tags a
     lb = ListBuilder()
     for (count, path, anchor) in contents.elements
+        path = Formats.extension(ctx.doc.user.format, path)
         header = anchor.object
         url = string(path, '#', anchor.id, '-', anchor.nth)
         node = a[:href=>url](mdconvert(header.text))
@@ -470,6 +471,7 @@ function domify(ctx, navnode, index::Documents.IndexNode)
     @tags a code li ul
     lis = map(index.elements) do _
         object, doc, page, mod, cat = _
+        page = Formats.extension(ctx.doc.user.format, page)
         url = string(page, "#", Utilities.slugify(object))
         li(a[:href=>url](code("$(object.binding)")))
     end

--- a/src/Writers/MarkdownWriter.jl
+++ b/src/Writers/MarkdownWriter.jl
@@ -103,7 +103,8 @@ end
 ## Index, Contents, and Eval Nodes.
 
 function render(io::IO, ::MIME"text/plain", index::Documents.IndexNode, page, doc)
-    for (object, doc, page, mod, cat) in index.elements
+    for (object, _, page, mod, cat) in index.elements
+        page = Formats.extension(doc.user.format, page)
         url = string(page, "#", Utilities.slugify(object))
         println(io, "- [`", object.binding, "`](", url, ")")
     end
@@ -112,6 +113,7 @@ end
 
 function render(io::IO, ::MIME"text/plain", contents::Documents.ContentsNode, page, doc)
     for (count, path, anchor) in contents.elements
+        path = Formats.extension(doc.user.format, path)
         header = anchor.object
         url    = string(path, '#', anchor.id, '-', anchor.nth)
         link   = Markdown.Link(header.text, url)


### PR DESCRIPTION
Currently the extensions are not changed for the pagesmap variables,
but are for the paths in `IndexNode`s and `ContentsNode`s. This
confuses the sort when the extension is not `.md` anymore. With this
patch we shift the changing of extensions to the writing step, making
the IndexNode and ContentsNode sort format-independent.

Fixes #226.

---

@carlobaldassi, would it be possible for you to build your docs with this branch and confirm that #226 is fixed?
