### PR TITLE
Add first-level headings to navmenu

### DIFF
--- a/assets/html/style.css
+++ b/assets/html/style.css
@@ -205,6 +205,11 @@ nav.toc ul.internal {
     list-style: none;
 }
 
+nav.toc ul.internal li.toplevel {
+    border-top: 1px solid #c9c9c9;
+    font-weight: bold;
+}
+
 nav.toc .toctext {
     padding-top: 0.3em;
     padding-bottom: 0.3em;

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -2,6 +2,17 @@
 Provides the [`render`](@ref) methods to write the documentation as HTML files
 (`MIME"text/html"`).
 
+# Page outline
+
+The [`HTMLWriter`](@ref) makes use of the page outline that is determined by the
+headings. It is assumed that if the very first block of a page is a level 1 heading,
+then it is intended as the page title. This has two consequences:
+
+1. It is then used to automatically determine the page title in the navigation menu
+   and in the `<title>` tag, unless specified in the `.pages` option.
+2. If the first heading is interpreted as being the page title, it is not displayed
+   in the navigation sidebar.
+
 # Default and custom assets
 
 Documenter copies all files under the source directory (e.g. `/docs/src/`) over

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -557,12 +557,17 @@ end
 Tries to guess the page title by looking at the `<h1>` headers and returns the
 header contents as a `Nullable` (nulled if the algorithm was unable to determine
 the header).
+
+It is assumed that the intended page title can only be guessed if the very first
+block of the page is `<h1>` heading. If there is something before the first heading
+or the first heading is a lower level heading, then the return value is nulled.
 """
 function pagetitle(page::Documents.Page)
-    for e in page.elements
-        isa(e, Base.Markdown.Header{1}) && return Nullable{Any}(e.text)
+    if length(page.elements) >= 1 && isa(page.elements[1], Base.Markdown.Header{1})
+        Nullable{Any}(page.elements[1].text)
+    else
+        Nullable{Any}()
     end
-    return Nullable{Any}()
 end
 
 function pagetitle(ctx, navnode::Documents.NavNode)


### PR DESCRIPTION
Add first-level headings to the navigation menu. The only exception is
when the very first block of a page is a first-level heading -- in this
case that particular heading is ignored. This is consistent with how
the headings are usually used, with the first heading being the page
title.

The `<li>` tags of the first-level headers have the class `.toplevel`
attached to them, so that we can style them in the CSS.

Fixes #225.

---

@cormullion and @MichaelHatherly: What I am wondering is whether the behavior that a `<h1>` is a page title if and only if it is the very first block of a page is reasonable. Also, should we go with this, I guess we should also change the [`pagetitle` function](https://github.com/JuliaDocs/Documenter.jl/blob/master/src/Writers/HTMLWriter.jl#L560-L565), so that only the very first block would be used to automagically determine a page title for the nav.menu?

We could also maybe use a small doc. note on this.