### PR TITLE
Evaluate blocks as :toplevel

### DIFF
--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -117,7 +117,11 @@ end
 function doctest(block::Markdown.Code, meta::Dict, doc::Documents.Document, page)
     if block.language == "jldoctest"
         code, sandbox = replace(block.code, "\r\n", "\n"), Module(:Main)
-        haskey(meta, :DocTestSetup) && eval(sandbox, meta[:DocTestSetup])
+        if haskey(meta, :DocTestSetup)
+            expr = meta[:DocTestSetup]
+            Meta.isexpr(expr, :block) && (expr.head = :toplevel)
+            eval(sandbox, expr)
+        end
         if ismatch(r"^julia> "m, code)
             eval_repl(code, sandbox, meta, doc, page)
             block.language = "jlcon"

--- a/test/examples/src/index.md
+++ b/test/examples/src/index.md
@@ -32,6 +32,15 @@ zeros(5, 5)
 zeros(50, 50)
 ```
 
+```@meta
+DocTestSetup = quote
+    using Base
+    x = -3:0.01:3
+    y = -4:0.02:5
+    z = [Float64((xi^2 + yi^2)) for xi in x, yi in y]
+end
+```
+
 ```jldoctest
 julia> [1.0, 2.0, 3.0]
 3-element Array{Float64,1}:


### PR DESCRIPTION
Fixes issue on Julia 0.4 where some blocks containing `using` expressions would throw errors when evaluated.