### PR TITLE
Fix incorrect code literal rendering in lists

### DIFF
--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -615,7 +615,8 @@ end
 # mdconvert
 # ------------------------------------------------------------------------------
 
-md_block_nodes = [Markdown.MD, Markdown.BlockQuote, Markdown.List]
+const md_block_nodes = [Markdown.MD, Markdown.BlockQuote]
+isa(fieldtype(Markdown.List, :ordered), Integer) && push!(md_block_nodes, Markdown.List)
 if isdefined(Base.Markdown, :Admonition) push!(md_block_nodes, Markdown.Admonition) end
 
 """

--- a/test/examples/src/index.md
+++ b/test/examples/src/index.md
@@ -73,3 +73,7 @@ julia> info("...")
 INFO: ...
 
 ```
+
+  * `one` two three
+  * four `five` six
+


### PR DESCRIPTION
Only affects Julia 0.4, fixes #275.