### PR TITLE
Add linkchecking doccheck

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.4
 Compat 0.8
 DocStringExtensions 0.2
+Requests 0.3.10

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,6 +5,7 @@ makedocs(
     clean   = false,
     format   = Documenter.Formats.HTML,
     sitename = "Documenter.jl",
+    linkcheck= !("skiplinks" in ARGS),
     pages    = Any[ # Compat: `Any` for 0.4 compat
         "Home" => "index.md",
         "Manual" => Any[

--- a/src/Builder.jl
+++ b/src/Builder.jl
@@ -182,6 +182,7 @@ function Selectors.runner(::Type{CheckDocument}, doc::Documents.Document)
     Documenter.DocChecks.missingdocs(doc)
     Documenter.DocChecks.doctest(doc)
     Documenter.DocChecks.footnotes(doc)
+    Documenter.DocChecks.linkcheck(doc)
 end
 
 function Selectors.runner(::Type{Populate}, doc::Documents.Document)

--- a/src/CrossReferences.jl
+++ b/src/CrossReferences.jl
@@ -83,6 +83,8 @@ end
 
 function namedxref(link::Markdown.Link, slug, meta, page, doc)
     headers = doc.internal.headers
+    # Add the link to list of local uncheck links.
+    push!(doc.internal.locallinks, link)
     # Error checking: `slug` should exist and be unique.
     # TODO: handle non-unique slugs.
     if Anchors.exists(headers, slug)
@@ -104,6 +106,8 @@ end
 # -----------------------------
 
 function docsxref(link::Markdown.Link, code, meta, page, doc)
+    # Add the link to list of local uncheck links.
+    push!(doc.internal.locallinks, link)
     # Parse the link text and find current module.
     local keyword = Symbol(strip(code))
     local ex

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -179,6 +179,7 @@ immutable User
     format  :: Formats.Format # What format to render the final document with?
     clean   :: Bool           # Empty the `build` directory before starting a new build?
     doctest :: Bool           # Run doctests?
+    linkcheck::Bool           # Check external links.
     modules :: Set{Module}    # Which modules to check for missing docs?
     pages   :: Vector{Any}    # Ordering of document pages specified by the user.
     repo    :: Compat.String  # Template for URL to source code repo
@@ -200,6 +201,7 @@ immutable Internal
     objects :: ObjectIdDict              # Tracks which `Utilities.Objects` are included in the `Document`.
     contentsnodes :: Vector{ContentsNode}
     indexnodes    :: Vector{IndexNode}
+    locallinks :: Set{Base.Markdown.Link}
 end
 
 # Document.
@@ -220,6 +222,7 @@ function Document(;
         format   :: Formats.Format   = Formats.Markdown,
         clean    :: Bool             = true,
         doctest  :: Bool             = true,
+        linkcheck:: Bool             = false,
         modules  :: Utilities.ModVec = Module[],
         pages    :: Vector           = Any[],
         repo     :: AbstractString   = "",
@@ -235,6 +238,7 @@ function Document(;
         format,
         clean,
         doctest,
+        linkcheck,
         Utilities.submodules(modules),
         pages,
         repo,
@@ -251,7 +255,8 @@ function Document(;
         ObjectIdDict(),
         ObjectIdDict(),
         [],
-        []
+        [],
+        Set{Base.Markdown.Link}(),
     )
     Document(user, internal)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,6 @@
+# Build the real docs first.
+include(joinpath(dirname(@__FILE__), "..", "docs", "make.jl"))
+
 # docs module
 # ===========
 
@@ -496,5 +499,3 @@ end
 
 # more tests from files
 include("mdflatten.jl")
-
-include(joinpath(dirname(@__FILE__), "..", "docs", "make.jl"))


### PR DESCRIPTION
Checks whether external URLs found in documentation exist.

Fixes #285.

---

Interestingly, this check picked up an incorrect link in the examples page for `DifferentialEquations.jl`. 