### PR TITLE
Allow missing docs check to be customised

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.jl.mem
 
 test/examples/build-*
+test/missingdocs/build/
 test/errors/build/
 docs/build/
 docs/site/

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -180,6 +180,7 @@ immutable User
     clean   :: Bool           # Empty the `build` directory before starting a new build?
     doctest :: Bool           # Run doctests?
     linkcheck::Bool           # Check external links.
+    checkdocs::Symbol         # Check objects missing from `@docs` blocks. `:none`, `:exports`, or `:all`.
     modules :: Set{Module}    # Which modules to check for missing docs?
     pages   :: Vector{Any}    # Ordering of document pages specified by the user.
     repo    :: Compat.String  # Template for URL to source code repo
@@ -223,6 +224,7 @@ function Document(;
         clean    :: Bool             = true,
         doctest  :: Bool             = true,
         linkcheck:: Bool             = false,
+        checkdocs::Symbol            = :all,
         modules  :: Utilities.ModVec = Module[],
         pages    :: Vector           = Any[],
         repo     :: AbstractString   = "",
@@ -239,6 +241,7 @@ function Document(;
         clean,
         doctest,
         linkcheck,
+        checkdocs,
         Utilities.submodules(modules),
         pages,
         repo,

--- a/test/missingdocs/src/exports/index.md
+++ b/test/missingdocs/src/exports/index.md
@@ -1,0 +1,5 @@
+# MissingDocs Exports
+
+```@docs
+Main.MissingDocs.f
+```

--- a/test/missingdocs/src/none/index.md
+++ b/test/missingdocs/src/none/index.md
@@ -1,0 +1,4 @@
+# MissingDocs None
+
+```@docs
+```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,6 +86,17 @@ end
 
 end
 
+module MissingDocs
+
+export f
+"exported"
+f(x) = x
+
+"unexported"
+g(x) = x
+
+end
+
 # tests module
 # ============
 
@@ -354,6 +365,20 @@ info("END of expected error output.")
 println("="^50)
 
 # Mock package docs:
+
+## Missing Docs.
+
+for sym in [:none, :exports]
+    makedocs(
+        root = joinpath(dirname(@__FILE__), "missingdocs"),
+        source = joinpath("src", string(sym)),
+        build = joinpath("build", string(sym)),
+        modules = Main.MissingDocs,
+        checkdocs = sym,
+        format = Documenter.Formats.HTML,
+        sitename = "MissingDocs Checks",
+    )
+end
 
 # setup
 # =====


### PR DESCRIPTION
Adds a ~~`missingdocs = `~~ `checkdocs = ` keyword to `makedocs` with values

  * `:none` - no checks done for any missing docs;
  * `:exports` - only check exported symbols for missing docs;
  * `:all` - the default, checks exported and unexported symbols.