### PR TITLE
Revert mutation of docstring ref URLs

### DIFF
--- a/src/CrossReferences.jl
+++ b/src/CrossReferences.jl
@@ -84,7 +84,7 @@ end
 function namedxref(link::Markdown.Link, slug, meta, page, doc)
     headers = doc.internal.headers
     # Add the link to list of local uncheck links.
-    push!(doc.internal.locallinks, link)
+    doc.internal.locallinks[link] = link.url
     # Error checking: `slug` should exist and be unique.
     # TODO: handle non-unique slugs.
     if Anchors.exists(headers, slug)
@@ -107,7 +107,7 @@ end
 
 function docsxref(link::Markdown.Link, code, meta, page, doc)
     # Add the link to list of local uncheck links.
-    push!(doc.internal.locallinks, link)
+    doc.internal.locallinks[link] = link.url
     # Parse the link text and find current module.
     local keyword = Symbol(strip(code))
     local ex

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -435,7 +435,7 @@ function linkcheck(doc::Documents.Document)
 end
 
 function linkcheck(link::Base.Markdown.Link, doc::Documents.Document)
-    if !(link in doc.internal.locallinks)
+    if !haskey(doc.internal.locallinks, link)
         local status, success
         try
             local response = Requests.head(link.url)

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -202,7 +202,7 @@ immutable Internal
     objects :: ObjectIdDict              # Tracks which `Utilities.Objects` are included in the `Document`.
     contentsnodes :: Vector{ContentsNode}
     indexnodes    :: Vector{IndexNode}
-    locallinks :: Set{Base.Markdown.Link}
+    locallinks :: Dict{Base.Markdown.Link, Compat.String}
 end
 
 # Document.
@@ -259,7 +259,7 @@ function Document(;
         ObjectIdDict(),
         [],
         [],
-        Set{Base.Markdown.Link}(),
+        Dict{Base.Markdown.Link, Compat.String}(),
     )
     Document(user, internal)
 end

--- a/src/Writers/Writers.jl
+++ b/src/Writers/Writers.jl
@@ -37,7 +37,13 @@ The method should be overloaded in each writer as
 
 where `format` is one of the values of the [`Formats.Format`](@ref) enumeration.
 """
-render(doc::Documents.Document) = render(Writer(doc.user.format), doc)
+function render(doc::Documents.Document)
+    render(Writer(doc.user.format), doc)
+    # Revert all local links to their original URLs.
+    for (link, url) in doc.internal.locallinks
+        link.url = url
+    end
+end
 
 include("MarkdownWriter.jl")
 include("HTMLWriter.jl")


### PR DESCRIPTION
Fixes #208. After rendering change the URLs of `at-ref` links back to their original value to allow for multiple renderings per Julia session.