### PR TITLE
Add `at-raw` block

### DIFF
--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -132,6 +132,11 @@ immutable RawHTML
     code::String
 end
 
+immutable RawNode
+    name::Symbol
+    text::Compat.String
+end
+
 # Navigation
 # ----------------------
 

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -546,6 +546,10 @@ end
 # nothing to show for MetaNodes, so we just return an empty list
 domify(ctx, navnode, node::Documents.MetaNode) = DOM.Node[]
 
+function domify(ctx, navnode, raw::Documents.RawNode)
+    raw.name === :html ? Tag(Symbol("#RAW#"))(raw.text) : DOM.Node[]
+end
+
 
 # Utilities
 # ------------------------------------------------------------------------------

--- a/src/Writers/MarkdownWriter.jl
+++ b/src/Writers/MarkdownWriter.jl
@@ -144,6 +144,10 @@ render(io::IO, ::MIME"text/plain", str::AbstractString, page, doc) = print(io, s
 # rest of the build and so we just leave them in place and print a blank line in their place.
 render(io::IO, ::MIME"text/plain", node::Documents.MetaNode, page, doc) = println(io, "\n")
 
+function render(io::IO, ::MIME"text/plain", raw::Documents.RawNode, page, doc)
+    raw.name === :html ? println(io, "\n", raw.text, "\n") : nothing
+end
+
 
 ## Markdown Utilities.
 

--- a/test/examples/src/index.md
+++ b/test/examples/src/index.md
@@ -80,3 +80,19 @@ INFO: ...
   * ```
     one
     ```
+
+## Raw Blocks
+
+```@raw html
+<center>
+    <strong>CENTER</strong>
+</center>
+```
+
+```@raw latex
+\begin{CJK*}{UTF8}{mj}
+```
+
+```@raw latex
+\end{CJK*}
+```


### PR DESCRIPTION
Useful for adding raw text that should appear only in a specific output format, such as raw HTML in markdown/HTML output or LaTeX commands in a LaTeX document. Fixes #272.