### PR TITLE
deploydocs: check that `julia` is a string, repo matches repo_slug

### DIFF
--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -264,6 +264,14 @@ function deploydocs(;
     ssh_key_file = abspath(joinpath(root, ".documenter.enc"))
     has_ssh_key  = isfile(ssh_key_file)
 
+    # Sanity checks
+    if !isa(julia, AbstractString)
+        error("julia must be a string, got $julia ($(typeof(julia)))")
+    end
+    if !isempty(travis_repo_slug) && !contains(repo, travis_repo_slug)
+        error("repo $repo does not match $travis_repo_slug")
+    end
+
     # When should a deploy be attempted?
     should_deploy =
         contains(repo, travis_repo_slug) &&

--- a/test/errors/deploydocs.jl
+++ b/test/errors/deploydocs.jl
@@ -1,0 +1,18 @@
+@test_throws ErrorException deploydocs(
+    repo = "github.com/JuliaDocs/Documenter.jl.git",
+    julia = 0.5,        # must be a string
+    target = "build",
+    deps = nothing,
+    make = nothing,
+)
+
+trsl = get(ENV, "TRAVIS_REPO_SLUG", "")
+try
+    ENV["TRAVIS_REPO_SLUG"] = "foo"
+    @test_throws ErrorException deploydocs(repo = "bar",
+                                           deps = nothing,
+                                           make = nothing,
+                                           )
+finally
+    ENV["TRAVIS_REPO_SLUG"] = trsl
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,6 +45,9 @@ end
     # Documenter package docs with other formats.
     include("formats/markdown.jl")
     include("formats/latex.jl")
+
+    # Deployment
+    include("errors/deploydocs.jl")
 end
 
 # Additional tests


### PR DESCRIPTION
I spent some time debugging a puzzling failure-to-deploy, before finally noticing that in my `make.jl` I had specified `julia = 0.5` rather than `julia = "0.5"`.
