### PR TITLE
Backport Requests removal

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.4
 Compat 0.8
 DocStringExtensions 0.2
-Requests 0.3.10

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -426,15 +426,20 @@ end
 hascurl() = (try; success(`curl --version`); catch err; false; end)
 
 function linkcheck(doc::Documents.Document)
-    if doc.user.linkcheck && hascurl()
-        println(" > checking external URLs:")
-        for (src, page) in doc.internal.pages
-            println("   - ", src)
-            for element in page.elements
-                Walkers.walk(page.globals.meta, page.mapping[element]) do block
-                    linkcheck(block, doc)
+    if doc.user.linkcheck
+        if hascurl()
+            println(" > checking external URLs:")
+            for (src, page) in doc.internal.pages
+                println("   - ", src)
+                for element in page.elements
+                    Walkers.walk(page.globals.meta, page.mapping[element]) do block
+                        linkcheck(block, doc)
+                    end
                 end
             end
+        else
+            push!(doc.internal.errors, :linkcheck)
+            Utilities.warn("linkcheck requires `curl`.")
         end
     end
     return nothing


### PR DESCRIPTION
Since `linkcheck` isn't documented it's fine to change behaviour and backport it. (Much too soon to have to release a `0.6`!)