### PR TITLE
Fixed nav menu with scrolling overflow

### DIFF
--- a/assets/html/style.css
+++ b/assets/html/style.css
@@ -129,19 +129,12 @@ article section.docstring h6 {
 
 /* Navigation */
 nav.toc {
-    /* TODO: would be nice to have the navigation fixed, but the simple
-     * solution (below) has problems with scrolling focus if there's overflow.
-     *
-     *   position: fixed;
-     *   overflow-y: auto;
-     *   height: calc(100% - 2em);
-     *
-     */
-    position: absolute;
-    width: 20em;
-    min-height: calc(100% - 2em);
+    position: fixed;
     top: 0;
     left: 0;
+    bottom: 0;
+    width: 20em;
+    overflow-y: auto;
     padding: 1em 0;
     background-color: #fcfcfc;
     box-shadow: inset -14px 0px 5px -12px rgb(210,210,210);


### PR DESCRIPTION
This appears to work fine (no focus problems) on Firefox and Chrome on Linux &mdash; would probably be good to see whether it has any serious problems on other platforms.

Also replace the `box-shadow` with a simple solid line since the combination of scroll bar and shadow looked a bit weird to me.