### PR TITLE
Disable 'strict' mode

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,7 +7,6 @@ makedocs(
     sitename = "Documenter.jl",
     authors = "Michael Hatherly, Morten Piibeleht, and contributors.",
     linkcheck = !("skiplinks" in ARGS),
-    strict = true,
     pages = Any[ # Compat: `Any` for 0.4 compat
         "Home" => "index.md",
         "Manual" => Any[


### PR DESCRIPTION
`curl` on Linux nightly is failing for `https` addresses, probably due
to the current SSL bug on Julia `master`. Use non-strict mode for the
docs build to allow it to finish.