### PR TITLE
Include `custom.css` in HTML build if it exists

### DIFF
--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -190,6 +190,7 @@ immutable User
     strict::Bool              # Throw an exception when any warnings are encountered.
     modules :: Set{Module}    # Which modules to check for missing docs?
     pages   :: Vector{Any}    # Ordering of document pages specified by the user.
+    assets  :: Vector{Compat.String}
     repo    :: Compat.String  # Template for URL to source code repo
     sitename:: Compat.String
     authors :: Compat.String
@@ -237,6 +238,7 @@ function Document(;
         strict::Bool                 = false,
         modules  :: Utilities.ModVec = Module[],
         pages    :: Vector           = Any[],
+        assets   :: Vector           = Compat.String[],
         repo     :: AbstractString   = "",
         sitename :: AbstractString   = "",
         authors  :: AbstractString   = "",
@@ -259,6 +261,7 @@ function Document(;
         strict,
         Utilities.submodules(modules),
         pages,
+        assets,
         repo,
         sitename,
         authors,

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -97,6 +97,7 @@ examples_html_doc = makedocs(
     root  = examples_root,
     build = "builds/html",
     format   = :html,
+    assets = ["assets/custom.css"],
     sitename = "Documenter example",
     pages    = Any[
         "Home" => "index.md",

--- a/test/examples/src/assets/custom.css
+++ b/test/examples/src/assets/custom.css
@@ -1,1 +1,5 @@
 /* custom.css */
+
+center.raw-html-block {
+    color: red;
+}

--- a/test/examples/src/index.md
+++ b/test/examples/src/index.md
@@ -84,7 +84,7 @@ INFO: ...
 ## Raw Blocks
 
 ```@raw html
-<center>
+<center class="raw-html-block">
     <strong>CENTER</strong>
 </center>
 ```


### PR DESCRIPTION
Fixes #327.

@mortenpi perhaps we should also just have a single `custom.js` that gets included if it exists rather than the whole `Vector` of them, is that doable or is there something I'm missing?