### PR TITLE
Fix hrefs on Windows

### DIFF
--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -576,7 +576,9 @@ Calculates a relative HTML link from one path to another.
 """
 function relhref(from, to)
     pagedir = dirname(from)
-    relpath(to, isempty(pagedir) ? "." : pagedir)
+    # The regex separator replacement is necessary since otherwise building the docs on
+    # Windows will result in paths that have `//` separators which break asset inclusion.
+    replace(relpath(to, isempty(pagedir) ? "." : pagedir), r"[/\\]+", "/")
 end
 
 """


### PR DESCRIPTION
Discovered over on https://github.com/JuliaStats/DataFrames.jl/pull/1105. Windows path separators in link `href`s don't seem to work, so just replace them all with `/`. @mortenpi are there any other places this should be done?