### PR TITLE
Remove 'documentation' from page titles

### DIFF
--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -168,7 +168,7 @@ end
 function render_head(ctx, navnode, additional_scripts)
     @tags head meta link script title
     src = get(navnode.page)
-    page_title = "$(mdflatten(pagetitle(ctx, navnode))) · $(ctx.doc.user.sitename) documentation"
+    page_title = "$(mdflatten(pagetitle(ctx, navnode))) · $(ctx.doc.user.sitename)"
     css_links = [
         normalize_css,
         highlightjs_css,


### PR DESCRIPTION
Not all sites built using Documenter are going to be specific to "documentation". Removing the word allows us to cater to users who might just be writing a tutorial or organisation page and so might
not want to be labelled as documentation. Getting the old naming back is as simple as adding ` documentation` to the `sitename`.