### PR TITLE
Detect doctest exceptions for empty output

### DIFF
--- a/test/errors/src/index.md
+++ b/test/errors/src/index.md
@@ -56,4 +56,10 @@ ErrorsModule.func
 julia> b = 1
 2
 
+julia> x
+
+julia> x
+ERROR: UndefVarError: x not defined
+
+julia> x
 ```


### PR DESCRIPTION
Fixes #347 where exceptions were not caught when the expected result
was an empty string.

Also fix skipped doctest when the last `julia>` prompt appears right
at the end of a code block, i.e.

    ```jldoctest
    ...
    julia> x
    ```

instead of

    ```jldoctest
    ...
    julia> x

    ```

Additionally, remove unnecessary parts of the generated backtrace that reference internals of the Documenter package itself, similar to how the Julia REPL handles backtrace printing.

@fredrikekre, if you've got a moment to confirm that this sorts out the issue you reported that would be great, thanks.