### PR TITLE
Add version selector dropdown menu

### DIFF
--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -158,6 +158,15 @@ nav.toc input {
     font-size: smaller;
 }
 
+nav.toc select {
+    display: block;
+    height: 2em;
+    width: calc(100% - 3em);
+    margin: 5px auto;
+    font-size: smaller;
+    text-align: center;
+}
+
 nav.toc > ul * {
     margin: 0;
 }

--- a/assets/html/documenter.js
+++ b/assets/html/documenter.js
@@ -52,6 +52,13 @@ require(['mathjax'], function(MathJax) {
 
 require(['jquery', 'highlight', 'highlight-julia'], function($, hljs) {
     $(document).ready(function() {
+        if (typeof DOC_VERSIONS !== 'undefined') {
+            var version_selector = $("#version-selector");
+            DOC_VERSIONS.forEach(function(each) {
+                var option = $("<option value='" + documenterBaseURL + "/../" + each + "'>" + each + "</option>");
+                version_selector.append(option);
+            });
+        }
         hljs.initHighlighting();
     })
 

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -444,6 +444,10 @@ function deploydocs(;
                             end
                         end
 
+                        # Create the versions.js file containing a list of all docs
+                        # versions. This must always happen after the folder copying.
+                        Writers.HTMLWriter.generate_version_file(pwd())
+
                         # Add, commit, and push the docs to the remote.
                         run(`git add -A .`)
                         try run(`git commit -m "build based on $sha"`) end


### PR DESCRIPTION
During `deploydocs` we check what documentation folders are currently available and write a `versions.js` file to the root of the repo that contains a list, `DOC_VERSIONS`, which is used to populate the dropdown menu. Here's an example of how it'll look with the dropdown above the search bar: https://michaelhatherly.github.io/DocumenterTests.jl/latest/. @mortenpi if you've got any suggestions I'll leave this open for a little while.