### PR TITLE
Add Google Analytics support

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,6 +6,7 @@ makedocs(
     format = :html,
     sitename = "Documenter.jl",
     authors = "Michael Hatherly, Morten Piibeleht, and contributors.",
+    analytics = "UA-89508993-1",
     linkcheck = !("skiplinks" in ARGS),
     pages = Any[ # Compat: `Any` for 0.4 compat
         "Home" => "index.md",

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -194,6 +194,7 @@ immutable User
     repo    :: Compat.String  # Template for URL to source code repo
     sitename:: Compat.String
     authors :: Compat.String
+    analytics::Compat.String
 end
 
 """
@@ -242,6 +243,7 @@ function Document(;
         repo     :: AbstractString   = "",
         sitename :: AbstractString   = "",
         authors  :: AbstractString   = "",
+        analytics :: AbstractString = "",
         others...
     )
     Utilities.check_kwargs(others)
@@ -265,6 +267,7 @@ function Document(;
         repo,
         sitename,
         authors,
+        analytics,
     )
     internal = Internal(
         Utilities.assetsdir(),

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -181,6 +181,8 @@ function render_head(ctx, navnode, additional_scripts)
         meta[:name => "viewport", :content => "width=device-width, initial-scale=1.0"],
         title(page_title),
 
+        analytics_script(ctx.doc.user.analytics),
+
         # Stylesheets.
         map(css_links) do each
             link[:href => each, :rel => "stylesheet", :type => "text/css"]
@@ -215,6 +217,19 @@ function asset_links(src::AbstractString, assets::Vector)
     end
     return links
 end
+
+analytics_script(tracking_id::AbstractString) =
+    isempty(tracking_id) ? Tag(Symbol("#RAW#"))("") : Tag(:script)(
+        """
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+        ga('create', '$(tracking_id)', 'auto');
+        ga('send', 'pageview');
+        """
+    )
 
 ## Search page
 # ------------


### PR DESCRIPTION
Optional `analytics` keyword for `makedocs` that adds the GA tracking code to the generated HTML head of each page.

Fixes #372.

Additionally, setup GA for Documenter.jl itself to test this out on a real site.

cc: @ViralBShah, I'll see whether this works correctly for Documenter itself, then get it working for the manual.