### PR TITLE
Update examples.md

### DIFF
--- a/docs/src/man/examples.md
+++ b/docs/src/man/examples.md
@@ -29,7 +29,7 @@ Packages that have tagged versions available in `METADATA.jl`.
 - [EzXML.jl](https://bicycle1885.github.io/EzXML.jl/latest/)
 - [Highlights.jl](https://juliadocs.github.io/Highlights.jl/latest/)
 - [IntervalConstraintProgramming.jl](http://dpsanders.github.io/IntervalConstraintProgramming.jl/latest/)
-- [Luxor.jl](https://github.com/JuliaGraphics/Luxor.jl)
+- [Luxor.jl](https://github.com/JuliaGraphics/Luxor.jl/stable/)
 - [MergedMethods.jl](https://michaelhatherly.github.io/MergedMethods.jl/latest)
 - [Mimi.jl](http://anthofflab.berkeley.edu/Mimi.jl/stable/)
 - [NumericSuffixes.jl](https://michaelhatherly.github.io/NumericSuffixes.jl/latest)

--- a/docs/src/man/examples.md
+++ b/docs/src/man/examples.md
@@ -29,7 +29,7 @@ Packages that have tagged versions available in `METADATA.jl`.
 - [EzXML.jl](https://bicycle1885.github.io/EzXML.jl/latest/)
 - [Highlights.jl](https://juliadocs.github.io/Highlights.jl/latest/)
 - [IntervalConstraintProgramming.jl](http://dpsanders.github.io/IntervalConstraintProgramming.jl/latest/)
-- [Luxor.jl](https://cormullion.github.io/Luxor.jl)
+- [Luxor.jl](https://github.com/JuliaGraphics/Luxor.jl)
 - [MergedMethods.jl](https://michaelhatherly.github.io/MergedMethods.jl/latest)
 - [Mimi.jl](http://anthofflab.berkeley.edu/Mimi.jl/stable/)
 - [NumericSuffixes.jl](https://michaelhatherly.github.io/NumericSuffixes.jl/latest)

--- a/docs/src/man/examples.md
+++ b/docs/src/man/examples.md
@@ -29,7 +29,7 @@ Packages that have tagged versions available in `METADATA.jl`.
 - [EzXML.jl](https://bicycle1885.github.io/EzXML.jl/latest/)
 - [Highlights.jl](https://juliadocs.github.io/Highlights.jl/latest/)
 - [IntervalConstraintProgramming.jl](http://dpsanders.github.io/IntervalConstraintProgramming.jl/latest/)
-- [Luxor.jl](https://github.com/JuliaGraphics/Luxor.jl/stable/)
+- [Luxor.jl](https://juliagraphics.github.io/Luxor.jl/stable/)
 - [MergedMethods.jl](https://michaelhatherly.github.io/MergedMethods.jl/latest)
 - [Mimi.jl](http://anthofflab.berkeley.edu/Mimi.jl/stable/)
 - [NumericSuffixes.jl](https://michaelhatherly.github.io/NumericSuffixes.jl/latest)


### PR DESCRIPTION
Updated path to https://github.com/JuliaGraphics/Luxor.jl.

I notice in the examples that some other's links are to "stable", some to "latest". I'd prefer a link to the main start page to allow a choice...?