### PR TITLE
Sidebar updates

### DIFF
--- a/assets/html/arrow.svg
+++ b/assets/html/arrow.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16.5mm"
+   height="8.6603003mm"
+   viewBox="0 0 58.464567 30.686103"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="arrow.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.2"
+     inkscape:cx="14.209234"
+     inkscape:cy="29.780479"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1053"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1021.6761)">
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 0,1021.6761 35.433071,0 -17.716536,30.6861 z"
+       id="path4140"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>

--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -144,6 +144,42 @@ nav.toc .logo {
 
 nav.toc h1 {
     text-align: center;
+    margin-top: .57em;
+    margin-bottom: 0;
+}
+
+nav.toc select {
+    display: block;
+    height: 2em;
+    padding: 0 1.6em 0 1em;
+    min-width: 7em;
+    max-width: 90%;
+    max-width: calc(100% - 5em);
+    margin: 0 auto;
+    font-size: .83em;
+    border: 1px solid #c9c9c9;
+    border-radius: 1em;
+
+    /* TODO: doesn't seem to be centered on Safari */
+    text-align: center;
+    text-align-last: center;
+
+    appearance: none;
+    -moz-appearance: none;
+    -webkit-appearance: none;
+
+    background: white url("arrow.svg");
+    background-size: 1.155em;
+    background-repeat: no-repeat;
+    background-position: right;
+}
+
+nav.toc select:hover {
+    border: 1px solid #a0a0a0;
+}
+
+nav.toc select option {
+    text-align: center;
 }
 
 nav.toc input {
@@ -151,20 +187,11 @@ nav.toc input {
     height: 2em;
     width: 90%;
     width: calc(100% - 5em);
-    margin: 0 auto;
+    margin: 1.2em auto;
     padding: 0 1em;
     border: 1px solid #c9c9c9;
     border-radius: 1em;
-    font-size: smaller;
-}
-
-nav.toc select {
-    display: block;
-    height: 2em;
-    width: calc(100% - 3em);
-    margin: 5px auto;
-    font-size: smaller;
-    text-align: center;
+    font-size: .83em;
 }
 
 nav.toc > ul * {

--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -172,7 +172,7 @@ nav.toc > ul * {
 }
 
 nav.toc ul {
-    color: #b3b3b3;
+    color: #404040;
     padding: 0;
     list-style: none;
 }
@@ -183,6 +183,7 @@ nav.toc ul .toctext {
 }
 
 nav.toc ul a:hover {
+    color: #fcfcfc;
     background-color: #4e4a4a;
 }
 
@@ -196,7 +197,6 @@ nav.toc ul.internal a:hover {
 }
 
 nav.toc ul.internal {
-    color: gray;
     background-color: #e3e3e3;
     box-shadow: inset -14px 0px 5px -12px rgb(210,210,210);
     list-style: none;

--- a/assets/html/documenter.js
+++ b/assets/html/documenter.js
@@ -52,14 +52,45 @@ require(['mathjax'], function(MathJax) {
 
 require(['jquery', 'highlight', 'highlight-julia'], function($, hljs) {
     $(document).ready(function() {
+        hljs.initHighlighting();
+    })
+
+})
+
+// update the version selector with info from the siteinfo.js and ../versions.js files
+require(['jquery'], function($) {
+    $(document).ready(function() {
+        var version_selector = $("#version-selector");
+
+        // add the current version to the selector based on siteinfo.js, but only if the selector is empty
+        if (typeof DOCUMENTER_CURRENT_VERSION !== 'undefined' && $('#version-selector > option').length == 0) {
+            var option = $("<option value='#' selected='selected'>" + DOCUMENTER_CURRENT_VERSION + "</option>");
+            version_selector.append(option);
+        }
+
         if (typeof DOC_VERSIONS !== 'undefined') {
-            var version_selector = $("#version-selector");
+            var existing_versions = $('#version-selector > option');
+            var existing_versions_texts = existing_versions.map(function(i,x){return x.text});
             DOC_VERSIONS.forEach(function(each) {
-                var option = $("<option value='" + documenterBaseURL + "/../" + each + "'>" + each + "</option>");
-                version_selector.append(option);
+                var version_url = documenterBaseURL + "/../" + each;
+                var existing_id = $.inArray(each, existing_versions_texts);
+                // if not already in the version selector, add it as a new option,
+                // otherwise update the old option with the URL and enable it
+                if (existing_id == -1) {
+                    var option = $("<option value='" + version_url + "'>" + each + "</option>");
+                    version_selector.append(option);
+                } else {
+                    var option = existing_versions[existing_id];
+                    option.value = version_url;
+                    option.disabled = false;
+                }
             });
         }
-        hljs.initHighlighting();
+
+        // only show the version selector if the selector has been populated
+        if ($('#version-selector > option').length > 0) {
+            version_selector.css("visibility", "visible");
+        }
     })
 
 })

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -149,6 +149,11 @@ For example if you are using GitLab.com, you could use
 makedocs(repo = \"https://gitlab.com/user/project/blob/{commit}{path}#L{line}\")
 ```
 
+**`version`** specifies the version string of the current version which will be the
+selected option in the version selector. If this is left empty (default) the version
+selector will be hidden. The special value `git-commit` sets the value in the output to
+`git:{commit}`, where `{commit}` is the first few characters of the current commit hash.
+
 # See Also
 
 A guide detailing how to document a package using Documenter's [`makedocs`](@ref) is provided
@@ -434,15 +439,19 @@ function deploydocs(;
                         # Copy docs to `latest`, or `stable`, `<release>`, and `<version>` directories.
                         if isempty(travis_tag)
                             cp(target_dir, latest_dir; remove_destination = true)
+                            Writers.HTMLWriter.generate_siteinfo_file(latest_dir, "latest")
                         else
                             cp(target_dir, stable_dir; remove_destination = true)
+                            Writers.HTMLWriter.generate_siteinfo_file(stable_dir, "stable")
                             cp(target_dir, tagged_dir; remove_destination = true)
+                            Writers.HTMLWriter.generate_siteinfo_file(tagged_dir, travis_tag)
                             # Build a `release-*.*` folder as well when the travis tag is
                             # valid, which it *should* always be anyway.
                             if ismatch(Base.VERSION_REGEX, travis_tag)
                                 local version = VersionNumber(travis_tag)
                                 local release = "release-$(version.major).$(version.minor)"
                                 cp(target_dir, joinpath(dirname, release); remove_destination = true)
+                                Writers.HTMLWriter.generate_siteinfo_file(joinpath(dirname, release), release)
                             end
                         end
 

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -195,6 +195,7 @@ immutable User
     sitename:: Compat.String
     authors :: Compat.String
     analytics::Compat.String
+    version :: Compat.String # version string used in the version selector by default
 end
 
 """
@@ -244,12 +245,17 @@ function Document(;
         sitename :: AbstractString   = "",
         authors  :: AbstractString   = "",
         analytics :: AbstractString = "",
+        version :: AbstractString = "",
         others...
     )
     Utilities.check_kwargs(others)
 
     local fmt = Formats.fmt(format)
     @assert !isempty(fmt) "No formats provided."
+
+    if version == "git-commit"
+        version = "git:$(Utilities.get_commit_short(root))"
+    end
 
     user = User(
         root,
@@ -268,6 +274,7 @@ function Document(;
         sitename,
         authors,
         analytics,
+        version,
     )
     internal = Internal(
         Utilities.assetsdir(),

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -4,6 +4,7 @@ Provides a collection of utility functions and types that are used in other subm
 module Utilities
 
 using Base.Meta, Compat
+using DocStringExtensions
 
 # Logging output.
 
@@ -503,6 +504,18 @@ function getremote(dir::AbstractString)
     else
         getmatch(match, 1)
     end
+end
+
+"""
+$(SIGNATURES)
+
+Returns the first 5 characters of the current git commit hash of the directory `dir`.
+"""
+function get_commit_short(dir)
+    commit = cd(dir) do
+        readchomp(`git rev-parse HEAD`)
+    end
+    (length(commit) > 5) ? commit[1:5] : commit
 end
 
 function inbase(m::Module)


### PR DESCRIPTION
Style and behaviour updates for the sidebar. Site build [available here](http://mortenpi.eu/Documenter.jl/fix-style/).

- Improve contrast of the sidebar menu as discussed [here](https://discourse.julialang.org/t/improve-contrast-in-docs-julialang-org-menu/1370/11).
- Update the version selector style and behaviour. Basically to make fit a bit better with the rest of the style and also make sure that it displays the current version when loaded.

The WIP bit is to make `makedocs` automatically determine the current version name (e.g. `latest`, tag name) which is currently only done in `deploydocs` (so, right now it would just show the commit hash for all builds).

I am also not necessarily entirely happy with the version selector's style, so feedback & ideas would be greatly appreciated (cc @cormullion).

Ideally fixes #406.