### PR TITLE
Newlines and indentation when printing HTML

### DIFF
--- a/src/Utilities/DOM.jl
+++ b/src/Utilities/DOM.jl
@@ -246,12 +246,13 @@ end
 attributes!(out, s::Symbol) = push!(out, tostr(s => ""))
 attributes!(out, p::Pair)   = push!(out, tostr(p))
 
-function Base.show(io::IO, n::Node)
+function Base.show(io::IO, n::Node; level = 0)
     if n.name === Symbol("#RAW#")
         print(io, n.nodes[1].text)
     elseif n.name === TEXT
         print(io, escapehtml(n.text))
     else
+        print(io, "  "^level)
         print(io, '<', n.name)
         for (name, value) in n.attributes
             print(io, ' ', name)
@@ -262,14 +263,18 @@ function Base.show(io::IO, n::Node)
         else
             print(io, '>')
             if n.name === :script || n.name === :style
-                println(io)
-                isempty(n.nodes) || print(io, n.nodes[1].text)
+                if !isempty(n.nodes)
+                  println(io)
+                  println(io, n.nodes[1].text)
+                  print(io, "  "^level)
+                end
             elseif !isempty(n.nodes)
                 println(io)
                 for each in n.nodes
-                    show(io, each)
+                    show(io, each; level = level + 1)
                     println(io)
                 end
+                print(io, "  "^level)
             end
             print(io, "</", n.name, '>')
         end

--- a/src/Utilities/DOM.jl
+++ b/src/Utilities/DOM.jl
@@ -247,12 +247,13 @@ attributes!(out, s::Symbol) = push!(out, tostr(s => ""))
 attributes!(out, p::Pair)   = push!(out, tostr(p))
 
 function Base.show(io::IO, n::Node; level = 0)
+    ws = n.name ∉ (:code, :pre)
     if n.name === Symbol("#RAW#")
         print(io, n.nodes[1].text)
     elseif n.name === TEXT
         print(io, escapehtml(n.text))
     else
-        print(io, "  "^level)
+        ws && print(io, "  "^level)
         print(io, '<', n.name)
         for (name, value) in n.attributes
             print(io, ' ', name)
@@ -269,12 +270,12 @@ function Base.show(io::IO, n::Node; level = 0)
                   print(io, "  "^level)
                 end
             elseif !isempty(n.nodes)
-                println(io)
+                ws && println(io)
                 for each in n.nodes
                     show(io, each; level = level + 1)
-                    println(io)
+                    ws && println(io)
                 end
-                print(io, "  "^level)
+                ws && print(io, "  "^level)
             end
             print(io, "</", n.name, '>')
         end

--- a/src/Utilities/DOM.jl
+++ b/src/Utilities/DOM.jl
@@ -262,10 +262,13 @@ function Base.show(io::IO, n::Node)
         else
             print(io, '>')
             if n.name === :script || n.name === :style
+                println(io)
                 isempty(n.nodes) || print(io, n.nodes[1].text)
-            else
+            elseif !isempty(n.nodes)
+                println(io)
                 for each in n.nodes
                     show(io, each)
+                    println(io)
                 end
             end
             print(io, "</", n.name, '>')

--- a/test/dom.jl
+++ b/test/dom.jl
@@ -68,13 +68,13 @@ import Documenter.Utilities.DOM: DOM, @tags, HTMLDocument
 
     @tags script style img
 
-    @test string(div(p("one"), p("two"))) == "<div><p>one</p><p>two</p></div>"
+    @test string(div(p("one"), p("two"))) == "<div>\n  <p>\none\n  </p>\n  <p>\ntwo\n  </p>\n</div>"
     @test string(div[:key => "value"])    == "<div key=\"value\"></div>"
-    @test string(p(" < > & ' \" "))       == "<p> &lt; &gt; &amp; &#39; &quot; </p>"
+    @test string(p(" < > & ' \" "))       == "<p>\n &lt; &gt; &amp; &#39; &quot; \n</p>"
     @test string(img[:src => "source"])   == "<img src=\"source\"/>"
     @test string(img[:none])              == "<img none/>"
-    @test string(script(" < > & ' \" "))  == "<script> < > & ' \" </script>"
-    @test string(style(" < > & ' \" "))   == "<style> < > & ' \" </style>"
+    @test string(script(" < > & ' \" "))  == "<script>\n < > & ' \" \n</script>"
+    @test string(style(" < > & ' \" "))   == "<style>\n < > & ' \" \n</style>"
     @test string(script)                  == "<script>"
 
     function locally_defined()


### PR DESCRIPTION
Makes for much nicer diffs and general output debugging. Example output at the source for [this page](http://mikeinnes.github.io/Flux.jl/latest/).