### PR TITLE
Fix file refrences since build occurs in a tmp directory

### DIFF
--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -43,11 +43,10 @@ const DOCUMENT_STRUCTURE = (
 )
 
 function render(doc::Documents.Document)
-    task_local_storage(:doc, doc)
     mktempdir() do path
-        cd(path) do
+        cp(joinpath(doc.user.root, doc.user.build), joinpath(path, "build"))
+        cd(joinpath(path, "build")) do
             local file = replace("$(doc.user.sitename).tex", " ", "")
-            cp(joinpath(doc.user.root, doc.user.source, "assets"), "assets")
             open(file, "w") do io
                 local context = Context(io)
                 writeheader(context, doc)
@@ -87,7 +86,6 @@ function render(doc::Documents.Document)
             end
         end
     end
-    task_local_storage(:doc, nothing)
 end
 
 function writeheader(io::IO, doc::Documents.Document)
@@ -407,11 +405,10 @@ function latexinline(io::IO, md::Markdown.Italic)
 end
 
 function latexinline(io::IO, md::Markdown.Image)
-    doc = task_local_storage(:doc)
     wrapblock(io, "figure") do
         _println(io, "\\centering")
         wrapinline(io, "includegraphics") do
-            _print(io, joinpath(doc.user.root, doc.user.build, md.url))
+            _print(io,  md.url)
         end
         _println(io)
         wrapinline(io, "caption") do

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -43,9 +43,11 @@ const DOCUMENT_STRUCTURE = (
 )
 
 function render(doc::Documents.Document)
+    task_local_storage(:doc, doc)
     mktempdir() do path
         cd(path) do
             local file = replace("$(doc.user.sitename).tex", " ", "")
+            cp(joinpath(doc.user.root, doc.user.source, "assets"), "assets")
             open(file, "w") do io
                 local context = Context(io)
                 writeheader(context, doc)
@@ -85,6 +87,7 @@ function render(doc::Documents.Document)
             end
         end
     end
+    task_local_storage(:doc, nothing)
 end
 
 function writeheader(io::IO, doc::Documents.Document)
@@ -404,10 +407,11 @@ function latexinline(io::IO, md::Markdown.Italic)
 end
 
 function latexinline(io::IO, md::Markdown.Image)
+    doc = task_local_storage(:doc)
     wrapblock(io, "figure") do
         _println(io, "\\centering")
         wrapinline(io, "includegraphics") do
-            _print(io, md.url)
+            _print(io, joinpath(doc.user.root, doc.user.build, md.url))
         end
         _println(io)
         wrapinline(io, "caption") do


### PR DESCRIPTION
Transform image references to absolute paths
copy assets directory to temporary build directory

This may not be the most elegant, but this is the only way I could fix this issue without a wholesale re-write of the structure of this codebase. So not sure if this is acceptable, but I thought I'd put this out there in any case. 

Fixes #411.