### PR TITLE
Replace backslashes in href paths with forward slashes

### DIFF
--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -136,7 +136,9 @@ function copy_asset(file, doc)
         ispath(dst) && Utilities.warn("Overwriting '$dst'.")
         cp(src, dst, remove_destination=true)
     end
-    normpath(joinpath("assets", file))
+    assetpath = normpath(joinpath("assets", file))
+    # Replace any backslashes in links, if building the docs on Windows
+    return replace(assetpath, '\\', '/')
 end
 
 # Page
@@ -464,7 +466,9 @@ end
 search_append(sib, node) = mdflatten(sib.buffer, node)
 
 function search_flush(sib)
-    ref = isempty(sib.src) ? sib.src : "$(sib.src)#$(sib.loc)"
+    # Replace any backslashes in links, if building the docs on Windows
+    src = replace(sib.src, '\\', '/')
+    ref = isempty(src) ? src : "$(src)#$(sib.loc)"
     text = Utilities.takebuf_str(sib.buffer)
     println(sib.ctx.search_index, """
     {
@@ -738,6 +742,8 @@ function mdconvert(link::Markdown.Link, parent)
         s = split(link.url, "#", limit = 2)
         path = first(s)
         path = endswith(path, ".md") ? Formats.extension(:html, path) : path
+        # Replace any backslashes in links, if building the docs on Windows
+        path = replace(path, '\\', '/')
         url = (length(s) > 1) ? "$path#$(last(s))" : Compat.String(path)
         Tag(:a)[:href => url](mdconvert(link.text, link))
     end


### PR DESCRIPTION
And Cygwin paths with Windows paths, if applicable

Working towards making the doc build of Base give the same
output whether run on Linux or Windows

Remaining discrepancies:
- build_sysimg source link isn't getting added yet on Windows
- method ordering differs



For code-signing reasons, I need to prepare release binaries from Windows. With the new Documenter-based docs, the source tarballs will therefore end up with html docs built from Windows. Many of the relative links in such a build have backslashes in them, which should probably be avoided in html href links.

I could use help in how to test this properly. It is possible to use Cygwin on AppVeyor, but a bit annoying. Maybe Base's tests would be a better place to do this? Would require some cross-CI coordination, and storing the built docs somewhere.