### PR TITLE
Specify repo URL format for deploydocs()

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -121,7 +121,8 @@ deploydocs(
 )
 ```
 
-where `USER_NAME` and `PACKAGE_NAME` must be set to the appropriate names.
+where `USER_NAME` and `PACKAGE_NAME` must be set to the appropriate names. Note that `repo`
+should not specify any protocol, i.e. it should not begin with `https://` or `git@`. 
 
 By default `deploydocs` will deploy the documentation from the `nightly` Julia build for
 Linux. This can be changed using the `julia` and `osname` keywords as follows:

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -247,9 +247,10 @@ deploydocs(
 written to. This directory **must** be added to the repository's `.gitignore` file. The
 default value is `"site"`.
 
-**`repo`** is the remote repository where generated HTML content should be pushed to. This
-keyword *must* be set and will throw an error when left undefined. For example this package
-uses the following `repo` value:
+**`repo`** is the remote repository where generated HTML content should be pushed to. Do not
+specify any protocol - "https://" or "git@" should not be present. This keyword *must*
+be set and will throw an error when left undefined. For example this package uses the 
+following `repo` value:
 
 ```julia
 repo = "github.com/JuliaDocs/Documenter.jl.git"


### PR DESCRIPTION
I just spent much longer than I care to admit troubleshooting why `deploydocs` couldn't fetch from my repo... it turns out I absentmindedly set `repo` to `https://github.com/my/repo.git` which Documenter converted to `git@https://github.com:my/repo.git`. I thought it might be helpful to explicitly tell people to avoid that.