### PR TITLE
Also use HTML escapes in attribute values

### DIFF
--- a/src/Utilities/DOM.jl
+++ b/src/Utilities/DOM.jl
@@ -255,7 +255,7 @@ function Base.show(io::IO, n::Node)
         print(io, '<', n.name)
         for (name, value) in n.attributes
             print(io, ' ', name)
-            isempty(value) || print(io, '=', repr(value))
+            isempty(value) || print(io, '=', repr(escapehtml(value)))
         end
         if n.name in VOID_ELEMENTS
             print(io, "/>")


### PR DESCRIPTION
Currently attribute values with double quotes etc. get printed without
the special characters being escaped, which is especially relevant for
page heading anchors. This will change links to page anchors that have
quotes in them, but they were already inconsistent with the search
index.

Example of this in the current manual: http://docs.julialang.org/en/latest/manual/faq.html#What-is-the-difference-between-\