### PR TITLE
Support for RawHTML type as a result in an  block

### DIFF
--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -17,10 +17,10 @@ import .Documents:
     DocsNode,
     DocsNodes,
     EvalNode,
-    MetaNode
+    MetaNode,
+    RawNode
 
 using Compat
-
 
 function expand(doc::Documents.Document)
     for (src, page) in doc.internal.pages
@@ -30,7 +30,6 @@ function expand(doc::Documents.Document)
         end
     end
 end
-
 
 # Expander Pipeline.
 # ------------------
@@ -472,10 +471,14 @@ function Selectors.runner(::Type{ExampleBlocks}, x, page, doc)
     content = []
     input   = droplines(x.code)
 
-    # Special-case support for displaying SVG graphics. TODO: make this more general.
-    output = mimewritable(MIME"image/svg+xml"(), result) ?
-        Documents.RawHTML(stringmime(MIME"image/svg+xml"(), result)) :
-        Markdown.Code(Documenter.DocChecks.result_to_string(buffer, result))
+    if isa(result, Documenter.Documents.RawHTML)
+         output = result
+      else
+        # Special-case support for displaying SVG graphics. TODO: make this more general.
+        output = mimewritable(MIME"image/svg+xml"(), result) ?
+            Documents.RawHTML(stringmime(MIME"image/svg+xml"(), result)) :
+            Markdown.Code(Documenter.DocChecks.result_to_string(buffer, result))
+    end
 
     # Only add content when there's actually something to add.
     isempty(input)  || push!(content, Markdown.Code("julia", input))


### PR DESCRIPTION
If a an @eval block returns a RawHTML
```
```@eval
import Documenter.Utilities.DOM: Tag
import Documenter.Documents.RawHTML
a =  Tag(:figure)[:class=>"figure"]( Tag(:img)[:src => "my_image.png", alt="Alt text"],     Tag(:figcaption)("My Caption"))
RawHTML(string(a))
```

 it will output
```html
<figure class="figure"><img src="my_image.png"><figcaption>My Caption</figcaption></figure>
```
but not in an @example block. The HTML code is converted to string. Now boths blocks have the same behaviour. I think it was not possible to return an HTML code in an @example block before.
```
Now if you have an  @example block:
```@example
import Documenter.Utilities.DOM: DOM, Tag, @tags
import Documenter.Documents.RawHTML

a =  Tag(:figure)[:class=>"figure"]( Tag(:img)[:src => "my_image.png", alt="Alt text"], Tag(:figcaption)("My Caption"))
RawHTML(string(a))
```
It will output
```
[The code] 
```
and 
```html
<figure class="figure"><img src="my_image.png"><figcaption>My Caption</figcaption></figure>
```


