### PR TITLE
Initialize empty branch if deploydocs can't find gh-pages

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -200,11 +200,13 @@ These are needed to avoid committing generated content to your repository.
 
 ## `gh-pages` Branch
 
-Create a new branch called `gh-pages` and push it to GitHub. Note that a new and empty
-`gh-pages` branch can be created following [these instructions](https://coderwall.com/p/0n3soa/create-a-disconnected-git-branch).
+By default, Documenter pushes documentation to the `gh-pages` branch. If the branch does not
+exist it will be created automatically by [`deploydocs`](@ref). If does exist then
+Documenter simply adds an additional commit with the built documentation. You should be
+aware that Documenter may overwrite existing content without warning.
 
-If the `gh-pages` branch already exists then you can skip this step, but do note that the 
-generated content is automatically pushed to this branch from Travis.
+If you wish to create the `gh-pages` branch manually the that can be done following
+[these instructions](https://coderwall.com/p/0n3soa/create-a-disconnected-git-branch).
 
 ## Documentation Versions
 

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -79,7 +79,7 @@ Follow the instructions that are printed out, namely:
 
  2. Next add the long private key to the Travis settings page using the provided link. Again
     note that you should include **no whitespace** when copying the key. In the **`Environment
-    Variables`** section add a key with the name `DOCUMENTER_KEY` and the value that was printed 
+    Variables`** section add a key with the name `DOCUMENTER_KEY` and the value that was printed
     out. **Do not** set the variable to be displayed in the build log. Then click **`Add`**.
 
     !!! warning "Security warning"
@@ -122,7 +122,7 @@ deploydocs(
 ```
 
 where `USER_NAME` and `PACKAGE_NAME` must be set to the appropriate names. Note that `repo`
-should not specify any protocol, i.e. it should not begin with `https://` or `git@`. 
+should not specify any protocol, i.e. it should not begin with `https://` or `git@`.
 
 By default `deploydocs` will deploy the documentation from the `nightly` Julia build for
 Linux. This can be changed using the `julia` and `osname` keywords as follows:

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -467,8 +467,15 @@ function deploydocs(;
                         success(`git fetch upstream`) ||
                             error("could not fetch from remote.")
 
-                        success(`git checkout -b $branch upstream/$branch`) ||
-                            error("could not checkout remote branch.")
+                        branch_exists = success(`git checkout -b $branch upstream/$branch`)
+
+                        if !branch_exists
+                            Utilities.log("assuming $branch doesn't exist yet; creating a new one.")
+                            success(`git checkout --orphan $branch`) ||
+                                error("could not create new empty branch.")
+                            success(`git commit --allow-empty -m "Initial empty commit for docs"`) ||
+                                error("could not commit to new branch $branch")
+                        end
 
                         # Copy docs to `latest`, or `stable`, `<release>`, and `<version>` directories.
                         if isempty(travis_tag)

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -295,8 +295,8 @@ following `repo` value:
 repo = "github.com/JuliaDocs/Documenter.jl.git"
 ```
 
-**`branch`** is the branch where the generated documentation is pushed. By default this
-value is set to `"gh-pages"`.
+**`branch`** is the branch where the generated documentation is pushed. If the branch does
+not exist, a new orphaned branch is created automatically. It defaults to `"gh-pages"`.
 
 **`latest`** is the branch that "tracks" the latest generated documentation. By default this
 value is set to `"master"`.


### PR DESCRIPTION
This fixes #361 by creating a blank orphan branch if the deploy branch (usually "gh-pages") doesn't exist yet.

The alternative is including a note in the docs on how to create an push the initial empty branch.