### PR TITLE
Allow whitelisting links in linkcheck

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,7 +7,7 @@ A package for building documentation from docstrings and markdown files.
 !!! note
 
     Please read through the
-    [Documentation](http://docs.julialang.org/en/latest/manual/documentation.html) section
+    [Documentation](https://docs.julialang.org/en/latest/manual/documentation.html) section
     of the main Julia manual if this is your first time using Julia's documentation system.
     Once you've read through how to write documentation for your code then come back here.
 

--- a/docs/src/man/examples.md
+++ b/docs/src/man/examples.md
@@ -24,28 +24,27 @@ Packages that have tagged versions available in `METADATA.jl`.
 - [Bio.jl](https://biojulia.github.io/Bio.jl/latest/)
 - [ControlSystems.jl](http://juliacontrol.github.io/ControlSystems.jl/latest/)
 - [Currencies.jl](https://juliafinance.github.io/Currencies.jl/latest/)
-- [DifferentialEquations.jl](http://juliadiffeq.github.io/DiffEqDocs.jl/latest/)
-- [Documenter.jl](https://juliadocs.github.io/Documenter.jl/latest)
-- [ExtractMacro.jl](https://carlobaldassi.github.io/ExtractMacro.jl/latest)
+- [DifferentialEquations.jl](http://docs.juliadiffeq.org/latest/)
+- [Documenter.jl](https://juliadocs.github.io/Documenter.jl/latest/)
+- [ExtractMacro.jl](https://carlobaldassi.github.io/ExtractMacro.jl/latest/)
 - [EzXML.jl](https://bicycle1885.github.io/EzXML.jl/latest/)
 - [Highlights.jl](https://juliadocs.github.io/Highlights.jl/latest/)
-- [IntervalConstraintProgramming.jl](http://dpsanders.github.io/IntervalConstraintProgramming.jl/latest/)
+- [IntervalConstraintProgramming.jl](https://juliaintervals.github.io/IntervalConstraintProgramming.jl/latest/)
 - [Luxor.jl](https://juliagraphics.github.io/Luxor.jl/stable/)
-- [MergedMethods.jl](https://michaelhatherly.github.io/MergedMethods.jl/latest)
+- [MergedMethods.jl](https://michaelhatherly.github.io/MergedMethods.jl/latest/)
 - [Mimi.jl](http://anthofflab.berkeley.edu/Mimi.jl/stable/)
-- [NumericSuffixes.jl](https://michaelhatherly.github.io/NumericSuffixes.jl/latest)
-- [Optim.jl](https://juliaopt.github.io/Optim.jl/latest)
+- [NumericSuffixes.jl](https://michaelhatherly.github.io/NumericSuffixes.jl/latest/)
 - [POMDPs.jl](http://juliapomdp.github.io/POMDPs.jl/latest/)
 - [PhyloNetworks.jl](http://crsl4.github.io/PhyloNetworks.jl/latest/)
-- [PrivateModules.jl](https://michaelhatherly.github.io/PrivateModules.jl/latest)
+- [PrivateModules.jl](https://michaelhatherly.github.io/PrivateModules.jl/latest/)
 - [Query.jl](http://www.david-anthoff.com/Query.jl/stable/)
 - [TaylorSeries.jl](http://www.juliadiff.org/TaylorSeries.jl/latest/)
-- [Weave.jl](https://mpastell.github.io/Weave.jl/stable)
+- [Weave.jl](http://weavejl.mpastell.com/stable/)
 
 ## Unregistered
 
 Packages that are not available in `METADATA.jl` and may be works-in-progress.
 Please do take that into consideration when browsing this list.
 
-- [AnonymousTypes.jl](https://michaelhatherly.github.io/AnonymousTypes.jl/latest)
+- [AnonymousTypes.jl](https://michaelhatherly.github.io/AnonymousTypes.jl/latest/)
 - [OhMyREPL.jl](https://github.com/KristofferC/OhMyREPL.jl)

--- a/docs/src/man/examples.md
+++ b/docs/src/man/examples.md
@@ -9,7 +9,7 @@ should give a good overview of what this package is currently able to do.
 !!! note
 
     Packages are listed alphabetically. If you have a package that uses Documenter then
-    please open a PR that adds it to the appropriate list below; a simple way to do so 
+    please open a PR that adds it to the appropriate list below; a simple way to do so
     is to navigate to
     https://github.com/JuliaDocs/Documenter.jl/edit/master/docs/src/man/examples.md.
 

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -167,6 +167,10 @@ of external-pointing links, to make sure that they are up-to-date. The links and
 status codes are printed to the standard output. If `strict` is also enabled then the build
 will fail if there are any broken (400+ status code) links. Default: `false`.
 
+**`linkcheck_ignore`** allows certain URLs to be ignored in `linkcheck`. The values should
+be a list of strings (which get matched exactly) or `Regex` objects. By default nothing is
+ignored.
+
 **`strict`** -- [`makedocs`](@ref) fails the build right before rendering if it encountered
 any errors with the document in the previous build phases.
 

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -254,7 +254,7 @@ default value is `"site"`.
 
 **`repo`** is the remote repository where generated HTML content should be pushed to. Do not
 specify any protocol - "https://" or "git@" should not be present. This keyword *must*
-be set and will throw an error when left undefined. For example this package uses the 
+be set and will throw an error when left undefined. For example this package uses the
 following `repo` value:
 
 ```julia

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -149,10 +149,40 @@ For example if you are using GitLab.com, you could use
 makedocs(repo = \"https://gitlab.com/user/project/blob/{commit}{path}#L{line}\")
 ```
 
-**`version`** specifies the version string of the current version which will be the
-selected option in the version selector. If this is left empty (default) the version
-selector will be hidden. The special value `git-commit` sets the value in the output to
-`git:{commit}`, where `{commit}` is the first few characters of the current commit hash.
+# Experimental keywords
+
+In addition to standard arguments there is a set of non-finalized experimental keyword
+arguments. The behaviour of these may change or they may be removed without deprecation
+when a minor version changes (i.e. except in patch releases).
+
+**`checkdocs`** instructs [`makedocs`](@ref) to check whether all names within the modules
+defined in the `modules` keyword that have a docstring attached have the docstring also
+listed in the manual (e.g. there's a `@docs` blocks with that docstring). Possible values
+are `:all` (check all names) and `:exports` (check only exported names). The default value
+is `:none`, in which case no checks are performed. If `strict` is also enabled then the
+build will fail if any missing docstrings are encountered.
+
+**`linkcheck`** -- if set to `true` [`makedocs`](@ref) uses `curl` to check the status codes
+of external-pointing links, to make sure that they are up-to-date. The links and their
+status codes are printed to the standard output. If `strict` is also enabled then the build
+will fail if there are any broken (400+ status code) links. Default: `false`.
+
+**`strict`** -- [`makedocs`](@ref) fails the build right before rendering if it encountered
+any errors with the document in the previous build phases.
+
+## Non-MkDocs builds
+
+Documenter also has (experimental) support for native HTML and LaTeX builds.
+These can be enabled using the `format` keyword and they generally require additional
+keywords be defined, depending on the format. These keywords are also currently considered
+experimental.
+
+**`format`** allows the output format to be specified. Possible values are `:html`, `:latex`
+and `:markdown` (default).
+
+Other keywords related to non-MkDocs builds (**`assets`**, **`sitename`**, **`analytics`**,
+**`authors`**, **`pages`**, **`version`**) should be documented at the respective `*Writer`
+modules ([`Writers.HTMLWriter`](@ref), [`Writers.LaTeXWriter`](@ref)).
 
 # See Also
 

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -185,7 +185,8 @@ immutable User
     format  :: Vector{Symbol} # What format to render the final document with?
     clean   :: Bool           # Empty the `build` directory before starting a new build?
     doctest :: Bool           # Run doctests?
-    linkcheck::Bool           # Check external links.
+    linkcheck::Bool           # Check external links..
+    linkcheck_ignore::Vector{Union{String,Regex}}  # ..and then ignore (some of) them.
     checkdocs::Symbol         # Check objects missing from `@docs` blocks. `:none`, `:exports`, or `:all`.
     strict::Bool              # Throw an exception when any warnings are encountered.
     modules :: Set{Module}    # Which modules to check for missing docs?
@@ -236,6 +237,7 @@ function Document(;
         clean    :: Bool             = true,
         doctest  :: Bool             = true,
         linkcheck:: Bool             = false,
+        linkcheck_ignore :: Vector   = [],
         checkdocs::Symbol            = :all,
         strict::Bool                 = false,
         modules  :: Utilities.ModVec = Module[],
@@ -265,6 +267,7 @@ function Document(;
         clean,
         doctest,
         linkcheck,
+        linkcheck_ignore,
         checkdocs,
         strict,
         Utilities.submodules(modules),

--- a/src/Generator.jl
+++ b/src/Generator.jl
@@ -9,7 +9,7 @@ using DocStringExtensions
 $(SIGNATURES)
 
 Attempts to save a file at `\$(root)/\$(filename)`. `f` will be called with file
-stream (see [`open`](http://docs.julialang.org/en/latest/stdlib/io-network.html#Base.open)).
+stream (see [`open`](https://docs.julialang.org/en/latest/stdlib/io-network.html#Base.open)).
 
 `filename` can also be a file in a subdirectory (e.g. `src/index.md`), and then
 then subdirectories will be created automatically.

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1,6 +1,17 @@
 """
 A module for rendering `Document` objects to HTML.
 
+# Keywords
+
+[`HTMLWriter`](@ref) uses the following additional keyword arguments that can be passed to
+[`Documenter.makedocs`](@ref): `assets`, `sitename`, `analytics`, `authors`, `pages`,
+`version`.
+
+**`version`** specifies the version string of the current version which will be the
+selected option in the version selector. If this is left empty (default) the version
+selector will be hidden. The special value `git-commit` sets the value in the output to
+`git:{commit}`, where `{commit}` is the first few characters of the current commit hash.
+
 # Page outline
 
 The [`HTMLWriter`](@ref) makes use of the page outline that is determined by the

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -134,5 +134,8 @@ examples_html_doc = makedocs(
             "hidden/y.md",
             "hidden/z.md",
         ])
-    ]
+    ],
+
+    linkcheck = true,
+    linkcheck_ignore = [r"(x|y).md", "z.md", r":func:.*"],
 )


### PR DESCRIPTION
@tkelman apologies for being a bit passive on the Documenter front at the moment. I assumed this to be a "nice to have".

I think adding another keyword argument would do the trick. This more or less copies how this is done in Sphinx as far as I can tell.

This will require a minor version bump, so I am thinking it might be time to merge a couple of the other PRs as well while we're at it. How fast would you like to have this available?

Fixes #447.