### PR TITLE
Use Source Code Pro as the monospace font

### DIFF
--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -25,6 +25,10 @@ pre, code {
   font-size: 0.95em;
 }
 
+pre code {
+  font-size: 1em;
+}
+
 a {
     color: #2980b9;
     text-decoration: none;

--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -21,7 +21,8 @@ body, input {
 }
 
 pre, code {
-  font-family: 'Ubuntu Mono', Monaco, courier, monospace;
+  font-family: 'Source Code Pro', Monaco, courier, monospace;
+  font-size: 0.95em;
 }
 
 a {

--- a/assets/latex/documenter.sty
+++ b/assets/latex/documenter.sty
@@ -2,7 +2,7 @@
 \usepackage{fontspec, newunicodechar, polyglossia}
 
 \setsansfont{Lato}[Scale=MatchLowercase, Ligatures=TeX]
-\setmonofont{Fantasque Sans Mono}[Scale=MatchLowercase]
+\setmonofont{Source Code Pro}[Scale=MatchLowercase]
 \renewcommand{\familydefault}{\sfdefault}
 %
 

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -66,7 +66,7 @@ using ...Utilities.MDFlatten
 const requirejs_cdn = "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.min.js"
 const normalize_css = "https://cdnjs.cloudflare.com/ajax/libs/normalize/4.2.0/normalize.min.css"
 const highlightjs_css = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.5.0/styles/default.min.css"
-const google_fonts = "https://fonts.googleapis.com/css?family=Lato|Ubuntu+Mono"
+const google_fonts = "https://fonts.googleapis.com/css?family=Lato|Source+Code+Pro"
 const fontawesome_css = "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css"
 
 """


### PR DESCRIPTION
This PR replaces Ubuntu Mono with [Source Code Pro](https://fonts.google.com/specimen/Source+Code+Pro) as the monospace font, as @mortenpi and I discussed in #461. Per Morten's request, the font size is scaled down to 0.95em.