### PR TITLE
Use Roboto Mono as the monospace font

### DIFF
--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -21,7 +21,12 @@ body, input {
 }
 
 pre, code {
-  font-family: 'Ubuntu Mono', Monaco, courier, monospace;
+  font-family: 'Roboto Mono', Monaco, courier, monospace;
+  font-size: 0.95em;
+}
+
+pre code {
+  font-family: 1em;
 }
 
 a {

--- a/assets/latex/documenter.sty
+++ b/assets/latex/documenter.sty
@@ -2,7 +2,7 @@
 \usepackage{fontspec, newunicodechar, polyglossia}
 
 \setsansfont{Lato}[Scale=MatchLowercase, Ligatures=TeX]
-\setmonofont{Fantasque Sans Mono}[Scale=MatchLowercase]
+\setmonofont{Roboto Mono}[Scale=MatchLowercase]
 \renewcommand{\familydefault}{\sfdefault}
 %
 

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -66,7 +66,7 @@ using ...Utilities.MDFlatten
 const requirejs_cdn = "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.min.js"
 const normalize_css = "https://cdnjs.cloudflare.com/ajax/libs/normalize/4.2.0/normalize.min.css"
 const highlightjs_css = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.5.0/styles/default.min.css"
-const google_fonts = "https://fonts.googleapis.com/css?family=Lato|Ubuntu+Mono"
+const google_fonts = "https://fonts.googleapis.com/css?family=Lato|Roboto+Mono"
 const fontawesome_css = "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css"
 
 """


### PR DESCRIPTION
Competitor to #462

This PR replaces the current monospace font, Ubuntu Mono, with [Roboto Mono](https://fonts.google.com/specimen/Roboto+Mono). Currently I've scaled this down to match what was done for Source Code Pro in #462, but I'm not sure whether it's necessary for Roboto Mono.

cc @mortenpi 