### PR TITLE
Reduce monospace font size to 0.90em

### DIFF
--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -22,7 +22,7 @@ body, input {
 
 pre, code {
   font-family: 'Roboto Mono', Monaco, courier, monospace;
-  font-size: 0.95em;
+  font-size: 0.90em;
 }
 
 pre code {


### PR DESCRIPTION
As noted in https://github.com/JuliaDocs/Documenter.jl/pull/463#issuecomment-297234924, 0.95em is a little too big.