### PR TITLE
Fix doctest highlighting #385

### DIFF
--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -749,7 +749,7 @@ mdconvert(b::Markdown.Bold, parent) = Tag(:strong)(mdconvert(b.text, parent))
 function mdconvert(c::Markdown.Code, parent::MDBlockContext)
     @tags pre code
     language = isempty(c.language) ? "none" : c.language
-    language = language == "jldoctest" ? "julia" : language
+    language = language in ("jldoctest", "jlcon") ? "julia" : language
     pre(code[".language-$(language)"](c.code))
 end
 mdconvert(c::Markdown.Code, parent) = Tag(:code)(c.code)


### PR DESCRIPTION
When a REPL session doctest was processed, its `code.language` changes to `jlcon`.  This works for Pygments and the Latex output, but not highlights.js.  This PR changes `jlcon` to `julia` when generating HTML docs.