### PR TITLE
Fix at-repl blocks

### DIFF
--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -504,7 +504,6 @@ function Selectors.runner(::Type{REPLBlocks}, x, page, doc)
             end
         end
         result = value
-        print(out, text)
         local output = if success
             hide = Documenter.DocChecks.ends_with_semicolon(input)
             Documenter.DocChecks.result_to_string(buffer, hide ? nothing : value)
@@ -512,13 +511,14 @@ function Selectors.runner(::Type{REPLBlocks}, x, page, doc)
             Documenter.DocChecks.error_to_string(buffer, value, [])
         end
         isempty(input) || println(out, prepend_prompt(input))
+        print(out, text)
         if isempty(input) || isempty(output)
             println(out)
         else
             println(out, output, "\n")
         end
     end
-    page.mapping[x] = Base.Markdown.Code("julia", rstrip(Utilities.takebuf_str(out)))
+    page.mapping[x] = Base.Markdown.Code("julia-repl", rstrip(Utilities.takebuf_str(out)))
 end
 
 # @setup

--- a/test/examples/src/man/tutorial.md
+++ b/test/examples/src/man/tutorial.md
@@ -150,6 +150,13 @@ f(0.01)
 div(1, 0)
 ```
 
+Make sure that STDOUT is in the right place (#484):
+
+```@repl 1
+println("---") === nothing
+versioninfo()
+```
+
 ```@eval
 1 + 2
 nothing


### PR DESCRIPTION
The STDOUT from the executed code should be printed after the prompt
line. And we should also apply the appropriate julia-repl language to
the output blocks.