### PR TITLE
Allow using pretty URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Please open an [issue][issues-url] if you encounter any problems. If you have a 
 
 [gitter-url]: https://gitter.im/juliadocs/users
 
-[contrib-url]: https://juliadocs.github.io/Documenter.jl/latest/man/contributing.html
+[contrib-url]: https://juliadocs.github.io/Documenter.jl/latest/man/contributing/
 
 [docs-latest-img]: https://img.shields.io/badge/docs-latest-blue.svg
 [docs-latest-url]: https://juliadocs.github.io/Documenter.jl/latest

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -40,7 +40,8 @@ makedocs(
                 "lib/internals/writers.md",
             ])
         ]
-    ]
+    ],
+    html_prettyurls = true,
 )
 
 deploydocs(

--- a/src/CrossReferences.jl
+++ b/src/CrossReferences.jl
@@ -95,7 +95,6 @@ function namedxref(link::Markdown.Link, slug, meta, page, doc)
             # Replace the `@ref` url with a path to the referenced header.
             anchor   = get(Anchors.anchor(headers, slug))
             path     = relpath(anchor.file, dirname(page.build))
-            path     = Formats.extension(doc.user.format[1], path) # TODO: handle multiple formats.
             link.url = string(path, '#', slug, '-', anchor.nth)
         else
             push!(doc.internal.errors, :cross_references)
@@ -156,7 +155,6 @@ function docsxref(link::Markdown.Link, code, meta, page, doc)
         # Replace the `@ref` url with a path to the referenced docs.
         docsnode = doc.internal.objects[object]
         path     = relpath(docsnode.page.build, dirname(page.build))
-        path     = Formats.extension(doc.user.format[1], path) # TODO: handle multiple formats.
         slug     = Utilities.slugify(object)
         link.url = string(path, '#', slug)
     else

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -197,6 +197,7 @@ immutable User
     authors :: Compat.String
     analytics::Compat.String
     version :: Compat.String # version string used in the version selector by default
+    html_prettyurls :: Bool # Use pretty URLs in the HTML build?
 end
 
 """
@@ -248,6 +249,7 @@ function Document(;
         authors  :: AbstractString   = "",
         analytics :: AbstractString = "",
         version :: AbstractString = "",
+        html_prettyurls :: Bool = false,
         others...
     )
     Utilities.check_kwargs(others)
@@ -278,6 +280,7 @@ function Document(;
         authors,
         analytics,
         version,
+        html_prettyurls,
     )
     internal = Internal(
         Utilities.assetsdir(),

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -455,8 +455,8 @@ function latexinline(io::IO, md::Markdown.Link)
     if io.in_header
         latexinline(io, md.text)
     else
-        if contains(md.url, ".tex#")
-            file, target = split(md.url, ".tex#"; limit = 2)
+        if contains(md.url, ".md#")
+            file, target = split(md.url, ".md#"; limit = 2)
             local id = string(hash(target))
             wrapinline(io, "hyperlink") do
                 _print(io, id)

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -98,6 +98,14 @@ export @define_show_and_make_object
 
 end # module
 
+module InlineSVG
+export SVG
+type SVG
+    code :: String
+end
+Base.show(io, ::MIME"image/svg+xml", svg::SVG) = write(io, svg.code)
+end # module
+
 # Build example docs
 using Documenter
 

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -147,3 +147,31 @@ examples_html_doc = makedocs(
     linkcheck = true,
     linkcheck_ignore = [r"(x|y).md", "z.md", r":func:.*"],
 )
+
+info("Building mock package docs: HTMLWriter with pretty URLs")
+examples_html_doc = makedocs(
+    debug = true,
+    root  = examples_root,
+    build = "builds/html-pretty-urls",
+    format   = :html,
+    html_prettyurls = true,
+    assets = ["assets/custom.css"],
+    sitename = "Documenter example",
+    pages    = Any[
+        "Home" => "index.md",
+        "Manual" => [
+            "man/tutorial.md",
+        ],
+        hide("hidden.md"),
+        "Library" => [
+            "lib/functions.md",
+            "lib/autodocs.md",
+        ],
+        hide("Hidden Pages" => "hidden/index.md", Any[
+            "Page X" => "hidden/x.md",
+            "hidden/y.md",
+            "hidden/z.md",
+        ])
+    ],
+    doctest = false,
+)

--- a/test/examples/src/index.md
+++ b/test/examples/src/index.md
@@ -185,3 +185,9 @@ julia> a = 1
 julia> ans
 1
 ```
+
+# Bad links (Windows)
+
+* [Colons not allowed on Windows -- `some:path`](some:path)
+* [No "drive" -- `:path`](:path)
+* [Absolute Windows paths -- `X:\some\path`](X:\some\path)

--- a/test/examples/src/man/tutorial.md
+++ b/test/examples/src/man/tutorial.md
@@ -161,3 +161,58 @@ versioninfo()
 1 + 2
 nothing
 ```
+
+## Including images with `MIME`
+
+If `show(io, ::MIME"image/svg+xml", x)` is overloaded for a particular type
+then `@example` blocks will show the SVG image in the output. Assuming the following type
+and method live in the `InlineSVG` module
+
+```julia
+type SVG
+    code :: String
+end
+Base.show(io, ::MIME"image/svg+xml", svg::SVG) = write(io, svg.code)
+```
+
+.. then we we can invoke and show them with an `@example` block:
+
+```@example
+using InlineSVG
+SVG("""
+<svg width="82" height="76">
+  <g style="stroke-width: 3">
+    <circle cx="20" cy="56" r="16" style="stroke: #cb3c33; fill: #d5635c" />
+    <circle cx="41" cy="20" r="16" style="stroke: #389826; fill: #60ad51" />
+    <circle cx="62" cy="56" r="16" style="stroke: #9558b2; fill: #aa79c1" />
+  </g>
+</svg>
+""")
+```
+
+_Note: we can't define the `show` method in the `@example` block due to the world age
+counter in Julia 0.6 (Documenter's `makedocs` is not aware of any of the new method
+definitions happening in `eval`s)._
+
+
+## Interacting with external files
+
+You can also write output files and then refer to them in the document:
+
+```@example
+open("julia.svg", "w") do io
+    write(io, """
+    <svg width="82" height="76" xmlns="http://www.w3.org/2000/svg">
+      <g style="stroke-width: 3">
+        <circle cx="20" cy="56" r="16" style="stroke: #cb3c33; fill: #d5635c" />
+        <circle cx="41" cy="20" r="16" style="stroke: #389826; fill: #60ad51" />
+        <circle cx="62" cy="56" r="16" style="stroke: #9558b2; fill: #aa79c1" />
+      </g>
+    </svg>
+    """)
+end
+```
+
+![Julia circles](julia.svg)
+
+Dowload [`data.csv`](data.csv).

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -89,4 +89,12 @@ using Compat
 
         # TODO: test the HTML build
     end
+
+    @testset "HTML: html-pretty-urls" begin
+        local doc = Main.examples_html_doc
+
+        @test isa(doc, Documenter.Documents.Document)
+
+        # TODO: test the HTML build with pretty URLs
+    end
 end

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -41,6 +41,7 @@ using Compat
             @test isfile(joinpath(build_dir, "lib", "functions.md"))
             @test isfile(joinpath(build_dir, "man", "tutorial.md"))
             @test isfile(joinpath(build_dir, "man", "data.csv"))
+            @test isfile(joinpath(build_dir, "man", "julia.svg"))
 
             @test (==)(
                 readstring(joinpath(source_dir, "man", "data.csv")),


### PR DESCRIPTION
Allows pretty URLs to be used in the HTML build, i.e. `dir/page.md` can be referenced as `dir/page/` instead of the current `dir/page.html`. This behaviour is consistent with MkDocs and Sphinx, and has been on the roadmap.

This is done by storing the actual page in `dir/page/index.html`. It does mean that this can't be used for local / offline builds though.

Currently it has to enabled via the `html_prettyurls` option and is disabled by default. It should become the default for the deploy-to-gh-pages builds for packages, even though it will involve breaking existing links.

@tkelman I think this would also be nice to have for 0.6. This way we won't have to swap to `.html` links for a release and then back again (assuming we want this in the long term), potentially breaking quite a lot of references to Base docs. Also, links that were referring to the 0.5 docs should start working again. For Base we should enable this feature explicitly and only for the `gh-pages` builds.

WIP because some internal links are still not being generated correctly, code needs cleanup and more testing.

Example build: http://mortenpi.eu/Documenter.jl/pretty-urls-deploy/