### PR TITLE
Only fix anchor links if domify is not called

### DIFF
--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -538,10 +538,10 @@ end
 
 function domify(ctx, navnode, anchor::Anchors.Anchor)
     @tags a
-    fixlinks!(ctx, navnode, anchor.object)
     aid = "$(anchor.id)-$(anchor.nth)"
     if isa(anchor.object, Markdown.Header)
         h = anchor.object
+        fixlinks!(ctx, navnode, h)
         DOM.Tag(Symbol("h$(Utilities.header_level(h))"))(
             a[".nav-anchor", :id => aid, :href => "#$aid"](mdconvert(h.text, h))
         )


### PR DESCRIPTION
In the else branch the links get fixed in the domify call anyway.
Hence we should only call fixlinks! if we go to mdconver directly.
Otherwise it gets called twice and the previously fixed links are
reported as invalid.