### PR TITLE
git rm old files before copy in deploy

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,6 +28,7 @@ makedocs(
                 "lib/internals/cross-references.md",
                 "lib/internals/docchecks.md",
                 "lib/internals/docsystem.md",
+                "lib/internals/documenter.md",
                 "lib/internals/documents.md",
                 "lib/internals/dom.md",
                 "lib/internals/expanders.md",

--- a/docs/src/lib/internals/documenter.md
+++ b/docs/src/lib/internals/documenter.md
@@ -1,0 +1,5 @@
+# Documenter
+
+```@docs
+Documenter.gitrm_copy
+```


### PR DESCRIPTION
This way we also commit case changes in file names on filesystems that are case-insensitive.

This patch seems to delete the capitalized `Documenter.css` successfully: https://travis-ci.org/mortenpi/Example.jl/builds/239259385#L166

Fixes #507.