### PR TITLE
detect named doctests as jldoctest

### DIFF
--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -817,7 +817,7 @@ function mdconvert(c::Markdown.Code, parent::MDBlockContext; kwargs...)
     @tags pre code
     language = if isempty(c.language)
         "none"
-    elseif startswith(c.language, "jldoctest")
+    elseif first(split(c.language)) == "jldoctest"
         # When the doctests are not being run, Markdown.Code blocks will have jldoctest as
         # the language attribute. The check here to determine if it is a REPL-type or
         # script-type doctest should match the corresponding one in DocChecks.jl. This makes

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -817,7 +817,7 @@ function mdconvert(c::Markdown.Code, parent::MDBlockContext; kwargs...)
     @tags pre code
     language = if isempty(c.language)
         "none"
-    elseif c.language == "jldoctest"
+    elseif startswith(c.language, "jldoctest")
         # When the doctests are not being run, Markdown.Code blocks will have jldoctest as
         # the language attribute. The check here to determine if it is a REPL-type or
         # script-type doctest should match the corresponding one in DocChecks.jl. This makes

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -260,7 +260,7 @@ const LEXER = Set([
 ])
 
 function latex(io::IO, code::Markdown.Code)
-    language = if code.language == "jldoctest"
+    language = if startswith(code.language, "jldoctest")
         # When the doctests are not being run, Markdown.Code blocks will have jldoctest as
         # the language attribute. The check here to determine if it is a REPL-type or
         # script-type doctest should match the corresponding one in DocChecks.jl. This makes

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -260,7 +260,7 @@ const LEXER = Set([
 ])
 
 function latex(io::IO, code::Markdown.Code)
-    language = if startswith(code.language, "jldoctest")
+    language = if first(split(c.language)) == "jldoctest"
         # When the doctests are not being run, Markdown.Code blocks will have jldoctest as
         # the language attribute. The check here to determine if it is a REPL-type or
         # script-type doctest should match the corresponding one in DocChecks.jl. This makes

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -260,7 +260,9 @@ const LEXER = Set([
 ])
 
 function latex(io::IO, code::Markdown.Code)
-    language = if first(split(code.language)) == "jldoctest"
+    language = if isempty(code.language)
+          "none"
+    elseif first(split(code.language)) == "jldoctest"
         # When the doctests are not being run, Markdown.Code blocks will have jldoctest as
         # the language attribute. The check here to determine if it is a REPL-type or
         # script-type doctest should match the corresponding one in DocChecks.jl. This makes

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -260,7 +260,7 @@ const LEXER = Set([
 ])
 
 function latex(io::IO, code::Markdown.Code)
-    language = if first(split(c.language)) == "jldoctest"
+    language = if first(split(code.language)) == "jldoctest"
         # When the doctests are not being run, Markdown.Code blocks will have jldoctest as
         # the language attribute. The check here to determine if it is a REPL-type or
         # script-type doctest should match the corresponding one in DocChecks.jl. This makes

--- a/test/examples/src/index.md
+++ b/test/examples/src/index.md
@@ -186,6 +186,16 @@ julia> ans
 1
 ```
 
+# Issue513
+
+```jldoctest named
+julia> a = 1
+1
+
+julia> ans
+1
+```
+
 # Bad links (Windows)
 
 * [Colons not allowed on Windows -- `some:path`](some:path)


### PR DESCRIPTION
Named doctests also want syntax highlighting :)

See e.g. https://docs.julialang.org/en/latest/manual/strings/#String-Basics-1 = no highlighting because the doctests are named