### PR TITLE
WIP: Added glob-capabilities to `Pages` option in `@autodocs`

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.5
 Compat 0.25
 DocStringExtensions 0.2
+Glob 1.1.1

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -20,7 +20,7 @@ import .Documents:
     MetaNode
 
 using Compat
-
+import Glob
 
 function expand(doc::Documents.Document)
     for (src, page) in doc.internal.pages
@@ -351,7 +351,7 @@ function Selectors.runner(::Type{AutoDocsBlocks}, x, page, doc)
                             push!(results, (mod, path, category, object, isexported, docstr))
                         else
                             for p in pages
-                                if endswith(path, p)
+                                if ismatch(Glob.FilenameMatch(p), path)
                                     push!(results, (mod, p, category, object, isexported, docstr))
                                     break
                                 end


### PR DESCRIPTION
Now the `@autodocs` block supports glob-matching:
````
```@autodocs
Modules = [SomeModule]
Pages = ["*/SomeModule.jl", "*/sub-folder/*"]
```
````

Note that this is not backward compatible, but maybe could be made so.

Needs tests & test updates.  Let me know if this is of interest and I can finish it.