### PR TITLE
Add style for <kbd>

### DIFF
--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -105,6 +105,20 @@ pre code {
     background-color: initial;
 }
 
+kbd {
+    font: 11px "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+    display: inline-block;
+    padding: 3px 5px;
+    line-height: 10px;
+    color: #444d56;
+    vertical-align: middle;
+    background-color: #fafbfc;
+    border: solid 1px #c6cbd1;
+    border-bottom-color: #959da5;
+    border-radius: 3px;
+    box-shadow: inset 0 -1px 0 #959da5;
+}
+
 /* Headers in admonitions and docstrings */
 .admonition h1,
 article section.docstring h1 {

--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -20,7 +20,7 @@ body, input {
   text-rendering: optimizeLegibility;
 }
 
-pre, code {
+pre, code, kbd {
   font-family: 'Roboto Mono', Monaco, courier, monospace;
   font-size: 0.90em;
 }
@@ -106,10 +106,10 @@ pre code {
 }
 
 kbd {
-    font: 11px "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+    font-size: 0.70em;
     display: inline-block;
-    padding: 3px 5px;
-    line-height: 10px;
+    padding: 0.1em 0.5em 0.4em 0.5em;
+    line-height: 1.0em;
     color: #444d56;
     vertical-align: middle;
     background-color: #fafbfc;

--- a/test/examples/src/man/tutorial.md
+++ b/test/examples/src/man/tutorial.md
@@ -221,3 +221,12 @@ Dowload [`data.csv`](data.csv).
 ## [Links](../index.md) in headers
 
 ... are dropped in the navigation links.
+
+
+## Embedding raw HTML
+
+Below is a nicely rendered version of `^D`:
+
+```@raw html
+<kbd>Ctrl</kbd> + <kbd>D</kbd>
+```


### PR DESCRIPTION
Added CSS styling for the `<kbd>` HTML tag which allows Markdown like:

````md
```@raw html
<kbd>Ctrl</kbd> + <kbd>D</kbd>
```
````

To render as:

<kbd>Ctrl</kbd> + <kbd>D</kbd>

Styling was based off GitHub