### PR TITLE
take more space above headings

### DIFF
--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -47,8 +47,8 @@ body {
 }
 
 h1 { font-size: 1.75em; }
-h2 { font-size: 1.50em; }
-h3 { font-size: 1.25em; }
+h2 { font-size: 1.50em; margin: 1.75em 0 0; border-bottom: 1px solid #ddd; }
+h3 { font-size: 1.25em; margin: 1.50em 0 0; }
 h4 { font-size: 1.15em; }
 h5 { font-size: 1.10em; }
 h6 { font-size: 1em; }

--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -50,20 +50,19 @@ h1 {
     font-size: 1.75em;
 }
 article > h1:not(:nth-child(2)) {
-    margin: 2.00em 0 0;
+    margin: 2.5em 0 0;
     padding-bottom: 0.30em;
     border-bottom: 1px solid #e5e5e5;
 }
 h2 {
     font-size: 1.50em;
-    margin: 1.75em 0 0;
+    margin: 2.3em 0 0;
     padding-bottom: 0.25em;
     border-bottom: 1px solid #e5e5e5;
 }
 h3 {
     font-size: 1.25em;
-    margin: 1.50em 0 0;
-    padding-bottom: 0.20em;
+    margin: 2.0em 0 0;
 }
 h4 { font-size: 1.15em; }
 h5 { font-size: 1.10em; }

--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -47,8 +47,8 @@ body {
 }
 
 h1 { font-size: 1.75em; }
-h2 { font-size: 1.50em; margin: 1.75em 0 0; border-bottom: 1px solid #e5e5e5; }
-h3 { font-size: 1.25em; margin: 1.50em 0 0; }
+h2 { font-size: 1.50em; margin: 1.75em 0 0; padding-bottom: 0.25em; border-bottom: 1px solid #e5e5e5; }
+h3 { font-size: 1.25em; margin: 1.50em 0 0; padding-bottom: 0.20em; }
 h4 { font-size: 1.15em; }
 h5 { font-size: 1.10em; }
 h6 { font-size: 1em; }

--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -49,6 +49,12 @@ body {
 h1 {
     font-size: 1.75em;
 }
+
+/* Unless the <h1> the is very first thing on the page (i.e. the second element
+ * in the <article>, * after the <header>, we add some additional styling to it
+ * to make it stand out a bit more. This way we get a reasonable fallback if CSS3
+ * selectors are not supported in the browser.
+ */
 article > h1:not(:nth-child(2)) {
     margin: 2.5em 0 0;
     padding-bottom: 0.30em;
@@ -69,7 +75,8 @@ h5 { font-size: 1.10em; }
 h6 { font-size: 1em; }
 
 h4, h5, h6 {
-    margin: 1em 0;
+    margin-top: 1.5em;
+    margin-bottom: 1em;
 }
 
 img {

--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -47,7 +47,7 @@ body {
 }
 
 h1 { font-size: 1.75em; }
-h2 { font-size: 1.50em; margin: 1.75em 0 0; border-bottom: 1px solid #ddd; }
+h2 { font-size: 1.50em; margin: 1.75em 0 0; border-bottom: 1px solid #e5e5e5; }
 h3 { font-size: 1.25em; margin: 1.50em 0 0; }
 h4 { font-size: 1.15em; }
 h5 { font-size: 1.10em; }

--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -46,9 +46,25 @@ body {
     line-height: 1.5;
 }
 
-h1 { font-size: 1.75em; }
-h2 { font-size: 1.50em; margin: 1.75em 0 0; padding-bottom: 0.25em; border-bottom: 1px solid #e5e5e5; }
-h3 { font-size: 1.25em; margin: 1.50em 0 0; padding-bottom: 0.20em; }
+h1 {
+    font-size: 1.75em;
+}
+article > h1:not(:nth-child(2)) {
+    margin: 2.00em 0 0;
+    padding-bottom: 0.30em;
+    border-bottom: 1px solid #e5e5e5;
+}
+h2 {
+    font-size: 1.50em;
+    margin: 1.75em 0 0;
+    padding-bottom: 0.25em;
+    border-bottom: 1px solid #e5e5e5;
+}
+h3 {
+    font-size: 1.25em;
+    margin: 1.50em 0 0;
+    padding-bottom: 0.20em;
+}
 h4 { font-size: 1.15em; }
 h5 { font-size: 1.10em; }
 h6 { font-size: 1em; }


### PR DESCRIPTION
I'd like to suggest allocating more space above headings to make a section visually separable to the next section as follows (left: current, right: proposed)

![screen shot 2017-06-10 at 18 15 15](https://user-images.githubusercontent.com/905683/27001585-d61f942c-4e08-11e7-8dff-c858bb057cc8.png)
