### PR TITLE
Fix CurrentModule example in manual

### DIFF
--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -176,7 +176,7 @@ a per-page basis with a `@meta` block as in the following
 # Example.jl Documentation
 
 ```@meta
-CurrentModule = Documenter
+CurrentModule = Example
 ```
 
 ```@docs


### PR DESCRIPTION
The module taken as an example throughout the guide is Example, not Documenter. (Or maybe I'm missing something.)