### PR TITLE
Merge Travis CI configuration lines into a single line

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -98,8 +98,7 @@ run your `docs/make.jl` file:
 
 ```yaml
 after_success:
-  - julia -e 'Pkg.add("Documenter")'
-  - julia -e 'cd(Pkg.dir("PACKAGE_NAME")); include(joinpath("docs", "make.jl"))'
+  - julia -e 'Pkg.add("Documenter"); cd(Pkg.dir("PACKAGE_NAME")); include(joinpath("docs", "make.jl"))'
 ```
 
 ## The `deploydocs` Function


### PR DESCRIPTION
This is cleaner when packages have another line for e.g. coverage.

Was there a particular reason to use two lines?