### PR TITLE
Render arbitrary markdown files

### DIFF
--- a/docs/src/man/examples.md
+++ b/docs/src/man/examples.md
@@ -30,6 +30,7 @@ Packages that have tagged versions available in `METADATA.jl`.
 - [EzXML.jl](https://bicycle1885.github.io/EzXML.jl/latest/)
 - [Highlights.jl](https://juliadocs.github.io/Highlights.jl/latest/)
 - [IntervalConstraintProgramming.jl](https://juliaintervals.github.io/IntervalConstraintProgramming.jl/latest/)
+- [JuliaImages](http://juliaimages.github.io/latest/) (organization-level documentation)
 - [Luxor.jl](https://juliagraphics.github.io/Luxor.jl/stable/)
 - [MergedMethods.jl](https://michaelhatherly.github.io/MergedMethods.jl/latest/)
 - [Mimi.jl](http://anthofflab.berkeley.edu/Mimi.jl/stable/)

--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -345,3 +345,17 @@ See [Hosting Documentation](@ref) for further information on configuring MkDocs 
     of the navigation menu.
 
     **`pages`** defines the hierarchy of the navigation menu.
+
+## Rendering arbitrary markdown files
+
+You can use Documenter to preview arbitrary markdown files like this (example on Linux):
+
+```sh
+cd /tmp
+mkdir src/
+ln -s /path/to/README.md src/
+julia -e "using Documenter; makedocs(format = :html)"
+```
+
+The rendered markdown file(s) (all the ones placed in `src/`) will be
+in a new directory called `build/`.

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -94,8 +94,6 @@ getpage(ctx, navnode::Documents.NavNode) = getpage(ctx, get(navnode.page))
 
 
 function render(doc::Documents.Document)
-    !isempty(doc.user.sitename) || error("HTML output requires `sitename`.")
-
     ctx = HTMLContext(doc)
     ctx.search_index_js = "search_index.js"
 
@@ -400,8 +398,10 @@ function render_article(ctx, navnode)
         host = "BitBucket"
         logo = "\uf171"
     end
-    Utilities.unwrap(Utilities.url(ctx.doc.user.repo, getpage(ctx, navnode).source)) do url
-        push!(topnav.nodes, a[".edit-page", :href => url](span[".fa"](logo), " Edit on $host"))
+    if !isempty(ctx.doc.user.sitename)
+        Utilities.unwrap(Utilities.url(ctx.doc.user.repo, getpage(ctx, navnode).source)) do url
+            push!(topnav.nodes, a[".edit-page", :href => url](span[".fa"](logo), " Edit on $host"))
+        end
     end
     art_header = header(topnav, hr(), render_topbar(ctx, navnode))
 


### PR DESCRIPTION
Not sure if you want this, but I found it handy to preview a README.md file for another package. Yes, there are many markdown renderers out there, but Documenter is the one that counts :wink:.