### PR TITLE
Correct length to endof in SubString call

### DIFF
--- a/src/Utilities/TextDiff.jl
+++ b/src/Utilities/TextDiff.jl
@@ -48,7 +48,7 @@ function splitby(reg::Regex, text::AbstractString)
         push!(out, SubString(text, last, each.match.offset + each.match.endof))
         last = each.match.endof + each.offset
     end
-    local laststr = SubString(text, last, endof(text))
+    local laststr = SubString(text, last)
     isempty(laststr) || push!(out, laststr)
     return out
 end

--- a/src/Utilities/TextDiff.jl
+++ b/src/Utilities/TextDiff.jl
@@ -48,7 +48,7 @@ function splitby(reg::Regex, text::AbstractString)
         push!(out, SubString(text, last, each.match.offset + each.match.endof))
         last = each.match.endof + each.offset
     end
-    local laststr = SubString(text, last, length(text))
+    local laststr = SubString(text, last, endof(text))
     isempty(laststr) || push!(out, laststr)
     return out
 end


### PR DESCRIPTION
`length` will fail on multibyte `Char`.
E.g.
```
x = "∀∀∀"
length(x) # 3 - results incorrect indexing
endof(x) # 7 - correct index of last Char
```

This is part of the fix needed for https://github.com/JuliaLang/julia/pull/22511.

Fixes #470.