### PR TITLE
add option to ignore stacktraces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 test/examples/builds/
 test/missingdocs/build/
 test/errors/build/
+test/doctest_stacktrace/build/
 docs/build/
 docs/site/

--- a/docs/src/man/doctests.md
+++ b/docs/src/man/doctests.md
@@ -105,6 +105,9 @@ ERROR: DivideError: integer division error
 ```
 ````
 
+It is possible to have Documenter ignore backtraces when running the doctests by setting
+the keyword argument `doctest_stacktraces` to `false` when calling [`makedocs`](@ref).
+
 ## Preserving definitions between blocks
 
 Every doctest block is evaluated inside its own `module`. This means that definitions

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -245,6 +245,12 @@ function checkresult(sandbox::Module, result::Result, doc::Documents.Document)
         # mark ignored output from an error message. Only the text prior to it is used to
         # test for doctest success/failure.
         head = replace(split(result.output, "\n[...]"; limit = 2)[1], mod_regex, "")
+        # Sometimes we want to show backtraces in doctests but not make the build fail
+        # if the stacktrace in the doctest is no longer correct (for example to run doctests in CI
+        # on Base Julia).
+        if !doc.user.doctest_stacktraces
+            head = split(result.output, "\nStacktrace:\n [1] ";)[1]
+        end
         str  = replace(error_to_string(result.stdout, result.value, result.bt), mod_regex, "")
         # Since checking for the prefix of an error won't catch the empty case we need
         # to check that manually with `isempty`.

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -174,6 +174,9 @@ ignored.
 **`strict`** -- [`makedocs`](@ref) fails the build right before rendering if it encountered
 any errors with the document in the previous build phases.
 
+**`doctest_stacktraces`** -- [`makedocs`](@ref) do not consider an erronous stacktrace
+for a doctest as a doctest failure.
+
 ## Non-MkDocs builds
 
 Documenter also has (experimental) support for native HTML and LaTeX builds.

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -185,6 +185,7 @@ immutable User
     format  :: Vector{Symbol} # What format to render the final document with?
     clean   :: Bool           # Empty the `build` directory before starting a new build?
     doctest :: Bool           # Run doctests?
+    doctest_stacktraces::Bool # Check stacktraces in doctests
     linkcheck::Bool           # Check external links..
     linkcheck_ignore::Vector{Union{String,Regex}}  # ..and then ignore (some of) them.
     checkdocs::Symbol         # Check objects missing from `@docs` blocks. `:none`, `:exports`, or `:all`.
@@ -236,6 +237,7 @@ function Document(;
         format   :: Any              = :markdown,
         clean    :: Bool             = true,
         doctest  :: Bool             = true,
+        doctest_stacktraces::Bool    = true,
         linkcheck:: Bool             = false,
         linkcheck_ignore :: Vector   = [],
         checkdocs::Symbol            = :all,
@@ -266,6 +268,7 @@ function Document(;
         fmt,
         clean,
         doctest,
+        doctest_stacktraces,
         linkcheck,
         linkcheck_ignore,
         checkdocs,

--- a/test/doctest_stacktrace/make.jl
+++ b/test/doctest_stacktrace/make.jl
@@ -1,0 +1,26 @@
+module ErrorsModule
+
+"""
+    f()
+
+This function throws an exception
+
+```jldoctest
+julia> using ErrorsModule
+
+julia> ErrorsModule.f()
+ERROR:
+Stacktrace:
+ [1] f() at ./make.jl:666666666666666666
+
+julia> 1 + 1
+2
+```
+"""
+f() = throw(ErrorException(""))
+
+end
+
+using Documenter
+
+makedocs(modules = [ErrorsModule], doctest_stacktraces = false)

--- a/test/doctest_stacktrace/src/index.md
+++ b/test/doctest_stacktrace/src/index.md
@@ -1,0 +1,3 @@
+```@docs
+ErrorsModule.f
+```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,9 @@ include("examples/make.jl")
 # Test missing docs
 include("missingdocs/make.jl")
 
+# Test ignoring stacktraces in doctests
+include("doctest_stacktrace/make.jl")
+
 # Primary @testset
 
 if VERSION >= v"0.5.0-dev+7720"


### PR DESCRIPTION
This makes it feasible to run doctests as a part of CI on e.g. Base Julai