### PR TITLE
Replace ANY with Any in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Please open an [issue][issues-url] if you encounter any problems. If you have a 
 [travis-img]: https://travis-ci.org/JuliaDocs/Documenter.jl.svg?branch=master
 [travis-url]: https://travis-ci.org/JuliaDocs/Documenter.jl
 
-[appveyor-img]: https://ci.appveyor.com/api/projects/status/egdu3hrptf3mnfc6/branch/master?svg=true
-[appveyor-url]: https://ci.appveyor.com/project/MichaelHatherly/documenter-jl-bqgcw/branch/master
+[appveyor-img]: https://ci.appveyor.com/api/projects/status/xx7nimfpnl1r4gx0?svg=true
+[appveyor-url]: https://ci.appveyor.com/project/JuliaDocs/documenter-jl
 
 [codecov-img]: https://codecov.io/gh/JuliaDocs/Documenter.jl/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/JuliaDocs/Documenter.jl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,10 @@ environment:
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
+matrix:
+  allow_failures:
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+
 notifications:
   - provider: Email
     on_build_success: false

--- a/test/docsystem.jl
+++ b/test/docsystem.jl
@@ -50,7 +50,7 @@ const alias_of_getdocs = DocSystem.getdocs # NOTE: won't get docstrings if in a 
     let b   = DocSystem.binding(DocSystem, :getdocs),
         d_0 = DocSystem.getdocs(b, Tuple{}),
         d_1 = DocSystem.getdocs(b),
-        d_2 = DocSystem.getdocs(b, Union{Tuple{ANY}, Tuple{ANY, Type}}; compare = (==)),
+        d_2 = DocSystem.getdocs(b, Union{Tuple{Any}, Tuple{Any, Type}}; compare = (==)),
         d_3 = DocSystem.getdocs(b; modules = Module[Main]),
         d_4 = DocSystem.getdocs(DocSystem.binding(current_module(), :alias_of_getdocs)),
         d_5 = DocSystem.getdocs(DocSystem.binding(current_module(), :alias_of_getdocs); aliases = false)
@@ -65,12 +65,12 @@ const alias_of_getdocs = DocSystem.getdocs # NOTE: won't get docstrings if in a 
         @test d_1[1].data[:binding] == b
         @test d_1[2].data[:binding] == b
         @test d_1[1].data[:typesig] == Union{Tuple{Docs.Binding}, Tuple{Docs.Binding, Type}}
-        @test d_1[2].data[:typesig] == Union{Tuple{ANY}, Tuple{ANY, Type}}
+        @test d_1[2].data[:typesig] == Union{Tuple{Any}, Tuple{Any, Type}}
         @test d_1[1].data[:module]  == DocSystem
         @test d_1[2].data[:module]  == DocSystem
 
         @test d_2[1].data[:binding] == b
-        @test d_2[1].data[:typesig] == Union{Tuple{ANY}, Tuple{ANY, Type}}
+        @test d_2[1].data[:typesig] == Union{Tuple{Any}, Tuple{Any, Type}}
         @test d_2[1].data[:module]  == DocSystem
 
         @test d_1 == d_4


### PR DESCRIPTION
On v0.7 the behaviour of `ANY` changed, so `Any` and `ANY` are no longer equivalent.