### PR TITLE
Update the supported/tested julia versions in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ julia> Pkg.add("Documenter")
 
 ## Project Status
 
-The package is tested against Julia `0.4`, `0.5`, and *current* `0.6-dev` on Linux, OS X, and Windows.
+The package is tested against Julia `0.5`, `0.6` and *current* `0.7-dev` on Linux, OS X, and Windows.
 
 ## Contributing and Questions
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,7 +15,7 @@ A package for building documentation from docstrings and markdown files.
 
 - Write all your documentation in [Markdown](https://en.wikipedia.org/wiki/Markdown).
 - Minimal configuration.
-- Supports Julia `0.4` and `0.5-dev`.
+- Supports Julia `0.5`, `0.6` and `0.7-dev`.
 - Doctests Julia code blocks.
 - Cross references for docs and section headers.
 - [``\LaTeX`` syntax](@ref latex_syntax) support.


### PR DESCRIPTION
Updates the julia versions which are currently supported (`REQUIRE`) and tested against (appveyor and travis configs) in the repo readme and the base documentation page.