### PR TITLE
Allow HTMLWriter to proceed when not using git

### DIFF
--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -196,6 +196,7 @@ struct User
     analytics::String
     version :: String # version string used in the version selector by default
     html_prettyurls :: Bool # Use pretty URLs in the HTML build?
+    html_disable_git :: Bool # Don't call git when exporting HTML
 end
 
 """
@@ -248,6 +249,7 @@ function Document(;
         analytics :: AbstractString = "",
         version :: AbstractString = "",
         html_prettyurls :: Bool = false,
+        html_disable_git :: Bool = false,
         others...
     )
     Utilities.check_kwargs(others)
@@ -279,6 +281,7 @@ function Document(;
         analytics,
         version,
         html_prettyurls,
+        html_disable_git,
     )
     internal = Internal(
         Utilities.assetsdir(),

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -403,8 +403,10 @@ function render_article(ctx, navnode)
         host = "BitBucket"
         logo = "\uf171"
     end
-    Utilities.unwrap(Utilities.url(ctx.doc.user.repo, getpage(ctx, navnode).source)) do url
-        push!(topnav.nodes, a[".edit-page", :href => url](span[".fa"](logo), " Edit on $host"))
+    if !ctx.doc.user.html_disable_git
+        Utilities.unwrap(Utilities.url(ctx.doc.user.repo, getpage(ctx, navnode).source)) do url
+            push!(topnav.nodes, a[".edit-page", :href => url](span[".fa"](logo), " Edit on $host"))
+        end
     end
     art_header = header(topnav, hr(), render_topbar(ctx, navnode))
 
@@ -644,8 +646,10 @@ function domify_doc(ctx, navnode, md::Markdown.MD)
             markdown, result = md
             ret = Any[domify(ctx, navnode, Writers.MarkdownWriter.dropheaders(markdown))]
             # When a source link is available then print the link.
-            Utilities.unwrap(Utilities.url(ctx.doc.internal.remote, ctx.doc.user.repo, result)) do url
-                push!(ret, a[".source-link", :target=>"_blank", :href=>url]("source"))
+            if !ctx.doc.user.html_disable_git
+                Utilities.unwrap(Utilities.url(ctx.doc.internal.remote, ctx.doc.user.repo, result)) do url
+                    push!(ret, a[".source-link", :target=>"_blank", :href=>url]("source"))
+                end
             end
             ret
         end

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -5,12 +5,18 @@ A module for rendering `Document` objects to HTML.
 
 [`HTMLWriter`](@ref) uses the following additional keyword arguments that can be passed to
 [`Documenter.makedocs`](@ref): `assets`, `sitename`, `analytics`, `authors`, `pages`,
-`version`, `html_prettyurls`.
+`version`, `html_prettyurls`, `html_disable_git`.
 
 **`version`** specifies the version string of the current version which will be the
 selected option in the version selector. If this is left empty (default) the version
 selector will be hidden. The special value `git-commit` sets the value in the output to
 `git:{commit}`, where `{commit}` is the first few characters of the current commit hash.
+
+**`html_disable_git`** can be used to disable calls to `git` when the document is not
+in a Git-controlled repository. Without setting this to `true`, Documenter will throw
+an error and exit if any of the Git commands fail. The calls to Git are mainly used to
+gather information about the current commit hash and file paths, necessary for constructing
+the links to the remote repository.
 
 # Page outline
 


### PR DESCRIPTION
I have a few Julia packages that I use at work.  They are version controlled, but not with git.

Currently, Documenter's HTML writer will die when run on a package that isn't using git.  There are a few git commands that are used to generate URLs for links to the source code.  This PR allows the `Utilities.url` functions to return null results if the git commands fail, such that the HTML writer can proceed and just not include links.

I also broke out new utility functions for getting the path of a file relative to the repository root and the commit of a file.  The new functions redirect stderr, to hide the git errors.