### PR TITLE
avoid introducing binding for String

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.5
-Compat 0.25
+Compat 0.29
 DocStringExtensions 0.2

--- a/src/Utilities/DOM.jl
+++ b/src/Utilities/DOM.jl
@@ -99,7 +99,7 @@ import ..Utilities
 using Compat
 
 if VERSION < v"0.5.0-dev"
-    const String = UTF8String
+    @eval const String = UTF8String
     tostr(p::Pair) = p[1] => utf8(p[2])
 else
     tostr(p::Pair) = p


### PR DESCRIPTION
this ensures that we only introduce package-local bindings for values
that we define in this package

ref JuliaLang/julia#22984