### PR TITLE
fix some MathJax links to the latest CDN provider

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -169,7 +169,7 @@ extra_css:
   - assets/Documenter.css
 
 extra_javascript:
-  - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML
+  - https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML
   - assets/mathjaxhelper.js
 
 markdown_extensions:

--- a/docs/src/man/latex.md
+++ b/docs/src/man/latex.md
@@ -165,7 +165,7 @@ markdown_extensions:
   # ...
 
 extra_javascript:
-  - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML
+  - https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML
   - assets/mathjaxhelper.js
 # ...
 ```

--- a/test/examples/mkdocs.yml
+++ b/test/examples/mkdocs.yml
@@ -20,7 +20,7 @@ markdown_extensions:
   - fenced_code
 
 extra_javascript:
-  - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML
+  - https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML
   - assets/mathjaxhelper.js
 
 docs_dir: 'build'


### PR DESCRIPTION
This fixes some links that still point to the old CDN.
https://www.mathjax.org/cdn-shutting-down/