### PR TITLE
add ignore_pointers option

### DIFF
--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -291,9 +291,9 @@ end
 
 function remove_pointers(str)
     if Sys.WORD_SIZE == 64
-        ptr_regex = r"@0x[0-9a-z]{16}"
+        ptr_regex = r"@0x[0-9a-f]{16}"
     elseif Sys.WORD_SIZE == 32
-        ptr_regex = r"@0x[0-9a-z]{8}"
+        ptr_regex = r"@0x[0-9a-f]{8}"
     else
         error("cannot determine pointer size")
     end

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -258,9 +258,9 @@ function checkresult(sandbox::Module, result::Result, doc::Documents.Document)
         str = replace(str, Regex(string(sandbox)), "Main")
         output = replace(strip(sanitise(IOBuffer(result.output))), mod_regex, "")
         expected = strip(str)
-        if doc.user.ignore_pointers
-            expected = remove_pointers(expected)
-            output   = remove_pointers(output)
+        if !isnull(doc.user.pattern_ignore)
+            expected = replace(expected, get(doc.user.pattern_ignore), "")
+            output   = replace(output,   get(doc.user.pattern_ignore), "")
         end
         expected == output || report(result, str, doc)
     end
@@ -287,17 +287,6 @@ function result_to_string(buf, value)
         eval(Expr(:call, display, dis, QuoteNode(value)))
     end
     sanitise(buf)
-end
-
-function remove_pointers(str)
-    if Sys.WORD_SIZE == 64
-        ptr_regex = r"@0x[0-9a-f]{16}"
-    elseif Sys.WORD_SIZE == 32
-        ptr_regex = r"@0x[0-9a-f]{8}"
-    else
-        error("cannot determine pointer size")
-    end
-    return replace(str, ptr_regex, "")
 end
 
 if VERSION < v"0.5.0-dev+4305"

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -189,6 +189,7 @@ immutable User
     linkcheck_ignore::Vector{Union{String,Regex}}  # ..and then ignore (some of) them.
     checkdocs::Symbol         # Check objects missing from `@docs` blocks. `:none`, `:exports`, or `:all`.
     strict::Bool              # Throw an exception when any warnings are encountered.
+    ignore_pointers::Bool     # Ignore difference of pointers in doctests.
     modules :: Set{Module}    # Which modules to check for missing docs?
     pages   :: Vector{Any}    # Ordering of document pages specified by the user.
     assets  :: Vector{Compat.String}
@@ -241,6 +242,7 @@ function Document(;
         linkcheck_ignore :: Vector   = [],
         checkdocs::Symbol            = :all,
         strict::Bool                 = false,
+        ignore_pointers::Bool        = false,
         modules  :: Utilities.ModVec = Module[],
         pages    :: Vector           = Any[],
         assets   :: Vector           = Compat.String[],
@@ -272,6 +274,7 @@ function Document(;
         linkcheck_ignore,
         checkdocs,
         strict,
+        ignore_pointers,
         Utilities.submodules(modules),
         pages,
         assets,

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -189,7 +189,7 @@ immutable User
     linkcheck_ignore::Vector{Union{String,Regex}}  # ..and then ignore (some of) them.
     checkdocs::Symbol         # Check objects missing from `@docs` blocks. `:none`, `:exports`, or `:all`.
     strict::Bool              # Throw an exception when any warnings are encountered.
-    ignore_pointers::Bool     # Ignore difference of pointers in doctests.
+    pattern_ignore::Nullable{Regex}  # Ignore differences that match this pattern in doctests.
     modules :: Set{Module}    # Which modules to check for missing docs?
     pages   :: Vector{Any}    # Ordering of document pages specified by the user.
     assets  :: Vector{Compat.String}
@@ -242,7 +242,7 @@ function Document(;
         linkcheck_ignore :: Vector   = [],
         checkdocs::Symbol            = :all,
         strict::Bool                 = false,
-        ignore_pointers::Bool        = false,
+        pattern_ignore::Union{Regex,Void} = nothing,
         modules  :: Utilities.ModVec = Module[],
         pages    :: Vector           = Any[],
         assets   :: Vector           = Compat.String[],
@@ -274,7 +274,7 @@ function Document(;
         linkcheck_ignore,
         checkdocs,
         strict,
-        ignore_pointers,
+        pattern_ignore,
         Utilities.submodules(modules),
         pages,
         assets,


### PR DESCRIPTION
My doctests have pointer values in the output and hence I cannot use `jldoctest` for my package. For example:
```
julia> using EzXML

julia> doc = XMLDocument()
EzXML.Document(EzXML.Node(<DOCUMENT_NODE@0x00007fa2ec190b70>))

```

The pointer values change from run to run, which results in failure when running doctests.

This pull request adds `ignore_pointers` option to `makedocs`. When `ignore_pointers=true`, the checker trims substrings that look like a pointer value and then compares the results. The default is `false`, so this does not change the behavior at all by default.