### PR TITLE
Fix #553, @autodocs can't handle parameterized types

### DIFF
--- a/src/DocSystem.jl
+++ b/src/DocSystem.jl
@@ -373,6 +373,9 @@ function category(b::Docs.Binding)
 end
 category(::Function) = :function
 category(::DataType) = :type
+if isdefined(Base, :UnionAll)
+    category(x::UnionAll) = category(Base.unwrap_unionall(x))
+end
 category(::Module) = :module
 category(::Any) = :constant
 

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -294,7 +294,7 @@ doccat(b::Binding, ::Type)  = "Method"
 doccat(::Function) = "Function"
 doccat(::DataType) = "Type"
 if isdefined(Base, :UnionAll)
-    doccat(::UnionAll) = "Type"
+    doccat(x::UnionAll) = doccat(Base.unwrap_unionall(x))
 end
 doccat(::Module)   = "Module"
 doccat(::Any)      = "Constant"

--- a/test/examples/pages/e.jl
+++ b/test/examples/pages/e.jl
@@ -29,4 +29,7 @@ mutable struct T_1 end
 "T_2"
 mutable struct T_2 end
 
+"T_3"
+immutable T_3{T} end
+
 end

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -74,7 +74,7 @@ using Compat
             end
         end
 
-        @test length(doc.internal.objects) == 37
+        @test length(doc.internal.objects) == 38
     end
 
     @testset "HTML" begin


### PR DESCRIPTION
Handle `UnionAll` in `category`.

Also handle `UnionAll` in `doccat` in a more correct way (at least in my opinion).

Could use more tests; I see that there are currently no direct tests for `category`. Should I add some, and if so, where?

Fixes #553.