### PR TITLE
Fix some deprecated syntax

### DIFF
--- a/src/CrossReferences.jl
+++ b/src/CrossReferences.jl
@@ -127,7 +127,7 @@ function docsxref(link::Markdown.Link, code, meta, page, doc)
             return
         end
     end
-    local mod = get(meta, :CurrentModule, current_module())
+    local mod = get(meta, :CurrentModule, @__MODULE__())
 
     # Find binding and type signature associated with the link.
     local binding

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -135,7 +135,7 @@ function doctest(block::Markdown.Code, meta::Dict, doc::Documents.Document, page
         local sym = isempty(name) ? gensym("doctest-") : Symbol("doctest-", name)
         local sandbox = get!(page.globals.meta, sym) do
             newmod = Module(sym)
-            eval(newmod, :(eval(x) = Core.eval(current_module(), x)))
+            eval(newmod, :(eval(x) = Core.eval(@__MODULE__(), x)))
             eval(newmod, :(eval(m, x) = Core.eval(m, x)))
             newmod
         end

--- a/src/DocSystem.jl
+++ b/src/DocSystem.jl
@@ -31,18 +31,18 @@ binding(any::Any) = throw(ArgumentError("cannot convert `$any` to a `Binding`.")
 binding(b::Docs.Binding) = binding(b.mod, b.var)
 binding(d::DataType)     = binding(d.name.module, d.name.name)
 binding(m::Module)       = binding(m, module_name(m))
-binding(s::Symbol)       = binding(current_module(), s)
+binding(s::Symbol)       = binding(@__MODULE__(), s)
 
 #
 # In `0.4` some functions aren't generic, hence the `isgeneric` check here.
-# We punt on using `current_module` in when not generic, which may cause
+# We punt on using `@__MODULE__` in when not generic, which may cause
 # trouble when calling this function with a qualified name.
 #
 if VERSION < v"0.5.0-dev"
     binding(f::Function) =
         isgeneric(f) ?
             binding(f.env.module, f.env.name) :
-            binding(current_module(), f.env)
+            binding(@__MODULE__(), f.env)
 else
     binding(f::Function) = binding(typeof(f).name.module, typeof(f).name.mt.name)
 end

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -28,7 +28,7 @@ type Globals
     mod  :: Module
     meta :: Dict{Symbol, Any}
 end
-Globals() = Globals(current_module(), Dict())
+Globals() = Globals(@__MODULE__(), Dict())
 
 """
 Represents a single markdown file.
@@ -376,7 +376,7 @@ end
 ## Utilities.
 
 function buildnode(T::Type, block, doc, page)
-    mod  = get(page.globals.meta, :CurrentModule, current_module())
+    mod  = get(page.globals.meta, :CurrentModule, @__MODULE__())
     dict = Dict{Symbol, Any}(:source => page.source, :build => page.build)
     for (ex, str) in Utilities.parseblock(block.code, doc, page)
         if Utilities.isassign(ex)

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -230,7 +230,7 @@ function Selectors.runner(::Type{MetaBlocks}, x, page, doc)
     for (ex, str) in Utilities.parseblock(x.code, doc, page)
         if Utilities.isassign(ex)
             try
-                meta[ex.args[1]] = eval(current_module(), ex.args[2])
+                meta[ex.args[1]] = eval(@__MODULE__(), ex.args[2])
             catch err
                 push!(doc.internal.errors, :meta_block)
                 Utilities.warn(doc, page, "Failed to evaluate `$(strip(str))` in `@meta` block.", err)
@@ -246,7 +246,7 @@ end
 function Selectors.runner(::Type{DocsBlocks}, x, page, doc)
     failed = false
     nodes  = DocsNode[]
-    curmod = get(page.globals.meta, :CurrentModule, current_module())
+    curmod = get(page.globals.meta, :CurrentModule, @__MODULE__())
     for (ex, str) in Utilities.parseblock(x.code, doc, page)
         local binding = try
             Documenter.DocSystem.binding(curmod, ex)
@@ -316,7 +316,7 @@ end
 const AUTODOCS_DEFAULT_ORDER = [:module, :constant, :type, :function, :macro]
 
 function Selectors.runner(::Type{AutoDocsBlocks}, x, page, doc)
-    curmod = get(page.globals.meta, :CurrentModule, current_module())
+    curmod = get(page.globals.meta, :CurrentModule, @__MODULE__())
     fields = Dict{Symbol, Any}()
     for (ex, str) in Utilities.parseblock(x.code, doc, page)
         if Utilities.isassign(ex)

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -232,7 +232,7 @@ function splitexpr(x::Expr)
     isexpr(x, :.)         ? (x.args[1], x.args[2]) :
     error("Invalid @var syntax `$x`.")
 end
-splitexpr(s::Symbol) = :(current_module()), quot(s)
+splitexpr(s::Symbol) = :(@__MODULE__()), quot(s)
 splitexpr(other)     = error("Invalid @var syntax `$other`.")
 
 """
@@ -407,7 +407,7 @@ Check if we're running under cygwin. Useful when we need to translate cygwin pat
 windows paths.
 """
 function in_cygwin()
-    if is_windows()
+    if Sys.iswindows()
         try
             return success(`cygpath -h`)
         catch

--- a/test/docsystem.jl
+++ b/test/docsystem.jl
@@ -14,7 +14,7 @@ const alias_of_getdocs = DocSystem.getdocs # NOTE: won't get docstrings if in a 
 @testset "DocSystem" begin
     ## Bindings.
     @test_throws ArgumentError DocSystem.binding(9000)
-    let b = Docs.Binding(current_module(), :DocSystem)
+    let b = Docs.Binding(@__MODULE__(), :DocSystem)
         @test DocSystem.binding(b) == b
     end
     let b = DocSystem.binding(Documenter.Documents.Document)
@@ -52,8 +52,8 @@ const alias_of_getdocs = DocSystem.getdocs # NOTE: won't get docstrings if in a 
         d_1 = DocSystem.getdocs(b),
         d_2 = DocSystem.getdocs(b, Union{Tuple{Any}, Tuple{Any, Type}}; compare = (==)),
         d_3 = DocSystem.getdocs(b; modules = Module[Main]),
-        d_4 = DocSystem.getdocs(DocSystem.binding(current_module(), :alias_of_getdocs)),
-        d_5 = DocSystem.getdocs(DocSystem.binding(current_module(), :alias_of_getdocs); aliases = false)
+        d_4 = DocSystem.getdocs(DocSystem.binding(@__MODULE__(), :alias_of_getdocs)),
+        d_5 = DocSystem.getdocs(DocSystem.binding(@__MODULE__(), :alias_of_getdocs); aliases = false)
 
         @test length(d_0) == 0
         @test length(d_1) == 2
@@ -79,7 +79,7 @@ const alias_of_getdocs = DocSystem.getdocs # NOTE: won't get docstrings if in a 
 
     ## `UnionAll`
     if isdefined(Base, :UnionAll)
-        let b = DocSystem.binding(current_module(), parse("f(x::T) where T"))
+        let b = DocSystem.binding(@__MODULE__(), parse("f(x::T) where T"))
             @test b.var == :f
         end
     end

--- a/test/dom.jl
+++ b/test/dom.jl
@@ -13,7 +13,7 @@ import Documenter.Utilities.DOM: DOM, @tags, HTMLDocument
 
 @testset "DOM" begin
     for tag in (:div, :ul, :li, :p)
-        TAG = getfield(current_module(), tag)
+        TAG = getfield(@__MODULE__(), tag)
         @test isdefined(tag)
         @test isa(TAG, DOM.Tag)
         @test TAG.name === tag
@@ -86,9 +86,9 @@ import Documenter.Utilities.DOM: DOM, @tags, HTMLDocument
             false
         end
     end
-    @test !isdefined(current_module(), :button)
+    @test !isdefined(@__MODULE__(), :button)
     locally_defined()
-    @test !isdefined(current_module(), :button)
+    @test !isdefined(@__MODULE__(), :button)
 
     # HTMLDocument
     @test string(HTMLDocument(div())) == "<!DOCTYPE html>\n<div></div>\n"

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -7,7 +7,7 @@
 isdefined(:examples_root) && error("examples_root is already defined\n$(@__FILE__) included multiple times?")
 
 # The `Mod` and `AutoDocs` modules are assumed to exists in the Main module.
-current_module() === Main || error("$(@__FILE__) must be included into Main.")
+@__MODULE__() === Main || error("$(@__FILE__) must be included into Main.")
 
 # Modules `Mod` and `AutoDocs`
 module Mod

--- a/test/examples/src/index.md
+++ b/test/examples/src/index.md
@@ -122,18 +122,18 @@ julia> a + 1
 # Sanitise module names
 
 ```jldoctest
-julia> type T end
+julia> mutable struct T end
 
 julia> t = T()
 T()
 
-julia> fullname(current_module())
+julia> fullname(@__MODULE__)
 ()
 
 julia> fullname(Base.Pkg)
-(:Base,:Pkg)
+(:Base, :Pkg)
 
-julia> current_module()
+julia> @__MODULE__
 Main
 ```
 

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -1,12 +1,12 @@
 # When the file is run separately we need to include make.jl which actually builds
 # the docs and defines a few modules that are referred to in the docs. The make.jl
 # has to be expected in the context of the Main module.
-if current_module() === Main && !isdefined(:examples_root)
+if @__MODULE__() === Main && !isdefined(:examples_root)
     include("make.jl")
-elseif current_module() !== Main && isdefined(Main, :examples_root)
+elseif @__MODULE__() !== Main && isdefined(Main, :examples_root)
     using Documenter
     const examples_root = Main.examples_root
-elseif current_module() !== Main && !isdefined(Main, :examples_root)
+elseif @__MODULE__() !== Main && !isdefined(Main, :examples_root)
     error("examples/make.jl has not been loaded into Main.")
 end
 


### PR DESCRIPTION
`current_module()` -> `@__MODULE__`
`is_windows()` -> `Sys.iswindows`
`type` -> `mutable struct`

The previous version gave a bunch of warnings when running the tests.