### PR TITLE
allow for custom filtering of doctests

### DIFF
--- a/docs/src/man/doctests.md
+++ b/docs/src/man/doctests.md
@@ -191,6 +191,37 @@ help avoid unintentional definitions in following doctest blocks.
     The `DocTestSetup` value is **re-evaluated** at the start of *each* doctest block
     and no state is shared between any code blocks.
 
+## Filtering Doctests
+
+A part of the output of a doctest might be non-deterministic, e.g. pointer addresses and timings.
+It is therefore possible to filter a doctest so that the deterministic part can still be tested.
+
+A filter takes the form of a regular expression.
+In a doctest, each match in the expected output and the actual output is removed before the two outputs are compared.
+Filters are added globally, i.e. applied to all doctests in the documentation, by passing a list of regular expressions to
+`makedocs` with the keyword `doctestfilters`.
+
+For more fine grained control, a list of regular expressions can also be assigned inside a `@meta` block by assigning to the variable `DocTestFilters`.
+The global filters and the filters defined in the `@meta` block are both applied to each doctest.
+
+An example is given below where some of the non-deterministic output from `@time` is filered.
+
+````markdown
+```@meta
+DocTestFilters = [r"[0-9\.]+ seconds \(.*\)"]
+```
+
+```jldoctest
+julia> @time [1,2,3,4]
+  0.000003 seconds (5 allocations: 272 bytes)
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+```
+````
+
 ## Skipping Doctests
 
 Doctesting can be disabled by setting the [`makedocs`](@ref) keyword `doctest = false`.

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -205,7 +205,7 @@ Use [`for i = 1:10 ...`](@ref for) to loop over all the numbers from 1 to 10.
 ## `@meta` block
 
 This block type is used to define metadata key/value pairs that can be used elsewhere in the
-page. Currently `CurrentModule` and `DocTestSetup` are the only recognised keys.
+page. Currently `CurrentModule`, `DocTestSetup` and `DocTestFilters` are the only recognised keys.
 
 ````markdown
 ```@meta
@@ -213,6 +213,7 @@ CurrentModule = FooBar
 DocTestSetup  = quote
     using MyPackage
 end
+DocTestFilters = [r"Stacktrace:[\s\S]+"]
 ```
 ````
 

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -186,6 +186,7 @@ struct User
     linkcheck::Bool           # Check external links..
     linkcheck_ignore::Vector{Union{String,Regex}}  # ..and then ignore (some of) them.
     checkdocs::Symbol         # Check objects missing from `@docs` blocks. `:none`, `:exports`, or `:all`.
+    doctestfilters::Vector{Regex} # Filtering for doctests
     strict::Bool              # Throw an exception when any warnings are encountered.
     modules :: Set{Module}    # Which modules to check for missing docs?
     pages   :: Vector{Any}    # Ordering of document pages specified by the user.
@@ -240,6 +241,7 @@ function Document(;
         linkcheck:: Bool             = false,
         linkcheck_ignore :: Vector   = [],
         checkdocs::Symbol            = :all,
+        doctestfilters::Vector{Regex}= Regex[],
         strict::Bool                 = false,
         modules  :: Utilities.ModVec = Module[],
         pages    :: Vector           = Any[],
@@ -247,10 +249,10 @@ function Document(;
         repo     :: AbstractString   = "",
         sitename :: AbstractString   = "",
         authors  :: AbstractString   = "",
-        analytics :: AbstractString = "",
-        version :: AbstractString = "",
-        html_prettyurls :: Bool = false,
-        html_disable_git :: Bool = false,
+        analytics :: AbstractString  = "",
+        version :: AbstractString    = "",
+        html_prettyurls  :: Bool     = false,
+        html_disable_git :: Bool     = false,
         html_edit_branch :: Union{String, Void} = "master",
         others...
     )
@@ -273,6 +275,7 @@ function Document(;
         linkcheck,
         linkcheck_ignore,
         checkdocs,
+        doctestfilters,
         strict,
         Utilities.submodules(modules),
         pages,

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -100,6 +100,7 @@ examples_html_doc = makedocs(
     root  = examples_root,
     build = "builds/html",
     format   = :html,
+    doctestfilters = [r"Ptr{0x[0-9]+}"],
     assets = ["assets/custom.css"],
     sitename = "Documenter example",
     pages    = Any[
@@ -132,6 +133,7 @@ examples_html_doc = makedocs(
     build = "builds/html-pretty-urls",
     format   = :html,
     html_prettyurls = true,
+    doctestfilters = [r"Ptr{0x[0-9]+}"],
     assets = [
         "assets/favicon.ico",
         "assets/custom.css"

--- a/test/examples/src/index.md
+++ b/test/examples/src/index.md
@@ -119,6 +119,47 @@ julia> a + 1
 2
 ```
 
+# Filtered doctests
+
+## Global
+
+```jldoctest
+julia> print("Ptr{0x123456}")
+Ptr{0x654321}
+```
+
+## Local
+```@meta
+DocTestFilters = [r"foo[a-z]+"]
+```
+
+```jldoctest
+julia> print("foobar")
+foobuu
+```
+
+```@meta
+DocTestFilters = []
+```
+
+## Errors
+
+```@meta
+DocTestFilters = [r"Stacktrace:\n \[1\][\s\S]+"]
+```
+
+```jldoctest
+julia> error()
+ERROR:
+Stacktrace:
+ [1] error() at ./thisfiledoesnotexist.jl:123456789
+```
+
+```@meta
+DocTestFilters = []
+```
+
+
 # Sanitise module names
 
 ```jldoctest


### PR DESCRIPTION
Replaces https://github.com/JuliaDocs/Documenter.jl/pull/540 and perhaps https://github.com/JuliaDocs/Documenter.jl/pull/549.