### PR TITLE
Replace Nullable{T} with Union{T, Void}

### DIFF
--- a/src/Anchors.jl
+++ b/src/Anchors.jl
@@ -105,23 +105,23 @@ end
 """
 $(SIGNATURES)
 
-Returns the [`Anchor`](@ref) object matching `id`. `file` and `n` may also be provided. A
-`Nullable{Anchor}` is returned which must be unwrapped with `isnull` and `get` before use.
+Returns the [`Anchor`](@ref) object matching `id`. `file` and `n` may also be provided. An
+`Anchor` is returned, or `nothing` in case of no match.
 """
 function anchor(m::AnchorMap, id)
     isunique(m, id) ?
         anchor(m, id, first(first(m.map[id])), 1) :
-        Nullable{Anchor}()
+        nothing
 end
 function anchor(m::AnchorMap, id, file)
     isunique(m, id, file) ?
         anchor(m, id, file, 1) :
-        Nullable{Anchor}()
+        nothing
 end
 function anchor(m::AnchorMap, id, file, n)
     exists(m, id, file, n) ?
-        Nullable(m.map[id][file][n]) :
-        Nullable{Anchor}()
+        m.map[id][file][n]   :
+        nothing
 end
 
 end

--- a/src/Builder.jl
+++ b/src/Builder.jl
@@ -127,11 +127,11 @@ function Selectors.runner(::Type{SetupBuildDirectory}, doc::Documents.Document)
 
     # Finally we populate the .next and .prev fields of the navnodes that point
     # to actual pages.
-    local prev::Nullable{Documents.NavNode} = nothing
+    local prev::Union{Documents.NavNode, Void} = nothing
     for navnode in doc.internal.navlist
         navnode.prev = prev
-        Utilities.unwrap(prev) do prevnode
-            prevnode.next = navnode
+        if prev !== nothing
+            prev.next = navnode
         end
         prev = navnode
     end

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -115,10 +115,10 @@ function __ans__!(m::Module, value)
 end
 
 function doctest(block::Markdown.Code, meta::Dict, doc::Documents.Document, page)
-    matched = Utilities.nullmatch(r"jldoctest[ ]?(.*)$", block.language)
-    if !isnull(matched)
+    m = match(r"jldoctest[ ]?(.*)$", block.language)
+    if m !== nothing
         # Define new module or reuse an old one from this page if we have a named doctest.
-        name = Utilities.getmatch(matched, 1)
+        name = m[1]
         sym = isempty(name) ? gensym("doctest-") : Symbol("doctest-", name)
         sandbox = get!(page.globals.meta, sym) do
             newmod = Module(sym)
@@ -335,19 +335,19 @@ function repl_splitter(code)
         # REPL code blocks may contain leading lines with comments. Drop them.
         # TODO: handle multiline comments?
         startswith(line, '#') && continue
-        prompt = Utilities.nullmatch(PROMPT_REGEX, line)
-        if isnull(prompt)
-            source = Utilities.nullmatch(SOURCE_REGEX, line)
-            if isnull(source)
+        prompt = match(PROMPT_REGEX, line)
+        if prompt === nothing
+            source = match(SOURCE_REGEX, line)
+            if source === nothing
                 savebuffer!(input, buffer)
                 println(buffer, line)
                 takeuntil!(PROMPT_REGEX, buffer, lines)
             else
-                println(buffer, Utilities.getmatch(source, 1))
+                println(buffer, source[1])
             end
         else
             savebuffer!(output, buffer)
-            println(buffer, Utilities.getmatch(prompt, 1))
+            println(buffer, prompt[1])
         end
     end
     savebuffer!(output, buffer)
@@ -362,7 +362,7 @@ end
 function takeuntil!(r, buf, lines)
     while !isempty(lines)
         line = lines[1]
-        if isnull(Utilities.nullmatch(r, line))
+        if !ismatch(r, line)
             println(buf, shift!(lines))
         else
             break

--- a/src/DocSystem.jl
+++ b/src/DocSystem.jl
@@ -124,7 +124,7 @@ function docstr(md::Markdown.MD; kws...)
         :module => md.meta[:module],
         :linenumber => 0,
     )
-    doc = DocStr(Core.svec(), Nullable(md), data)
+    doc = DocStr(Core.svec(), md, data)
     for (key, value) in kws
         doc.data[key] = value
     end

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -144,20 +144,20 @@ to other page, reference to the [`Page`](@ref) object etc.
 """
 mutable struct NavNode
     """
-    `null` if the `NavNode` is a non-page node of the navigation tree, otherwise
+    `nothing` if the `NavNode` is a non-page node of the navigation tree, otherwise
     the string should be a valid key in `doc.internal.pages`
     """
-    page           :: Nullable{String}
+    page           :: Union{String, Void}
     """
-    If not `null`, specifies the text that should be displayed in navigation
+    If not `nothing`, specifies the text that should be displayed in navigation
     links etc. instead of the automatically determined text.
     """
-    title_override :: Nullable{String}
-    parent         :: Nullable{NavNode}
+    title_override :: Union{String, Void}
+    parent         :: Union{NavNode, Void}
     children       :: Vector{NavNode}
     visible        :: Bool
-    prev           :: Nullable{NavNode}
-    next           :: Nullable{NavNode}
+    prev           :: Union{NavNode, Void}
+    next           :: Union{NavNode, Void}
 end
 NavNode(page, title_override, parent) = NavNode(page, title_override, parent, [], true, nothing, nothing)
 
@@ -166,8 +166,8 @@ Constructs a list of the ancestors of the `navnode` (inclding the `navnode` itse
 ordered so that the root of the navigation tree is the first and `navnode` itself
 is the last item.
 """
-navpath(navnode::NavNode) = isnull(navnode.parent) ? [navnode] :
-    push!(navpath(get(navnode.parent)), navnode)
+navpath(navnode::NavNode) = navnode.parent === nothing ? [navnode] :
+    push!(navpath(navnode.parent), navnode)
 
 
 # Inner Document Fields.

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -445,10 +445,10 @@ end
 # --------
 
 function Selectors.runner(::Type{ExampleBlocks}, x, page, doc)
-    matched = Utilities.nullmatch(r"^@example[ ]?(.*)$", x.language)
-    isnull(matched) && error("invalid '@example' syntax: $(x.language)")
+    matched = match(r"^@example[ ]?(.*)$", x.language)
+    matched === nothing && error("invalid '@example' syntax: $(x.language)")
     # The sandboxed module -- either a new one or a cached one from this page.
-    name = Utilities.getmatch(matched, 1)
+    name = matched[1]
     sym  = isempty(name) ? gensym("ex-") : Symbol("ex-", name)
     mod  = get!(page.globals.meta, sym, Module(sym))::Module
     # Evaluate the code block. We redirect STDOUT/STDERR to `buffer`.
@@ -488,9 +488,9 @@ end
 # -----
 
 function Selectors.runner(::Type{REPLBlocks}, x, page, doc)
-    matched = Utilities.nullmatch(r"^@repl[ ]?(.*)$", x.language)
-    isnull(matched) && error("invalid '@repl' syntax: $(x.language)")
-    name = Utilities.getmatch(matched, 1)
+    matched = match(r"^@repl[ ]?(.*)$", x.language)
+    matched === nothing && error("invalid '@repl' syntax: $(x.language)")
+    name = matched[1]
     sym  = isempty(name) ? gensym("repl-") : Symbol("repl-", name)
     mod  = get!(page.globals.meta, sym, Module(sym))::Module
     code = split(x.code, '\n'; limit = 2)[end]
@@ -525,10 +525,10 @@ end
 # ------
 
 function Selectors.runner(::Type{SetupBlocks}, x, page, doc)
-    matched = Utilities.nullmatch(r"^@setup[ ](.+)$", x.language)
-    isnull(matched) && error("invalid '@setup <name>' syntax: $(x.language)")
+    matched = match(r"^@setup[ ](.+)$", x.language)
+    matched === nothing && error("invalid '@setup <name>' syntax: $(x.language)")
     # The sandboxed module -- either a new one or a cached one from this page.
-    name = Utilities.getmatch(matched, 1)
+    name = matched[1]
     sym  = isempty(name) ? gensym("ex-") : Symbol("ex-", name)
     mod  = get!(page.globals.meta, sym, Module(sym))::Module
 
@@ -552,9 +552,9 @@ end
 # ----
 
 function Selectors.runner(::Type{RawBlocks}, x, page, doc)
-    matched = Utilities.nullmatch(r"@raw[ ](.+)$", x.language)
-    isnull(matched) && error("invalid '@raw <name>' syntax: $(x.language)")
-    page.mapping[x] = Documents.RawNode(Symbol(Utilities.getmatch(matched, 1)), x.code)
+    m = match(r"@raw[ ](.+)$", x.language)
+    m === nothing && error("invalid '@raw <name>' syntax: $(x.language)")
+    page.mapping[x] = Documents.RawNode(Symbol(m[1]), x.code)
 end
 
 # Utilities.

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -168,7 +168,8 @@ function latexdoc(io::IO, md::Markdown.MD, page, doc)
         for (markdown, result) in zip(md.content, md.meta[:results])
             latex(io, Writers.MarkdownWriter.dropheaders(markdown), page, doc)
             # When a source link is available then print the link.
-            Utilities.unwrap(Utilities.url(doc.internal.remote, doc.user.repo, result)) do url
+            url = Utilities.url(doc.internal.remote, doc.user.repo, result)
+            if url !== nothing
                 link = "\\href{$url}{\\texttt{source}}"
                 _println(io, "\n", link, "\n")
             end

--- a/src/Writers/MarkdownWriter.jl
+++ b/src/Writers/MarkdownWriter.jl
@@ -79,7 +79,8 @@ function renderdoc(io::IO, mime::MIME"text/plain", md::Markdown.MD, page, doc)
         for (markdown, result) in zip(md.content, md.meta[:results])
             render(io, mime, dropheaders(markdown), page, doc)
             # When a source link is available then print the link.
-            Utilities.unwrap(Utilities.url(doc.internal.remote, doc.user.repo, result)) do url
+            url = Utilities.url(doc.internal.remote, doc.user.repo, result)
+            if url !== nothing
                 link = "<a target='_blank' href='$url' class='documenter-source'>source</a><br>"
                 println(io, "\n", link, "\n")
             end

--- a/test/navnode.jl
+++ b/test/navnode.jl
@@ -38,7 +38,7 @@ end
 
     @test length(navlist) == 6
     for (i,navnode) in enumerate(navlist)
-        @test get(navnode.page) == "page$i.md"
+        @test navnode.page == "page$i.md"
     end
 
     @test isa(navtree, Vector{NavNode})
@@ -48,8 +48,8 @@ end
     @test navtree[4] === navlist[6]
 
     section = navtree[3]
-    @test get(section.title_override) == "Section"
-    @test isnull(section.page)
+    @test section.title_override == "Section"
+    @test section.page === nothing
     @test length(section.children) == 3
 
     navpath = Documents.navpath(navlist[5])

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -41,13 +41,13 @@ end
         c = Documenter.Utilities.filterdocs(doc, Set{Module}([Base]))
         d = Documenter.Utilities.filterdocs(doc, Set{Module}([UtilitiesTests]))
 
-        @test !isnull(a)
-        @test get(a) === doc
-        @test !isnull(b)
-        @test contains(stringmime("text/plain", get(b)), "Documenter unit tests.")
-        @test !isnull(c)
-        @test !contains(stringmime("text/plain", get(c)), "Documenter unit tests.")
-        @test isnull(d)
+        @test a !== nothing
+        @test a === doc
+        @test b !== nothing
+        @test contains(stringmime("text/plain", b), "Documenter unit tests.")
+        @test c !== nothing
+        @test !contains(stringmime("text/plain", c), "Documenter unit tests.")
+        @test d === nothing
     end
 
     # Documenter.Utilities.issubmodule


### PR DESCRIPTION
Nullable is going to be removed in Julia 0.7. The replacement is `Union{T, Void}`
or `Union{Some{T}, Void}`. The latter allows distinguishing a valid `nothing` from
the absence of a value, but it is not yet available and does not really appear
to be required, except maybe for `DocStr.object` (see TODO).

This change is needed to remove `Nullable` from Julia master (https://github.com/JuliaLang/julia/pull/23642) since Documenter is used on CI. (An alternative is to use the new [Nullables](https://github.com/nalimilan/Nullables.jl) package, but better move directly to the final replacement.)