### PR TITLE
smallest possible change to make tests pass on 0.7

### DIFF
--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -474,7 +474,7 @@ function Selectors.runner(::Type{ExampleBlocks}, x, page, doc)
 
     # Special-case support for displaying SVG graphics. TODO: make this more general.
     output = mimewritable(MIME"image/svg+xml"(), result) ?
-        Documents.RawHTML(stringmime(MIME"image/svg+xml"(), result)) :
+        Documents.RawHTML(Base.invokelatest(stringmime, MIME"image/svg+xml"(), result)) :
         Markdown.Code(Documenter.DocChecks.result_to_string(buffer, result))
 
     # Only add content when there's actually something to add.

--- a/test/docsystem.jl
+++ b/test/docsystem.jl
@@ -6,6 +6,8 @@ import Documenter: Documenter, DocSystem
 
 const alias_of_getdocs = DocSystem.getdocs # NOTE: won't get docstrings if in a @testset
 
+PACKAGES_LOADED_MAIN = VERSION < v"0.7.0-DEV.1877"
+
 @testset "DocSystem" begin
     ## Bindings.
     @test_throws ArgumentError DocSystem.binding(9000)
@@ -17,7 +19,7 @@ const alias_of_getdocs = DocSystem.getdocs # NOTE: won't get docstrings if in a 
         @test b.var === :Document
     end
     let b = DocSystem.binding(Documenter)
-        @test b.mod === Main
+        @test b.mod === (PACKAGES_LOADED_MAIN ? Main : Documenter)
         @test b.var === :Documenter
     end
     let b = DocSystem.binding(:Main)
@@ -29,7 +31,7 @@ const alias_of_getdocs = DocSystem.getdocs # NOTE: won't get docstrings if in a 
         @test b.var === :binding
     end
     let b = DocSystem.binding(Documenter, :Documenter)
-        @test b.mod === Main
+        @test b.mod === (PACKAGES_LOADED_MAIN ? Main : Documenter)
         @test b.var === :Documenter
     end
 

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -79,33 +79,6 @@ module AutoDocs
     end
 end
 
-module Issue398
-
-struct TestType{T} end
-
-function _show end
-Base.show(io::IO, t::TestType) = _show(io, t)
-
-macro define_show_and_make_object(x, y)
-    z = Expr(:quote, x)
-    esc(quote
-        $(Issue398)._show(io::IO, t::$(Issue398).TestType{$z}) = print(io, $y)
-        const $x = $(Issue398).TestType{$z}()
-    end)
-end
-
-export @define_show_and_make_object
-
-end # module
-
-module InlineSVG
-export SVG
-mutable struct SVG
-    code :: String
-end
-Base.show(io, ::MIME"image/svg+xml", svg::SVG) = write(io, svg.code)
-end # module
-
 # Build example docs
 using Documenter
 

--- a/test/examples/src/index.md
+++ b/test/examples/src/index.md
@@ -141,13 +141,36 @@ Main
 
 ```@meta
 DocTestSetup = quote
-    using Issue398
+    module Issue398
+
+    struct TestType{T} end
+
+    function _show end
+    Base.show(io::IO, t::TestType) = _show(io, t)
+
+    macro define_show_and_make_object(x, y)
+        z = Expr(:quote, x)
+        esc(quote
+            $(Issue398)._show(io::IO, t::$(Issue398).TestType{$z}) = print(io, $y)
+            const $x = $(Issue398).TestType{$z}()
+        end)
+    end
+
+    export @define_show_and_make_object
+
+    end # module
+
+    using .Issue398
 end
 ```
 
 ```jldoctest
 julia> @define_show_and_make_object q "abcd"
 abcd
+```
+
+```@meta
+DocTestSetup = nothing
 ```
 
 # Issue418

--- a/test/examples/src/man/tutorial.md
+++ b/test/examples/src/man/tutorial.md
@@ -177,8 +177,18 @@ Base.show(io, ::MIME"image/svg+xml", svg::SVG) = write(io, svg.code)
 
 .. then we we can invoke and show them with an `@example` block:
 
-```@example
-using InlineSVG
+```@setup inlinesvg
+module InlineSVG
+export SVG
+mutable struct SVG
+    code :: String
+end
+Base.show(io, ::MIME"image/svg+xml", svg::SVG) = write(io, svg.code)
+end # module
+```
+
+```@example inlinesvg
+using .InlineSVG
 SVG("""
 <svg width="82" height="76">
   <g style="stroke-width: 3">


### PR DESCRIPTION
With this tests should pass on 0.7. I intend to merge this quickly since tests are needed to pass for other PRs and this almost only touches the tests (and fixes an exposed bug).