### PR TITLE
Make edit links point to master by default

### DIFF
--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -127,7 +127,7 @@ a different host, you can use this option to tell Documenter how URLs should be
 generated. The following placeholders will be replaced with the respective
 value of the generated link:
 
-  - `{commit}` Git commit id
+  - `{commit}` Git branch or tag name, or commit hash
   - `{path}` Path to the file in the repository
   - `{line}` Line (or range of lines) in the source file
 

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -197,6 +197,7 @@ struct User
     version :: String # version string used in the version selector by default
     html_prettyurls :: Bool # Use pretty URLs in the HTML build?
     html_disable_git :: Bool # Don't call git when exporting HTML
+    html_edit_branch :: Union{String, Void} # Change how the "Edit on GitHub" links are handled
 end
 
 """
@@ -250,6 +251,7 @@ function Document(;
         version :: AbstractString = "",
         html_prettyurls :: Bool = false,
         html_disable_git :: Bool = false,
+        html_edit_branch :: Union{String, Void} = "master",
         others...
     )
     Utilities.check_kwargs(others)
@@ -282,6 +284,7 @@ function Document(;
         version,
         html_prettyurls,
         html_disable_git,
+        html_edit_branch,
     )
     internal = Internal(
         Utilities.assetsdir(),

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -391,11 +391,7 @@ function relpath_from_repo_root(file)
         if in_cygwin()
             root = readchomp(`cygpath -m "$root"`)
         end
-        if startswith(file, root)
-            Nullable{Compat.String}(relpath(file, root))
-        else
-            Nullable{Compat.String}()
-        end
+        startswith(file, root) ? relpath(file, root) : nothing
     end
 end
 
@@ -416,7 +412,7 @@ function url(repo, file)
         nothing
     else
         repo = replace(repo, "{commit}", repo_commit(file))
-        repo = replace(repo, "{path}", string("/", get(path)))
+        repo = replace(repo, "{path}", string("/", path))
         repo
     end
 end
@@ -451,7 +447,7 @@ function url(remote, repo, mod, file, linerange)
             nothing
         else
             repo = replace(repo, "{commit}", repo_commit(file))
-            repo = replace(repo, "{path}", string("/", get(path)))
+            repo = replace(repo, "{path}", string("/", path))
             repo = replace(repo, "{line}", line)
             repo
         end

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -401,17 +401,17 @@ function repo_commit(file)
     end
 end
 
-function url(repo, file)
+function url(repo, file; commit=nothing)
     file = abspath(file)
     remote = getremote(dirname(file))
-    isempty(repo) && (repo = "https://github.com/$remote/tree/{commit}{path}")
+    isempty(repo) && (repo = "https://github.com/$remote/blob/{commit}{path}")
     # Replace any backslashes in links, if building the docs on Windows
     file = replace(file, '\\', '/')
     path = relpath_from_repo_root(file)
     if path === nothing
         nothing
     else
-        repo = replace(repo, "{commit}", repo_commit(file))
+        repo = replace(repo, "{commit}", commit === nothing ? repo_commit(file) : commit)
         repo = replace(repo, "{path}", string("/", path))
         repo
     end
@@ -430,7 +430,7 @@ function url(remote, repo, mod, file, linerange)
     # `deprecated.jl` since that is where the macro is defined. Use that to help
     # determine the correct URL.
     if inbase(mod) || !isabspath(file)
-        base = "https://github.com/JuliaLang/julia/tree"
+        base = "https://github.com/JuliaLang/julia/blob"
         dest = "base/$file#$line"
         if isempty(Base.GIT_VERSION_INFO.commit)
             "$base/v$VERSION/$dest"
@@ -441,7 +441,7 @@ function url(remote, repo, mod, file, linerange)
     else
         path = relpath_from_repo_root(file)
         if isempty(repo)
-            repo = "https://github.com/$remote/tree/{commit}{path}#{line}"
+            repo = "https://github.com/$remote/blob/{commit}{path}#{line}"
         end
         if path === nothing
             nothing

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -18,6 +18,9 @@ an error and exit if any of the Git commands fail. The calls to Git are mainly u
 gather information about the current commit hash and file paths, necessary for constructing
 the links to the remote repository.
 
+**`html_edit_branch`** specifies which branch, tag or commit the "Edit on GitHub" links
+point to. It defaults to `master`. If it set to `nothing`, the current commit will be used.
+
 # Page outline
 
 The [`HTMLWriter`](@ref) makes use of the page outline that is determined by the
@@ -410,7 +413,7 @@ function render_article(ctx, navnode)
         logo = "\uf171"
     end
     if !ctx.doc.user.html_disable_git
-        url = Utilities.url(ctx.doc.user.repo, getpage(ctx, navnode).source)
+        url = Utilities.url(ctx.doc.user.repo, getpage(ctx, navnode).source, commit=ctx.doc.user.html_edit_branch)
         if url !== nothing
             push!(topnav.nodes, a[".edit-page", :href => url](span[".fa"](logo), " Edit on $host"))
         end

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -121,6 +121,8 @@ examples_html_doc = makedocs(
 
     linkcheck = true,
     linkcheck_ignore = [r"(x|y).md", "z.md", r":func:.*"],
+
+    html_edit_branch = nothing,
 )
 
 info("Building mock package docs: HTMLWriter with pretty URLs")


### PR DESCRIPTION
Resolves #580. The original decision to point to the commit was so that the links wouldn't get out of date. But not forcing the user to change the branch is indeed better for the edit links.