### PR TITLE
Allow for different line range formattings depending on repo type

### DIFF
--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -500,11 +500,11 @@ end
 #      "https://bitbucket.org/xxx" => RepoBitbucket
 # If no match, returns RepoUnknown
 function repo_host_from_url(repoURL::String)
-    if contains(repoURL, "bitbucket.org")
+    if contains(repoURL, "bitbucket")
         return RepoBitbucket
-    elseif contains(repoURL, "github.com")
+    elseif contains(repoURL, "github")
         return RepoGithub
-    elseif contains(repoURL, "gitlab.com")
+    elseif contains(repoURL, "gitlab")
         return RepoGitlab
     else
         return RepoUnknown

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -425,7 +425,7 @@ function url(remote, repo, mod, file, linerange)
     # Replace any backslashes in links, if building the docs on Windows
     file = replace(file, '\\', '/')
     # Format the line range.
-    line = format_line(linerange)
+    line = format_line(linerange, LineRangeFormatting(repo))
     # Macro-generated methods such as those produced by `@deprecate` list their file as
     # `deprecated.jl` since that is where the macro is defined. Use that to help
     # determine the correct URL.
@@ -501,11 +501,25 @@ function linerange(text, from)
     return lines > 0 ? (from:(from + lines + 1)) : (from:from)
 end
 
-function format_line(range::AbstractRange)
-    top = format_line(first(range))
-    return length(range) <= 1 ? top : string(top, '-', format_line(last(range)))
+struct LineRangeFormatting
+    prefix::String
+    separator::String
+
+    function LineRangeFormatting(repoURL::String)
+        if (startswith(repoURL, "https://bitbucket.org") || startswith(repoURL, "http://bitbucket.org"))
+            new("", ":")
+        else
+            # default is github-style
+            new("L", "-")
+        end
+    end
 end
-format_line(line::Integer) = string('L', line)
+
+function format_line(range::Range, format::LineRangeFormatting)
+    local top = format_line(first(range), format.prefix)
+    return length(range) <= 1 ? top : string(top, format.separator, format_line(last(range), format.prefix))
+end
+format_line(line::Integer, prefix::String) = string(prefix, line)
 
 newlines(s::AbstractString) = count(c -> c === '\n', s)
 newlines(other) = 0

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -535,7 +535,7 @@ struct LineRangeFormatting
     end
 end
 
-function format_line(range::Range, format::LineRangeFormatting)
+function format_line(range::Compat.AbstractRange, format::LineRangeFormatting)
     local top = format_line(first(range), format.prefix)
     return length(range) <= 1 ? top : string(top, format.separator, format_line(last(range), format.prefix))
 end

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -406,11 +406,11 @@ function render_article(ctx, navnode)
     host = "GitHub"
     logo = "\uf09b"
 
-    hostType = Utilities.repo_host_from_url(ctx.doc.user.repo)
-    if hostType == Utilities.RepoGitlab
+    host_type = Utilities.repo_host_from_url(ctx.doc.user.repo)
+    if host_type == Utilities.RepoGitlab
         host = "GitLab"
         logo = "\uf296"
-    elseif hostType == Utilities.RepoBitbucket
+    elseif host_type == Utilities.RepoBitbucket
         host = "BitBucket"
         logo = "\uf171"
     end

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -405,13 +405,16 @@ function render_article(ctx, navnode)
     # Set the logo and name for the "Edit on.." button. We assume GitHub as a host.
     host = "GitHub"
     logo = "\uf09b"
-    if contains(ctx.doc.user.repo, "gitlab")
+
+    hostType = Utilities.repo_host_from_url(ctx.doc.user.repo)
+    if hostType == Utilities.RepoGitlab
         host = "GitLab"
         logo = "\uf296"
-    elseif contains(ctx.doc.user.repo, "bitbucket")
+    elseif hostType == Utilities.RepoBitbucket
         host = "BitBucket"
         logo = "\uf171"
     end
+
     if !ctx.doc.user.html_disable_git
         url = Utilities.url(ctx.doc.user.repo, getpage(ctx, navnode).source, commit=ctx.doc.user.html_edit_branch)
         if url !== nothing

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -80,6 +80,25 @@ end
     @test Documenter.Utilities.doccat(UnitTests.f) == "Function"
     @test Documenter.Utilities.doccat(UnitTests.pi) == "Constant"
 
+    # line range
+    let
+        repo = "https://github.com/something"
+        lineRange = 2:5
+        expectedString = "L2-L5"
+
+        formatting = Documenter.Utilities.LineRangeFormatting(repo)
+        @test Documenter.Utilities.format_line(lineRange, formatting) == expectedString
+    end
+
+    let
+        repo = "https://bitbucket.org/something"
+        lineRange = 2:5
+        expectedString = "2:5"
+
+        formatting = Documenter.Utilities.LineRangeFormatting(repo)
+        @test Documenter.Utilities.format_line(lineRange, formatting) == expectedString
+    end
+
     import Documenter.Documents: Document, Page, Globals
     let page = Page("source", "build", [], ObjectIdDict(), Globals()), doc = Document()
         code = """

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -91,21 +91,21 @@ end
 
     # line range
     let
-        repoType = Documenter.Utilities.RepoGithub
-        lineRange = 2:5
-        expectedString = "L2-L5"
+        repo_type = Documenter.Utilities.RepoGithub
+        line_range = 2:5
+        expected_string = "L2-L5"
 
-        formatting = Documenter.Utilities.LineRangeFormatting(repoType)
-        @test Documenter.Utilities.format_line(lineRange, formatting) == expectedString
+        formatting = Documenter.Utilities.LineRangeFormatting(repo_type)
+        @test Documenter.Utilities.format_line(line_range, formatting) == expected_string
     end
 
     let
-        repoType = Documenter.Utilities.RepoBitbucket
-        lineRange = 2:5
-        expectedString = "2:5"
+        repo_type = Documenter.Utilities.RepoBitbucket
+        line_range = 2:5
+        expected_string = "2:5"
 
-        formatting = Documenter.Utilities.LineRangeFormatting(repoType)
-        @test Documenter.Utilities.format_line(lineRange, formatting) == expectedString
+        formatting = Documenter.Utilities.LineRangeFormatting(repo_type)
+        @test Documenter.Utilities.format_line(line_range, formatting) == expected_string
     end
 
     import Documenter.Documents: Document, Page, Globals

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -80,22 +80,31 @@ end
     @test Documenter.Utilities.doccat(UnitTests.f) == "Function"
     @test Documenter.Utilities.doccat(UnitTests.pi) == "Constant"
 
+    # repo type
+    @test Documenter.Utilities.repo_host_from_url("https://bitbucket.org/somerepo") == Documenter.Utilities.RepoBitbucket
+    @test Documenter.Utilities.repo_host_from_url("https://www.bitbucket.org/somerepo") == Documenter.Utilities.RepoBitbucket
+    @test Documenter.Utilities.repo_host_from_url("http://bitbucket.org/somethingelse") == Documenter.Utilities.RepoBitbucket
+    @test Documenter.Utilities.repo_host_from_url("http://github.com/Whatever") == Documenter.Utilities.RepoGithub
+    @test Documenter.Utilities.repo_host_from_url("https://github.com/Whatever") == Documenter.Utilities.RepoGithub
+    @test Documenter.Utilities.repo_host_from_url("https://www.github.com/Whatever") == Documenter.Utilities.RepoGithub
+    @test Documenter.Utilities.repo_host_from_url("https://gitlab.com/Whatever") == Documenter.Utilities.RepoGitlab
+
     # line range
     let
-        repo = "https://github.com/something"
+        repoType = Documenter.Utilities.RepoGithub
         lineRange = 2:5
         expectedString = "L2-L5"
 
-        formatting = Documenter.Utilities.LineRangeFormatting(repo)
+        formatting = Documenter.Utilities.LineRangeFormatting(repoType)
         @test Documenter.Utilities.format_line(lineRange, formatting) == expectedString
     end
 
     let
-        repo = "https://bitbucket.org/something"
+        repoType = Documenter.Utilities.RepoBitbucket
         lineRange = 2:5
         expectedString = "2:5"
 
-        formatting = Documenter.Utilities.LineRangeFormatting(repo)
+        formatting = Documenter.Utilities.LineRangeFormatting(repoType)
         @test Documenter.Utilities.format_line(lineRange, formatting) == expectedString
     end
 


### PR DESCRIPTION
I realized that the links to source code with line and line ranges bookmarks were not working for bitbucket because the syntax is different than the syntax of github.

This aims at fixing that, by using a LineRangeFormatting struct that adapts to the repository domain.  Let me know if you have any suggestions on how to improve this PR.

I can easily make another one for v0.5 if this one looks ok for you. Thanks for the hard work behind Documenter.jl, I find it a super useful package :)