### PR TITLE
Backports for 0.11.3: Allow for different line range formattings depending on repo type (for 0.5)

### DIFF
--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -447,7 +447,7 @@ if VERSION >= v"0.5.0-dev+3442"
         # Replace any backslashes in links, if building the docs on Windows
         file = replace(file, '\\', '/')
         # Format the line range.
-        line = format_line(linerange)
+        line = format_line(linerange, LineRangeFormatting(repo_host_from_url(repo)))
         # Macro-generated methods such as those produced by `@deprecate` list their file as
         # `deprecated.jl` since that is where the macro is defined. Use that to help
         # determine the correct URL.
@@ -528,6 +528,26 @@ function inbase(m::Module)
     end
 end
 
+# Repository hosts
+#   RepoUnknown denotes that the repository type could not be determined automatically
+@enum RepoHost RepoGithub RepoBitbucket RepoGitlab RepoUnknown
+
+# Repository host from repository url
+# i.e. "https://github.com/something" => RepoGithub
+#      "https://bitbucket.org/xxx" => RepoBitbucket
+# If no match, returns RepoUnknown
+function repo_host_from_url(repoURL::String)
+    if contains(repoURL, "bitbucket")
+        return RepoBitbucket
+    elseif contains(repoURL, "github")
+        return RepoGithub
+    elseif contains(repoURL, "gitlab")
+        return RepoGitlab
+    else
+        return RepoUnknown
+    end
+end
+
 # Find line numbers.
 # ------------------
 
@@ -538,11 +558,25 @@ function linerange(text, from)
     return lines > 0 ? (from:(from + lines + 1)) : (from:from)
 end
 
-function format_line(range::Range)
-    local top = format_line(first(range))
-    return length(range) <= 1 ? top : string(top, '-', format_line(last(range)))
+immutable LineRangeFormatting
+    prefix::String
+    separator::String
+
+    function LineRangeFormatting(host::RepoHost)
+        if host == RepoBitbucket
+            new("", ":")
+        else
+            # default is github-style
+            new("L", "-")
+        end
+    end
 end
-format_line(line::Integer) = string('L', line)
+
+function format_line(range::Compat.AbstractRange, format::LineRangeFormatting)
+    local top = format_line(first(range), format.prefix)
+    return length(range) <= 1 ? top : string(top, format.separator, format_line(last(range), format.prefix))
+end
+format_line(line::Integer, prefix::String) = string(prefix, line)
 
 newlines(s::AbstractString) = count(c -> c === '\n', s)
 newlines(other) = 0

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -393,10 +393,12 @@ function render_article(ctx, navnode)
     # Set the logo and name for the "Edit on.." button. We assume GitHub as a host.
     host = "GitHub"
     logo = "\uf09b"
-    if contains(ctx.doc.user.repo, "gitlab")
+
+    host_type = Utilities.repo_host_from_url(ctx.doc.user.repo)
+    if host_type == Utilities.RepoGitlab
         host = "GitLab"
         logo = "\uf296"
-    elseif contains(ctx.doc.user.repo, "bitbucket")
+    elseif host_type == Utilities.RepoBitbucket
         host = "BitBucket"
         logo = "\uf171"
     end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -85,6 +85,34 @@ end
     @test Documenter.Utilities.doccat(UnitTests.f) == "Function"
     @test Documenter.Utilities.doccat(UnitTests.pi) == "Constant"
 
+    # repo type
+    @test Documenter.Utilities.repo_host_from_url("https://bitbucket.org/somerepo") == Documenter.Utilities.RepoBitbucket
+    @test Documenter.Utilities.repo_host_from_url("https://www.bitbucket.org/somerepo") == Documenter.Utilities.RepoBitbucket
+    @test Documenter.Utilities.repo_host_from_url("http://bitbucket.org/somethingelse") == Documenter.Utilities.RepoBitbucket
+    @test Documenter.Utilities.repo_host_from_url("http://github.com/Whatever") == Documenter.Utilities.RepoGithub
+    @test Documenter.Utilities.repo_host_from_url("https://github.com/Whatever") == Documenter.Utilities.RepoGithub
+    @test Documenter.Utilities.repo_host_from_url("https://www.github.com/Whatever") == Documenter.Utilities.RepoGithub
+    @test Documenter.Utilities.repo_host_from_url("https://gitlab.com/Whatever") == Documenter.Utilities.RepoGitlab
+
+    # line range
+    let
+        repo_type = Documenter.Utilities.RepoGithub
+        line_range = 2:5
+        expected_string = "L2-L5"
+
+        formatting = Documenter.Utilities.LineRangeFormatting(repo_type)
+        @test Documenter.Utilities.format_line(line_range, formatting) == expected_string
+    end
+
+    let
+        repo_type = Documenter.Utilities.RepoBitbucket
+        line_range = 2:5
+        expected_string = "2:5"
+
+        formatting = Documenter.Utilities.LineRangeFormatting(repo_type)
+        @test Documenter.Utilities.format_line(line_range, formatting) == expected_string
+    end
+
     import Documenter.Documents: Document, Page, Globals
     let page = Page("source", "build", [], ObjectIdDict(), Globals()), doc = Document()
         code = """


### PR DESCRIPTION
Same as https://github.com/JuliaDocs/Documenter.jl/pull/583 but for Julia v0.5 .