### PR TITLE
Backports for 0.11.4: Fix url generation function to work with symlinked paths

### DIFF
--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -415,7 +415,7 @@ function in_cygwin()
 end
 
 function url(repo, file)
-    file = abspath(file)
+    file = realpath(abspath(file))
     remote = getremote(dirname(file))
     isempty(repo) && (repo = "https://github.com/$remote/tree/{commit}{path}")
     # Replace any backslashes in links, if building the docs on Windows
@@ -444,6 +444,12 @@ if VERSION >= v"0.5.0-dev+3442"
     function url(remote, repo, mod, file, linerange)
         remote = getremote(dirname(file))
         isabspath(file) && isempty(remote) && isempty(repo) && return Nullable{Compat.String}()
+
+        # make sure we get the true path, as otherwise we will get different paths when we compute `root` below
+        if isfile(file)
+            file = realpath(abspath(file))
+        end
+
         # Replace any backslashes in links, if building the docs on Windows
         file = replace(file, '\\', '/')
         # Format the line range.


### PR DESCRIPTION
Took me a while to find out why the `source` link was not appearing when I was building the docs.

Turned out that I had a symlink from `$HOME/.julia` to another path, and the `file` and `root` variables used in the `url` function (see commit diff) would then have different base names, as `cd()` translates the links to the real paths.

This fixes this issue. I will make the fix for master if you're ok with this one. 

---

Ref: #587 