### PR TITLE
Fix url generation function to work with symlinked paths

### DIFF
--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -402,7 +402,7 @@ function repo_commit(file)
 end
 
 function url(repo, file; commit=nothing)
-    file = abspath(file)
+    file = realpath(abspath(file))
     remote = getremote(dirname(file))
     isempty(repo) && (repo = "https://github.com/$remote/blob/{commit}{path}")
     # Replace any backslashes in links, if building the docs on Windows
@@ -422,6 +422,12 @@ url(remote, repo, doc) = url(remote, repo, doc.data[:module], doc.data[:path], l
 function url(remote, repo, mod, file, linerange)
     remote = getremote(dirname(file))
     isabspath(file) && isempty(remote) && isempty(repo) && return nothing
+
+    # make sure we get the true path, as otherwise we will get different paths when we compute `root` below
+    if isfile(file)
+        file = realpath(abspath(file))
+    end
+
     # Replace any backslashes in links, if building the docs on Windows
     file = replace(file, '\\', '/')
     # Format the line range.


### PR DESCRIPTION
Took me a while to find out why the source link was not appearing when I was building the docs.

Turned out that I had a symlink from $HOME/.julia to another path, and the file and root variables used in the url function (see commit diff) would then have different base names, as cd() translates the links to the real paths.

This fixes this issue. I will make the fix for master if you're ok with this one.

[Backport here https://github.com/JuliaDocs/Documenter.jl/pull/586]