### PR TITLE
Run pip installs separately

### DIFF
--- a/src/Deps.jl
+++ b/src/Deps.jl
@@ -29,7 +29,11 @@ deploydocs(
 )
 ```
 """
-pip(deps...) = () -> run(`pip install --user $(deps...)`)
+function pip(deps...)
+    for dep in deps
+        run(`pip install --user $(dep)`)
+    end
+end
 
 
 function localbin()


### PR DESCRIPTION
Helps with dependency resolution, since installing packages in a single command sometimes ends up in an inconsistent state.

Closes #590.