### PR TITLE
HTMLWriter: add html_canonical option

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -46,6 +46,7 @@ makedocs(
     ],
     # Use clean URLs, unless built as a "local" build
     html_prettyurls = !("local" in ARGS),
+    html_canonical = "https://juliadocs.github.io/Documenter.jl/stable/",
 )
 
 deploydocs(

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -200,6 +200,7 @@ struct User
     html_prettyurls :: Bool # Use pretty URLs in the HTML build?
     html_disable_git :: Bool # Don't call git when exporting HTML
     html_edit_branch :: Union{String, Nothing} # Change how the "Edit on GitHub" links are handled
+    html_canonical   :: Union{String, Nothing} # Set a canonical url, if desired (https://en.wikipedia.org/wiki/Canonical_link_element)
 end
 
 """
@@ -255,6 +256,7 @@ function Document(;
         html_prettyurls  :: Bool     = false,
         html_disable_git :: Bool     = false,
         html_edit_branch :: Union{String, Nothing} = "master",
+        html_canonical   :: Union{String, Nothing} = nothing,
         others...
     )
     Utilities.check_kwargs(others)
@@ -289,6 +291,7 @@ function Document(;
         html_prettyurls,
         html_disable_git,
         html_edit_branch,
+        html_canonical,
     )
     internal = Internal(
         Utilities.assetsdir(),

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -21,6 +21,12 @@ the links to the remote repository.
 **`html_edit_branch`** specifies which branch, tag or commit the "Edit on GitHub" links
 point to. It defaults to `master`. If it set to `nothing`, the current commit will be used.
 
+**`html_canonical`** specifies the canonical URL for your documentation. We recommend
+you set this to the base url of your stable documentation, e.g. `https://juliadocs.github.io/Documenter.jl/stable`.
+This allows search engines to know which version to send their users to. [See
+wikipedia for more information](https://en.wikipedia.org/wiki/Canonical_link_element).
+Default is `nothing`, in which case no canonical link is set.
+
 # Page outline
 
 The [`HTMLWriter`](@ref) makes use of the page outline that is determined by the
@@ -209,6 +215,8 @@ function render_head(ctx, navnode)
 
         analytics_script(ctx.doc.user.analytics),
 
+        canonical_link_element(ctx.doc.user.html_canonical, src),
+
         # Stylesheets.
         map(css_links) do each
             link[:href => each, :rel => "stylesheet", :type => "text/css"]
@@ -255,6 +263,17 @@ analytics_script(tracking_id::AbstractString) =
         ga('send', 'pageview');
         """
     )
+
+function canonical_link_element(canonical_link, src)
+   @tags link
+   if canonical_link === nothing
+      return Tag(Symbol("#RAW#"))("")
+   else
+      canonical_link_stripped = rstrip(canonical_link, '/')
+      href = "$canonical_link_stripped/$src"
+      return link[:rel => "canonical", :href => href]
+   end
+end
 
 ## Search page
 # ------------

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -157,3 +157,35 @@ examples_html_doc = makedocs(
     ],
     doctest = false,
 )
+info("Building mock package docs: HTMLWriter with pretty URLs and canonical links")
+examples_html_doc = makedocs(
+    debug = true,
+    root  = examples_root,
+    build = "builds/html-pretty-urls",
+    format   = :html,
+    html_prettyurls = true,
+    html_canonical = "https://example.com/stable",
+    doctestfilters = [r"Ptr{0x[0-9]+}"],
+    assets = [
+        "assets/favicon.ico",
+        "assets/custom.css"
+    ],
+    sitename = "Documenter example",
+    pages    = Any[
+        "Home" => "index.md",
+        "Manual" => [
+            "man/tutorial.md",
+        ],
+        hide("hidden.md"),
+        "Library" => [
+            "lib/functions.md",
+            "lib/autodocs.md",
+        ],
+        hide("Hidden Pages" => "hidden/index.md", Any[
+            "Page X" => "hidden/x.md",
+            "hidden/y.md",
+            "hidden/z.md",
+        ])
+    ],
+    doctest = false,
+)

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -126,37 +126,6 @@ examples_html_doc = makedocs(
     html_edit_branch = nothing,
 )
 
-info("Building mock package docs: HTMLWriter with pretty URLs")
-examples_html_doc = makedocs(
-    debug = true,
-    root  = examples_root,
-    build = "builds/html-pretty-urls",
-    format   = :html,
-    html_prettyurls = true,
-    doctestfilters = [r"Ptr{0x[0-9]+}"],
-    assets = [
-        "assets/favicon.ico",
-        "assets/custom.css"
-    ],
-    sitename = "Documenter example",
-    pages    = Any[
-        "Home" => "index.md",
-        "Manual" => [
-            "man/tutorial.md",
-        ],
-        hide("hidden.md"),
-        "Library" => [
-            "lib/functions.md",
-            "lib/autodocs.md",
-        ],
-        hide("Hidden Pages" => "hidden/index.md", Any[
-            "Page X" => "hidden/x.md",
-            "hidden/y.md",
-            "hidden/z.md",
-        ])
-    ],
-    doctest = false,
-)
 info("Building mock package docs: HTMLWriter with pretty URLs and canonical links")
 examples_html_doc = makedocs(
     debug = true,


### PR DESCRIPTION
As discussed in #621, This allows search engines to point their users only to the most relevant version of a certain page. This is particularly useful when serving many similar pages (e.g. many versions of the same documentation).

See https://en.wikipedia.org/wiki/Canonical_link_element for details.