### PR TITLE
fix some deprecations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
-Compat 0.41.0
+Compat 0.43.0
 DocStringExtensions 0.2

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
-Compat 0.43.0
+Compat 0.46.0
 DocStringExtensions 0.2

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -307,7 +307,8 @@ Code blocks may have some content that does not need to be displayed in the fina
 
 ````markdown
 ```@example
-srand(1) # hide
+using Documenter # hide
+Documenter.Random.srand(1) # hide
 A = rand(3, 3)
 b = [1, 2, 3]
 A \ b

--- a/src/CrossReferences.jl
+++ b/src/CrossReferences.jl
@@ -119,9 +119,9 @@ function docsxref(link::Markdown.Link, code, meta, page, doc)
         ex = QuoteNode(keyword)
     else
         try
-            ex = parse(code)
+            ex = Meta.parse(code)
         catch err
-            !isa(err, ParseError) && rethrow(err)
+            !isa(err, Meta.ParseError) && rethrow(err)
             push!(doc.internal.errors, :cross_references)
             Utilities.warn(page.source, "Unable to parse the reference '[`$code`](@ref)'.")
             return

--- a/src/CrossReferences.jl
+++ b/src/CrossReferences.jl
@@ -42,8 +42,8 @@ end
 const NAMED_XREF = r"^@ref (.+)$"
 
 function xref(link::Markdown.Link, meta, page, doc)
-    link.url == "@ref"            ? basicxref(link, meta, page, doc) :
-    ismatch(NAMED_XREF, link.url) ? namedxref(link, meta, page, doc) : nothing
+    link.url == "@ref"             ? basicxref(link, meta, page, doc) :
+    contains(link.url, NAMED_XREF) ? namedxref(link, meta, page, doc) : nothing
     return false # Stop `walk`ing down this `link` element.
 end
 xref(other, meta, page, doc) = true # Continue to `walk` through element `other`.
@@ -54,7 +54,7 @@ function basicxref(link::Markdown.Link, meta, page, doc)
     elseif isa(link.text, Vector)
         # No `name` was provided, since given a `@ref`, so slugify the `.text` instead.
         text = strip(sprint(Markdown.plain, Markdown.Paragraph(link.text)))
-        if ismatch(r"#[0-9]+", text)
+        if contains(text, r"#[0-9]+")
             issue_xref(link, lstrip(text, '#'), meta, page, doc)
         else
             name = Utilities.slugify(text)

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -351,7 +351,7 @@ function repl_splitter(code)
     output = String[]
     buffer = IOBuffer()
     while !isempty(lines)
-        line = shift!(lines)
+        line = popfirst!(lines)
         # REPL code blocks may contain leading lines with comments. Drop them.
         # TODO: handle multiline comments?
         # ANON_FUNC_DECLARATION deals with `x->x` -> `#1 (generic function ....)` on 0.7
@@ -385,7 +385,7 @@ function takeuntil!(r, buf, lines)
     while !isempty(lines)
         line = lines[1]
         if !contains(line, r)
-            println(buf, shift!(lines))
+            println(buf, popfirst!(lines))
         else
             break
         end

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -289,7 +289,7 @@ function error_to_string(buf, er, bt)
     # Print a REPL-like error message.
     disable_color() do
         print(buf, "ERROR: ")
-        showerror(buf, er, index == 0 ? bt : bt[1:(index - 1)])
+        showerror(buf, er, (index != nothing && index > 0) ? bt[1:(index - 1)] : bt)
     end
     sanitise(buf)
 end

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -127,7 +127,7 @@ function doctest(block::Markdown.Code, meta::Dict, doc::Documents.Document, page
             newmod
         end
         # Normalise line endings.
-        code = replace(block.code, "\r\n", "\n")
+        code = replace(block.code, "\r\n" => "\n")
         if haskey(meta, :DocTestSetup)
             expr = meta[:DocTestSetup]
             Meta.isexpr(expr, :block) && (expr.head = :toplevel)
@@ -230,7 +230,7 @@ function filter_doctests(strings::NTuple{2, AbstractString},
     local_filters == nothing && local_filters == []
     for r in [doc.user.doctestfilters; local_filters]
         if all(ismatch.(r, strings))
-            strings = replace.(strings, r, "")
+            strings = replace.(strings, r => "")
         end
     end
     return strings
@@ -245,10 +245,10 @@ function checkresult(sandbox::Module, result::Result, meta::Dict, doc::Documents
         # To avoid dealing with path/line number issues in backtraces we use `[...]` to
         # mark ignored output from an error message. Only the text prior to it is used to
         # test for doctest success/failure.
-        head = replace(split(result.output, "\n[...]"; limit = 2)[1], mod_regex, "")
-        head = replace(head, mod_regex_nodot, "Main")
-        str  = replace(error_to_string(result.stdout, result.value, result.bt), mod_regex, "")
-        str  = replace(str, mod_regex_nodot, "Main")
+        head = replace(split(result.output, "\n[...]"; limit = 2)[1], mod_regex  => "")
+        head = replace(head, mod_regex_nodot => "Main")
+        str  = replace(error_to_string(result.stdout, result.value, result.bt), mod_regex => "")
+        str  = replace(str, mod_regex_nodot => "Main")
 
         str, head = filter_doctests((str, head), doc, meta)
         # Since checking for the prefix of an error won't catch the empty case we need
@@ -258,10 +258,10 @@ function checkresult(sandbox::Module, result::Result, meta::Dict, doc::Documents
         end
     else
         value = result.hide ? nothing : result.value # `;` hides output.
-        output = replace(strip(sanitise(IOBuffer(result.output))), mod_regex, "")
-        str = replace(result_to_string(result.stdout, value), mod_regex, "")
+        output = replace(strip(sanitise(IOBuffer(result.output))), mod_regex => "")
+        str = replace(result_to_string(result.stdout, value), mod_regex => "")
         # Replace a standalone module name with `Main`.
-        str = strip(replace(str, mod_regex_nodot, "Main"))
+        str = strip(replace(str, mod_regex_nodot => "Main"))
         str, output = filter_doctests((str, output), doc, meta)
         str == output || report(result, str, doc)
     end
@@ -337,7 +337,7 @@ end
 # Remove terminal colors.
 
 const TERM_COLOR_REGEX = r"\e\[[0-9;]*m"
-remove_term_colors(s) = replace(s, TERM_COLOR_REGEX, "")
+remove_term_colors(s) = replace(s, TERM_COLOR_REGEX => "")
 
 # REPL doctest splitter.
 

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -456,7 +456,7 @@ function git_push(
     target_dir = abspath(target)
 
     # The upstream URL to which we push new content and the ssh decryption commands.
-    upstream = "git@$(replace(repo, "github.com/", "github.com:"))"
+    upstream = "git@$(replace(repo, "github.com/" => "github.com:"))"
 
     write(keyfile, String(base64decode(key)))
     chmod(keyfile, 0o600)

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -501,7 +501,7 @@ function git_push(
                     Writers.HTMLWriter.generate_siteinfo_file(tagged_dir, tag)
                     # Build a `release-*.*` folder as well when the travis tag is
                     # valid, which it *should* always be anyway.
-                    if ismatch(Base.VERSION_REGEX, tag)
+                    if contains(tag, Base.VERSION_REGEX)
                         version = VersionNumber(tag)
                         release = "release-$(version.major).$(version.minor)"
                         gitrm_copy(target_dir, joinpath(dirname, release))
@@ -567,7 +567,7 @@ end
 
 function getenv(regex::Regex)
     for (key, value) in ENV
-        ismatch(regex, key) && return value
+        contains(key, regex) && return value
     end
     error("could not find key/iv pair.")
 end

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -19,6 +19,12 @@ module Documenter
 using Compat, DocStringExtensions
 import Compat.Base64: base64decode, base64encode
 
+@static if VERSION < v"0.7.0-DEV.3406"
+    import Base.Random
+else
+    import Random
+end
+
 # Submodules
 # ----------
 

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -560,7 +560,7 @@ end
 # Utilities.
 # ----------
 
-iscode(x::Markdown.Code, r::Regex) = ismatch(r, x.language)
+iscode(x::Markdown.Code, r::Regex) = contains(x.language, r)
 iscode(x::Markdown.Code, lang)     = x.language == lang
 iscode(x, lang)                    = false
 
@@ -569,7 +569,7 @@ const NAMEDHEADER_REGEX = r"^@id (.+)$"
 function namedheader(h::Markdown.Header)
     if isa(h.text, Vector) && length(h.text) === 1 && isa(h.text[1], Markdown.Link)
         url = h.text[1].url
-        ismatch(NAMEDHEADER_REGEX, url)
+        contains(url, NAMEDHEADER_REGEX)
     else
         false
     end
@@ -579,7 +579,7 @@ end
 function droplines(code; skip = 0)
     buffer = IOBuffer()
     for line in split(code, '\n')[(skip + 1):end]
-        ismatch(r"^(.*)# hide$", line) && continue
+        contains(line, r"^(.*)# hide$") && continue
         println(buffer, rstrip(line))
     end
     strip(Utilities.takebuf_str(buffer), '\n')

--- a/src/Utilities/DOM.jl
+++ b/src/Utilities/DOM.jl
@@ -284,7 +284,7 @@ string is constructed with the characters escaped. The returned object should
 always be treated as an immutable copy and compared using `==` rather than `===`.
 """
 function escapehtml(text::AbstractString)
-    if ismatch(r"[<>&'\"]", text)
+    if contains(text, r"[<>&'\"]")
         buffer = IOBuffer()
         for char in text
             char === '<'  ? write(buffer, "&lt;")   :

--- a/src/Utilities/MDFlatten.jl
+++ b/src/Utilities/MDFlatten.jl
@@ -72,7 +72,7 @@ mdflatten(io, link::Link, parent) = mdflatten(io, link.text, link)
 mdflatten(io, b::Bold, parent) = mdflatten(io, b.text, b)
 mdflatten(io, i::Italic, parent) = mdflatten(io, i.text, i)
 mdflatten(io, i::Image, parent) = print(io, "(Image: $(i.alt))")
-mdflatten(io, m::LaTeX, parent) = print(io, replace(m.formula, r"[^()+\-*^=\w\s]", ""))
+mdflatten(io, m::LaTeX, parent) = print(io, replace(m.formula, r"[^()+\-*^=\w\s]" => ""))
 mdflatten(io, ::LineBreak, parent) = print(io, '\n')
 
 # Is both inline and block

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -130,7 +130,7 @@ function parseblock(code::AbstractString, doc, page; skip = 0, keywords = true)
                 (QuoteNode(keyword), cursor + endof(line) + offset)
             else
                 try
-                    parse(code, cursor)
+                    Meta.parse(code, cursor)
                 catch err
                     push!(doc.internal.errors, :parse_error)
                     Utilities.warn(doc, page, "Failed to parse expression.", err)

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -624,7 +624,7 @@ end
 
 Checks whether `url` is an absolute URL (as opposed to a relative one).
 """
-isabsurl(url) = ismatch(ABSURL_REGEX, url)
+isabsurl(url) = contains(url, ABSURL_REGEX)
 const ABSURL_REGEX = r"^[[:alpha:]+-.]+://"
 
 include("DOM.jl")

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -92,11 +92,11 @@ srcpath(source, root, file) = normpath(joinpath(relpath(root, source), file))
 Slugify a string into a suitable URL.
 """
 function slugify(s::AbstractString)
-    s = replace(s, r"\s+", "-")
-    s = replace(s, r"^\d+", "")
-    s = replace(s, r"&", "-and-")
-    s = replace(s, r"[^\p{L}\p{P}\d\-]+", "")
-    s = strip(replace(s, r"\-\-+", "-"), '-')
+    s = replace(s, r"\s+" => "-")
+    s = replace(s, r"^\d+" => "")
+    s = replace(s, r"&" => "-and-")
+    s = replace(s, r"[^\p{L}\p{P}\d\-]+" => "")
+    s = strip(replace(s, r"\-\-+" => "-"), '-')
 end
 slugify(object) = string(object) # Non-string slugifying doesn't do anything.
 
@@ -406,13 +406,13 @@ function url(repo, file; commit=nothing)
     remote = getremote(dirname(file))
     isempty(repo) && (repo = "https://github.com/$remote/blob/{commit}{path}")
     # Replace any backslashes in links, if building the docs on Windows
-    file = replace(file, '\\', '/')
+    file = replace(file, '\\' => '/')
     path = relpath_from_repo_root(file)
     if path === nothing
         nothing
     else
-        repo = replace(repo, "{commit}", commit === nothing ? repo_commit(file) : commit)
-        repo = replace(repo, "{path}", string("/", path))
+        repo = replace(repo, "{commit}" => commit === nothing ? repo_commit(file) : commit)
+        repo = replace(repo, "{path}" => string("/", path))
         repo
     end
 end
@@ -429,7 +429,7 @@ function url(remote, repo, mod, file, linerange)
     end
 
     # Replace any backslashes in links, if building the docs on Windows
-    file = replace(file, '\\', '/')
+    file = replace(file, '\\' => '/')
     # Format the line range.
     line = format_line(linerange, LineRangeFormatting(repo_host_from_url(repo)))
     # Macro-generated methods such as those produced by `@deprecate` list their file as
@@ -452,9 +452,9 @@ function url(remote, repo, mod, file, linerange)
         if path === nothing
             nothing
         else
-            repo = replace(repo, "{commit}", repo_commit(file))
-            repo = replace(repo, "{path}", string("/", path))
-            repo = replace(repo, "{line}", line)
+            repo = replace(repo, "{commit}" => repo_commit(file))
+            repo = replace(repo, "{path}" => string("/", path))
+            repo = replace(repo, "{line}" => line)
             repo
         end
     end

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -473,9 +473,9 @@ function generate_version_file(dir::AbstractString)
     release_folders = []
     tag_folders = []
     for each in readdir(dir)
-        each in ("stable", "latest")        ? push!(named_folders,   each) :
-        ismatch(r"release\-\d+\.\d+", each) ? push!(release_folders, each) :
-        ismatch(Base.VERSION_REGEX, each)   ? push!(tag_folders,     each) : nothing
+        each in ("stable", "latest")         ? push!(named_folders,   each) :
+        contains(each, r"release\-\d+\.\d+") ? push!(release_folders, each) :
+        contains(each, Base.VERSION_REGEX)   ? push!(tag_folders,     each) : nothing
     end
     open(joinpath(dir, "versions.js"), "w") do buf
         println(buf, "var DOC_VERSIONS = [")
@@ -863,7 +863,7 @@ function mdconvert(c::Markdown.Code, parent::MDBlockContext; kwargs...)
         # script-type doctest should match the corresponding one in DocChecks.jl. This makes
         # sure that doctests get highlighted the same way independent of whether they're
         # being run or not.
-        ismatch(r"^julia> "m, c.code) ? "julia-repl" : "julia"
+        contains(c.code, r"^julia> "m) ? "julia-repl" : "julia"
     else
         c.language
     end

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -167,7 +167,7 @@ function copy_asset(file, doc)
     end
     assetpath = normpath(joinpath("assets", file))
     # Replace any backslashes in links, if building the docs on Windows
-    return replace(assetpath, '\\', '/')
+    return replace(assetpath, '\\' => '/')
 end
 
 # Page
@@ -548,7 +548,7 @@ search_append(sib, node) = mdflatten(sib.buffer, node)
 
 function search_flush(sib)
     # Replace any backslashes in links, if building the docs on Windows
-    src = replace(sib.src, '\\', '/')
+    src = replace(sib.src, '\\' => '/')
     ref = "$(src)#$(sib.loc)"
     text = Utilities.takebuf_str(sib.buffer)
     println(sib.ctx.search_index, """
@@ -563,9 +563,9 @@ function search_flush(sib)
 end
 
 function jsonescape(s)
-    s = replace(s, '\\', "\\\\")
-    s = replace(s, '\n', "\\n")
-    replace(s, '"', "\\\"")
+    s = replace(s, '\\' => "\\\\")
+    s = replace(s, '\n' => "\\n")
+    replace(s, '"' => "\\\"")
 end
 
 function domify(ctx, navnode, node)
@@ -732,7 +732,7 @@ function relhref(from, to)
     pagedir = dirname(from)
     # The regex separator replacement is necessary since otherwise building the docs on
     # Windows will result in paths that have `//` separators which break asset inclusion.
-    replace(relpath(to, isempty(pagedir) ? "." : pagedir), r"[/\\]+", "/")
+    replace(relpath(to, isempty(pagedir) ? "." : pagedir), r"[/\\]+" => "/")
 end
 
 """
@@ -954,7 +954,7 @@ function fixlinks!(ctx, navnode, link::Markdown.Link)
     end
 
     # Replace any backslashes in links, if building the docs on Windows
-    path = replace(path, '\\', '/')
+    path = replace(path, '\\' => '/')
     link.url = (length(s) > 1) ? "$path#$(last(s))" : String(path)
 end
 
@@ -970,7 +970,7 @@ function fixlinks!(ctx, navnode, img::Markdown.Image)
     if isfile(joinpath(ctx.doc.user.build, path))
         path = relhref(get_url(ctx, navnode), path)
         # Replace any backslashes in links, if building the docs on Windows
-        img.url = replace(path, '\\', '/')
+        img.url = replace(path, '\\' => '/')
     else
         Utilities.warn("Invalid local image: unresolved path\n    '$(img.url)' in `$(navnode.page)`")
     end

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -47,7 +47,7 @@ function render(doc::Documents.Document)
     mktempdir() do path
         cp(joinpath(doc.user.root, doc.user.build), joinpath(path, "build"))
         cd(joinpath(path, "build")) do
-            file = replace("$(doc.user.sitename).tex", " ", "")
+            file = replace("$(doc.user.sitename).tex", " " => "")
             open(file, "w") do io
                 context = Context(io)
                 writeheader(context, doc)
@@ -75,7 +75,7 @@ function render(doc::Documents.Document)
             cp(STYLE, "documenter.sty")
             if hastex()
                 outdir = joinpath(doc.user.root, doc.user.build)
-                pdf = replace("$(doc.user.sitename).pdf", " ", "")
+                pdf = replace("$(doc.user.sitename).pdf", " " => "")
                 try
                     run(`latexmk -f -interaction=nonstopmode -view=none -lualatex -shell-escape $file`)
                 catch err

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -269,7 +269,7 @@ function latex(io::IO, code::Markdown.Code)
         # script-type doctest should match the corresponding one in DocChecks.jl. This makes
         # sure that doctests get highlighted the same way independent of whether they're
         # being run or not.
-        ismatch(r"^julia> "m, code.code) ? "julia-repl" : "julia"
+        contains(code.code, r"^julia> "m) ? "julia-repl" : "julia"
     else
         code.language
     end

--- a/test/docsystem.jl
+++ b/test/docsystem.jl
@@ -75,7 +75,7 @@ PACKAGES_LOADED_MAIN = VERSION < v"0.7.0-DEV.1877"
     end
 
     ## `UnionAll`
-    let b = DocSystem.binding(@__MODULE__, parse("f(x::T) where T"))
+    let b = DocSystem.binding(@__MODULE__, Meta.parse("f(x::T) where T"))
         @test b.var == :f
     end
 end

--- a/test/examples/src/lib/functions.md
+++ b/test/examples/src/lib/functions.md
@@ -92,7 +92,8 @@ b = ans
 ```
 
 ```@repl
-srand(1); # hide
+using Documenter # hide
+Documenter.Random.srand(1); # hide
 nothing
 rand()
 a = 1

--- a/test/examples/src/man/tutorial.md
+++ b/test/examples/src/man/tutorial.md
@@ -38,7 +38,8 @@ a + b
 ```@meta
 DocTestSetup =
     quote
-        srand(1)
+        using Documenter
+        Documenter.Random.srand(1)
     end
 ```
 


### PR DESCRIPTION
Building the docs on CI results in a huge amount of depwarn again, fixed most of them.

Needs https://github.com/JuliaLang/Compat.jl/pull/452 to pass on julia 0.6

It would be nice with a new release with this and 611aa82bfac3ea64306a5b8e8be9675cbc519eb8 which should silence most of the warnings.