### PR TITLE
Make menu section separation darker

### DIFF
--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -271,7 +271,7 @@ nav.toc ul.internal {
 }
 
 nav.toc ul.internal li.toplevel {
-    border-top: 1px solid #c9c9c9;
+    border-top: 1px solid #909090;
     font-weight: bold;
 }
 


### PR DESCRIPTION
Fixes #635. Will stick with `px` units, since they should actually scale properly with DPI and zoom and `em` feels a bit weird for a border.