### PR TITLE
HTMLWriter.jl: lowercase categories

### DIFF
--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -556,7 +556,7 @@ function search_flush(sib)
         "location": "$(jsonescape(ref))",
         "page": "$(jsonescape(sib.page_title))",
         "title": "$(jsonescape(sib.title))",
-        "category": "$(jsonescape(string(sib.category)))",
+        "category": "$(jsonescape(lowercase(string(sib.category))))",
         "text": "$(jsonescape(text))"
     },
     """)


### PR DESCRIPTION
this ensures that the category of entries in search results listings
(e.g. "function", "method", "module", "page", "section", etc.)
will be rendered consistently in lowercase.

Fix #634