### PR TITLE
Deprecation fixes

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
-Compat 0.47.0
+Compat 0.54.0
 DocStringExtensions 0.2

--- a/src/CrossReferences.jl
+++ b/src/CrossReferences.jl
@@ -14,6 +14,7 @@ import ..Documenter:
     Walkers
 
 using Compat, DocStringExtensions
+import Compat.Markdown
 
 """
 $(SIGNATURES)
@@ -49,7 +50,7 @@ end
 xref(other, meta, page, doc) = true # Continue to `walk` through element `other`.
 
 function basicxref(link::Markdown.Link, meta, page, doc)
-    if length(link.text) === 1 && isa(link.text[1], Base.Markdown.Code)
+    if length(link.text) === 1 && isa(link.text[1], Markdown.Code)
         docsxref(link, link.text[1].code, meta, page, doc)
     elseif isa(link.text, Vector)
         # No `name` was provided, since given a `@ref`, so slugify the `.text` instead.
@@ -76,7 +77,7 @@ function namedxref(link::Markdown.Link, meta, page, doc)
     else
         if Anchors.exists(doc.internal.headers, slug)
             namedxref(link, slug, meta, page, doc)
-        elseif length(link.text) === 1 && isa(link.text[1], Base.Markdown.Code)
+        elseif length(link.text) === 1 && isa(link.text[1], Markdown.Code)
             docsxref(link, slug, meta, page, doc)
         else
             namedxref(link, slug, meta, page, doc)

--- a/src/CrossReferences.jl
+++ b/src/CrossReferences.jl
@@ -204,7 +204,7 @@ function find_object(binding, typesig)
     end
 end
 function find_object(λ::Union{Function, DataType}, binding, typesig)
-    if _method_exists(λ, typesig)
+    if hasmethod(λ, typesig)
         signature = getsig(λ, typesig)
         return Utilities.Object(binding, signature)
     else
@@ -213,8 +213,6 @@ function find_object(λ::Union{Function, DataType}, binding, typesig)
 end
 find_object(::Union{Function, DataType}, binding, ::Union{Union,Type{Union{}}}) = Utilities.Object(binding, Union{})
 find_object(other, binding, typesig) = Utilities.Object(binding, typesig)
-
-_method_exists(f, t) = method_exists(f, t)
 
 getsig(λ::Union{Function, DataType}, typesig) = Base.tuple_type_tail(which(λ, typesig).sig)
 

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -312,22 +312,22 @@ function report(result::Result, str, doc::Documents.Document)
     buffer = IOBuffer()
     println(buffer, "=====[Test Error]", "="^30)
     println(buffer)
-    print_with_color(:cyan, buffer, "> File: ", result.file, "\n")
-    print_with_color(:cyan, buffer, "\n> Code block:\n")
+    printstyled(buffer, "> File: ", result.file, "\n", color=:cyan)
+    printstyled(buffer, "\n> Code block:\n", color=:cyan)
     println(buffer, "\n```jldoctest")
     println(buffer, result.code)
     println(buffer, "```")
     if !isempty(result.input)
-        print_with_color(:cyan, buffer, "\n> Subexpression:\n")
+        printstyled(buffer, "\n> Subexpression:\n", color=:cyan)
         print_indented(buffer, result.input; indent = 4)
     end
     warning = Base.have_color ? "" : " (REQUIRES COLOR)"
-    print_with_color(:cyan, buffer, "\n> Output Diff", warning, ":\n\n")
+    printstyled(buffer, "\n> Output Diff", warning, ":\n\n", color=:cyan)
     diff = TextDiff.Diff{TextDiff.Words}(result.output, rstrip(str))
     Utilities.TextDiff.showdiff(buffer, diff)
     println(buffer, "\n\n", "=====[End Error]=", "="^30)
     push!(doc.internal.errors, :doctest)
-    print_with_color(:normal, Utilities.takebuf_str(buffer))
+    printstyled(Utilities.takebuf_str(buffer), color=:normal)
 end
 
 function print_indented(buffer::IO, str::AbstractString; indent = 4)
@@ -483,7 +483,7 @@ function linkcheck(link::Markdown.Link, doc::Documents.Document)
     # first, make sure we're not supposed to ignore this link
     for r in doc.user.linkcheck_ignore
         if linkcheck_ismatch(r, link.url)
-            print_with_color(:normal, INDENT, "--- ", link.url, "\n")
+            printstyled(INDENT, "--- ", link.url, "\n", color=:normal)
             return false
         end
     end
@@ -501,19 +501,19 @@ function linkcheck(link::Markdown.Link, doc::Documents.Document)
         if contains(result, STATUS_REGEX)
             status = parse(Int, match(STATUS_REGEX, result).captures[1])
             if status < 300
-                print_with_color(:green, INDENT, "$(status) ", link.url, "\n")
+                printstyled(INDENT, "$(status) ", link.url, "\n", color=:green)
             elseif status < 400
                 LOCATION_REGEX = r"^Location: (.+)$"m
                 if contains(result, LOCATION_REGEX)
                     location = strip(match(LOCATION_REGEX, result).captures[1])
-                    print_with_color(:yellow, INDENT, "$(status) ", link.url, "\n")
-                    print_with_color(:yellow, INDENT, " -> ", location, "\n\n")
+                    printstyled(INDENT, "$(status) ", link.url, "\n", color=:yellow)
+                    printstyled(INDENT, " -> ", location, "\n\n", color=:yellow)
                 else
-                    print_with_color(:yellow, INDENT, "$(status) ", link.url, "\n")
+                    printstyled(INDENT, "$(status) ", link.url, "\n", color=:yellow)
                 end
             else
                 push!(doc.internal.errors, :linkcheck)
-                print_with_color(:red, INDENT, "$(status) ", link.url, "\n")
+                printstyled(INDENT, "$(status) ", link.url, "\n", color=:red)
             end
         else
             push!(doc.internal.errors, :linkcheck)

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -14,6 +14,7 @@ import ..Documenter:
     IdDict
 
 using Compat, DocStringExtensions
+import Compat.Markdown
 
 # Missing docstrings.
 # -------------------
@@ -476,7 +477,7 @@ function linkcheck(doc::Documents.Document)
     return nothing
 end
 
-function linkcheck(link::Base.Markdown.Link, doc::Documents.Document)
+function linkcheck(link::Markdown.Link, doc::Documents.Document)
     INDENT = " "^6
 
     # first, make sure we're not supposed to ignore this link

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -380,7 +380,7 @@ function repl_splitter(code)
 end
 
 function savebuffer!(out, buf)
-    n = nb_available(seekstart(buf))
+    n = bytesavailable(seekstart(buf))
     n > 0 ? push!(out, rstrip(Utilities.takebuf_str(buf))) : out
 end
 

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -80,7 +80,7 @@ meta(m) = Docs.meta(m)
 nameof(x::Function)          = typeof(x).name.mt.name
 nameof(b::Base.Docs.Binding) = b.var
 nameof(x::DataType)          = x.name.name
-nameof(m::Module)            = module_name(m)
+nameof(m::Module)            = Compat.nameof(m)
 
 sigs(x::Base.Docs.MultiDoc) = x.order
 sigs(::Any) = Type[Union{}]
@@ -241,7 +241,7 @@ end
 
 # Regex used here to replace gensym'd module names could probably use improvements.
 function checkresult(sandbox::Module, result::Result, meta::Dict, doc::Documents.Document)
-    sandbox_name = module_name(sandbox)
+    sandbox_name = nameof(sandbox)
     mod_regex = Regex("(Main\\.)?(Symbol\\(\"$(sandbox_name)\"\\)|$(sandbox_name))[,.]")
     mod_regex_nodot = Regex(("(Main\\.)?$(sandbox_name)"))
     if isdefined(result, :bt) # An error was thrown and we have a backtrace.

--- a/src/DocSystem.jl
+++ b/src/DocSystem.jl
@@ -53,7 +53,7 @@ end
 # This is done within the `Binding` constructor on `0.5`, but not on `0.4`.
 #
 function binding(m::Module, v::Symbol)
-    m = nameof(m) === v ? module_parent(m) : m
+    m = nameof(m) === v ? parentmodule(m) : m
     Docs.Binding(m, v)
 end
 

--- a/src/DocSystem.jl
+++ b/src/DocSystem.jl
@@ -43,7 +43,7 @@ binding(f::Function)     = binding(typeof(f).name.module, typeof(f).name.mt.name
 #
 # Note that `IntrinsicFunction` is exported from `Base` in `0.4`, but not in `0.5`.
 #
-let INTRINSICS = Dict(map(s -> getfield(Core.Intrinsics, s) => s, names(Core.Intrinsics, true)))
+let INTRINSICS = Dict(map(s -> getfield(Core.Intrinsics, s) => s, Compat.names(Core.Intrinsics, all=true)))
     binding(i::Core.IntrinsicFunction) = binding(Core.Intrinsics, INTRINSICS[i]::Symbol)
 end
 

--- a/src/DocSystem.jl
+++ b/src/DocSystem.jl
@@ -33,7 +33,7 @@ binding(any::Any) = throw(ArgumentError("cannot convert `$any` to a `Binding`.")
 #
 binding(b::Docs.Binding) = binding(b.mod, b.var)
 binding(d::DataType)     = binding(d.name.module, d.name.name)
-binding(m::Module)       = binding(m, module_name(m))
+binding(m::Module)       = binding(m, nameof(m))
 binding(s::Symbol)       = binding(Main, s)
 binding(f::Function)     = binding(typeof(f).name.module, typeof(f).name.mt.name)
 
@@ -53,7 +53,7 @@ end
 # This is done within the `Binding` constructor on `0.5`, but not on `0.4`.
 #
 function binding(m::Module, v::Symbol)
-    m = module_name(m) === v ? module_parent(m) : m
+    m = nameof(m) === v ? module_parent(m) : m
     Docs.Binding(m, v)
 end
 

--- a/src/DocSystem.jl
+++ b/src/DocSystem.jl
@@ -5,6 +5,7 @@ docsystem in both `0.4` and `0.5`.
 module DocSystem
 
 using Compat, DocStringExtensions
+import Compat.Markdown
 import Base.Docs: MultiDoc, parsedoc, formatdoc, DocStr
 import ..IdDict
 

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -600,7 +600,7 @@ using Compat, DocStringExtensions
 
 export genkeys
 
-import Base.LibGit2.GITHUB_REGEX
+import Compat.LibGit2.GITHUB_REGEX
 
 
 """

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -16,6 +16,7 @@ import ..Documenter:
     IdDict
 
 using Compat, DocStringExtensions
+import Compat.Markdown
 using Compat.Unicode
 
 # Pages.
@@ -50,7 +51,7 @@ struct Page
     globals  :: Globals
 end
 function Page(source::AbstractString, build::AbstractString)
-    elements = Base.Markdown.parse(read(source, String)).content
+    elements = Markdown.parse(read(source, String)).content
     Page(source, build, elements, IdDict(), Globals())
 end
 
@@ -124,7 +125,7 @@ struct DocsNodes
 end
 
 struct EvalNode
-    code   :: Base.Markdown.Code
+    code   :: Markdown.Code
     result :: Any
 end
 
@@ -219,7 +220,7 @@ struct Internal
     objects :: IdDict                    # Tracks which `Utilities.Objects` are included in the `Document`.
     contentsnodes :: Vector{ContentsNode}
     indexnodes    :: Vector{IndexNode}
-    locallinks :: Dict{Base.Markdown.Link, String}
+    locallinks :: Dict{Markdown.Link, String}
     errors::Set{Symbol}
 end
 
@@ -306,7 +307,7 @@ function Document(;
         IdDict(),
         [],
         [],
-        Dict{Base.Markdown.Link, String}(),
+        Dict{Markdown.Link, String}(),
         Set{Symbol}(),
     )
     Document(user, internal)

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -20,6 +20,7 @@ import .Documents:
     MetaNode
 
 using Compat
+import Compat.Markdown
 
 
 function expand(doc::Documents.Document)
@@ -291,7 +292,7 @@ function Selectors.runner(::Type{DocsBlocks}, x, page, doc)
         end
 
         # Concatenate found docstrings into a single `MD` object.
-        docstr = Base.Markdown.MD(map(Documenter.DocSystem.parsedoc, docs))
+        docstr = Markdown.MD(map(Documenter.DocSystem.parsedoc, docs))
         docstr.meta[:results] = docs
 
         # Generate a unique name to be used in anchors and links for the docstring.
@@ -518,7 +519,7 @@ function Selectors.runner(::Type{REPLBlocks}, x, page, doc)
             println(out, output, "\n")
         end
     end
-    page.mapping[x] = Base.Markdown.Code("julia-repl", rstrip(Utilities.takebuf_str(out)))
+    page.mapping[x] = Markdown.Code("julia-repl", rstrip(Utilities.takebuf_str(out)))
 end
 
 # @setup

--- a/src/Utilities/MDFlatten.jl
+++ b/src/Utilities/MDFlatten.jl
@@ -13,7 +13,7 @@ import ..Utilities
 
 using Compat
 
-import Base.Markdown:
+import Compat.Markdown:
     MD, BlockQuote, Bold, Code, Header, HorizontalRule,
     Image, Italic, LaTeX, LineBreak, Link, List, Paragraph, Table,
     Footnote, Admonition

--- a/src/Utilities/TextDiff.jl
+++ b/src/Utilities/TextDiff.jl
@@ -50,7 +50,7 @@ function splitby(reg::Regex, text::AbstractString)
     out = SubString{String}[]
     token_first = 1
     for each in eachmatch(reg, text)
-        token_last = each.offset + endof(each.match) - 1
+        token_last = each.offset + lastindex(each.match) - 1
         push!(out, SubString(text, token_first, token_last))
         token_first = nextind(text, token_last)
     end

--- a/src/Utilities/TextDiff.jl
+++ b/src/Utilities/TextDiff.jl
@@ -90,12 +90,12 @@ prefix(::Diff{Words}, ::Symbol) = ""
 
 function showdiff(io::IO, diff::Diff)
     for (color, text) in diff.diff
-        print_with_color(color, io, prefix(diff, color), text)
+        printstyled(io, prefix(diff, color), text, color=color)
     end
 end
 
 function Base.show(io::IO, diff::Diff)
-    print_with_color(:normal, io) # Reset colors.
+    printstyled(io, color=:normal) # Reset colors.
     showdiff(io, diff)
 end
 

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -118,7 +118,7 @@ function parseblock(code::AbstractString, doc, page; skip = 0, keywords = true)
     code = last(split(code, '\n', limit = skip + 1))
     # Check whether we have windows-style line endings.
     offset = contains(code, "\n\r") ? 2 : 1
-    endofstr = endof(code)
+    endofstr = lastindex(code)
     results = []
     cursor = 1
     while cursor < endofstr
@@ -128,7 +128,7 @@ function parseblock(code::AbstractString, doc, page; skip = 0, keywords = true)
         (ex, ncursor) =
             if keywords && haskey(Docs.keywords, keyword)
                 # adding offset below should be OK, as `\n` and `\r` are single byte
-                (QuoteNode(keyword), cursor + endof(line) + offset)
+                (QuoteNode(keyword), cursor + lastindex(line) + offset)
             else
                 try
                     Meta.parse(code, cursor)

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -468,7 +468,7 @@ function getremote(dir::AbstractString)
         catch err
             ""
         end
-    m = match(Base.LibGit2.GITHUB_REGEX, remote)
+    m = match(Compat.LibGit2.GITHUB_REGEX, remote)
     if m === nothing
         travis = get(ENV, "TRAVIS_REPO_SLUG", "")
         isempty(travis) ? "" : travis

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -21,15 +21,15 @@ logging(flag::Bool) = __log__[] = flag
 """
 Format and print a message to the user.
 """
-log(msg) = __log__[] ? print_with_color(:magenta, STDOUT, "Documenter: ", msg, "\n") : nothing
+log(msg) = __log__[] ? printstyled(STDOUT, "Documenter: ", msg, "\n", color=:magenta) : nothing
 
 # Print logging output to the "real" STDOUT.
 function log(doc, msg)
-    __log__[] && print_with_color(:magenta, STDOUT, "Documenter: ", msg, "\n")
+    __log__[] && printstyled(STDOUT, "Documenter: ", msg, "\n", color=:magenta)
     return nothing
 end
 
-debug(msg) = print_with_color(:green, " ?? ", msg, "\n")
+debug(msg) = printstyled(" ?? ", msg, "\n", color=:green)
 
 """
     warn(file, msg)
@@ -41,17 +41,17 @@ where the warning was raised.
 function warn(file, msg)
     if __log__[]
         msg = string(" !! ", msg, " [", file, "]\n")
-        print_with_color(:red, STDOUT, msg)
+        printstyled(STDOUT, msg, color=:red)
     else
         nothing
     end
 end
-warn(msg) = __log__[] ? print_with_color(:red, STDOUT, " !! ", msg, "\n") : nothing
+warn(msg) = __log__[] ? printstyled(STDOUT, " !! ", msg, "\n", color=:red) : nothing
 
 function warn(file, msg, err, ex, mod)
     if __log__[]
         warn(file, msg)
-        print_with_color(:red, STDOUT, "\nERROR: $err\n\nexpression '$ex' in module '$mod'\n\n")
+        printstyled(STDOUT, "\nERROR: $err\n\nexpression '$ex' in module '$mod'\n\n", color=:red)
     else
         nothing
     end
@@ -59,7 +59,7 @@ end
 
 function warn(doc, page, msg, err)
     file = page.source
-    print_with_color(:red, STDOUT, " !! Warning in $(file):\n\n$(msg)\n\nERROR: $(err)\n\n")
+    printstyled(STDOUT, " !! Warning in $(file):\n\n$(msg)\n\nERROR: $(err)\n\n", color=:red)
 end
 
 # Directory paths.

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -202,7 +202,7 @@ struct Object
     signature :: Type
 
     function Object(b::Binding, signature::Type)
-        m = nameof(b.mod) === b.var ? module_parent(b.mod) : b.mod
+        m = nameof(b.mod) === b.var ? parentmodule(b.mod) : b.mod
         new(Binding(m, b.var), signature)
     end
 end
@@ -493,7 +493,7 @@ function inbase(m::Module)
     if m ≡ Base
         true
     else
-        parent = module_parent(m)
+        parent = parentmodule(m)
         parent ≡ m ? false : inbase(parent)
     end
 end
@@ -617,7 +617,7 @@ function issubmodule(sub, mod)
     if (sub === Main) && (mod !== Main)
         return false
     end
-    (sub === mod) || issubmodule(module_parent(sub), mod)
+    (sub === mod) || issubmodule(parentmodule(sub), mod)
 end
 
 """

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -176,7 +176,7 @@ function submodules(modules::Vector{Module})
 end
 function submodules(root::Module, seen = Set{Module}())
     push!(seen, root)
-    for name in names(root, true)
+    for name in Compat.names(root, all=true)
         if Base.isidentifier(name) && isdefined(root, name) && !isdeprecated(root, name)
             object = getfield(root, name)
             if isa(object, Module) && !(object in seen)

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -202,7 +202,7 @@ struct Object
     signature :: Type
 
     function Object(b::Binding, signature::Type)
-        m = module_name(b.mod) === b.var ? module_parent(b.mod) : b.mod
+        m = nameof(b.mod) === b.var ? module_parent(b.mod) : b.mod
         new(Binding(m, b.var), signature)
     end
 end

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -6,6 +6,7 @@ module Utilities
 using Base.Meta, Compat
 import Base: isdeprecated, Docs.Binding
 using DocStringExtensions
+import Compat.Markdown
 
 # Logging output.
 

--- a/src/Walkers.jl
+++ b/src/Walkers.jl
@@ -12,6 +12,7 @@ import ..Documenter:
     Utilities
 
 using Compat, DocStringExtensions
+import Compat.Markdown
 
 """
 $(SIGNATURES)

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -65,7 +65,7 @@ Adding an ICO asset is primarilly useful for setting a custom `favicon`.
 module HTMLWriter
 
 using Compat
-import Base.Markdown: isordered
+import Compat.Markdown
 
 import ...Documenter:
     Anchors,
@@ -498,7 +498,7 @@ end
 # ------------
 
 """
-Converts recursively a [`Documents.Page`](@ref), `Base.Markdown` or Documenter
+Converts recursively a [`Documents.Page`](@ref), `Markdown` or Documenter
 `*Node` objects into HTML DOM.
 """
 function domify(ctx, navnode)
@@ -570,7 +570,7 @@ end
 
 function domify(ctx, navnode, node)
     fixlinks!(ctx, navnode, node)
-    mdconvert(node, Base.Markdown.MD())
+    mdconvert(node, Markdown.MD())
 end
 
 function domify(ctx, navnode, anchor::Anchors.Anchor)
@@ -779,7 +779,7 @@ was unable to find any `<h1>` headers).
 function pagetitle(page::Documents.Page)
     title = nothing
     for element in page.elements
-        if isa(element, Base.Markdown.Header{1})
+        if isa(element, Markdown.Header{1})
             title = element.text
             break
         end
@@ -808,7 +808,7 @@ function collect_subsections(page::Documents.Page)
     sections = []
     title_found = false
     for element in page.elements
-        if isa(element, Base.Markdown.Header) && Utilities.header_level(element) < 3
+        if isa(element, Markdown.Header) && Utilities.header_level(element) < 3
             toplevel = Utilities.header_level(element) === 1
             # Don't include the first header if it is `h1`.
             if toplevel && isempty(sections) && !title_found
@@ -889,7 +889,7 @@ function mdconvert(link::Markdown.Link, parent; droplinks=false, kwargs...)
     droplinks ? link_text : Tag(:a)[:href => link.url](link_text)
 end
 
-mdconvert(list::Markdown.List, parent; kwargs...) = (isordered(list) ? Tag(:ol) : Tag(:ul))(map(Tag(:li), mdconvert(list.items, list; kwargs...)))
+mdconvert(list::Markdown.List, parent; kwargs...) = (Markdown.isordered(list) ? Tag(:ol) : Tag(:ul))(map(Tag(:li), mdconvert(list.items, list; kwargs...)))
 
 mdconvert(paragraph::Markdown.Paragraph, parent; kwargs...) = Tag(:p)(mdconvert(paragraph.content, paragraph; kwargs...))
 

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -14,7 +14,7 @@ import ...Documenter:
     Writers
 
 using Compat
-import Base.Markdown: isordered
+import Compat.Markdown
 
 mutable struct Context{I <: IO} <: IO
     io::I
@@ -337,7 +337,7 @@ function latex(io::IO, md::Markdown.List)
     # \end{itemize}
     #
     pad = ndigits(md.ordered + length(md.items)) + 2
-    fmt = n -> (isordered(md) ? "[$(rpad("$(n + md.ordered - 1).", pad))]" : "")
+    fmt = n -> (Markdown.isordered(md) ? "[$(rpad("$(n + md.ordered - 1).", pad))]" : "")
     wrapblock(io, "itemize") do
         for (n, item) in enumerate(md.items)
             _print(io, "\\item$(fmt(n)) ")

--- a/src/Writers/MarkdownWriter.jl
+++ b/src/Writers/MarkdownWriter.jl
@@ -12,6 +12,8 @@ import ...Documenter:
     Documenter,
     Utilities
 
+import Compat.Markdown
+
 function render(doc::Documents.Document)
     copy_assets(doc)
     mime = Formats.mimetype(:markdown)

--- a/test/docsystem.jl
+++ b/test/docsystem.jl
@@ -38,11 +38,11 @@ PACKAGES_LOADED_MAIN = VERSION < v"0.7.0-DEV.1877"
 
     ## `MultiDoc` object.
     @test isdefined(DocSystem, :MultiDoc)
-    @test fieldnames(DocSystem.MultiDoc) == [:order, :docs]
+    @test (fieldnames(DocSystem.MultiDoc)...,) == (:order, :docs)
 
     ## `DocStr` object.
     @test isdefined(DocSystem, :DocStr)
-    @test fieldnames(DocSystem.DocStr) == [:text, :object, :data]
+    @test (fieldnames(DocSystem.DocStr)...,) == (:text, :object, :data)
     ## `getdocs`.
     let b   = DocSystem.binding(DocSystem, :getdocs),
         d_0 = DocSystem.getdocs(b, Tuple{}),

--- a/test/formats/markdown.jl
+++ b/test/formats/markdown.jl
@@ -1,6 +1,7 @@
 module MarkdownFormatTests
 
 using Compat.Test
+using Compat.Random
 using Compat: @info
 
 using Documenter

--- a/test/mdflatten.jl
+++ b/test/mdflatten.jl
@@ -2,7 +2,7 @@ module MDFlattenTests
 
 using Compat.Test
 
-using Base.Markdown
+import Compat.Markdown
 using Documenter.Utilities.MDFlatten
 
 @testset "MDFlatten" begin


### PR DESCRIPTION
Requires https://github.com/JuliaLang/Compat.jl/pull/492, https://github.com/JuliaLang/Compat.jl/pull/493 ~and https://github.com/JuliaLang/Compat.jl/pull/494~ and then a new Compat release to pass on 0.6.