### PR TITLE
add doctest = :fix option to makedocs

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
-Compat 0.57.0
+Compat 0.58.0
 DocStringExtensions 0.2

--- a/docs/src/man/doctests.md
+++ b/docs/src/man/doctests.md
@@ -263,6 +263,26 @@ julia> @time [1,2,3,4]
     The global filters, filters defined in `@meta` blocks, and filters defined with the `filter`
     keyword argument are all applied to each doctest.
 
+## Fixing outdated Doctests
+
+To fix outdated doctests, the `doctest` flag to [`makedocs`](@ref) can be set to
+`doctest = :fix`. This will run the doctests, and overwrite the old results with
+the new output.
+
+!!! note
+
+    The :fix option currently only works for LF line endings (`'\n'`)
+
+!!! note
+
+    It is recommended to `git commit` any code changes before running the doctest fixing.
+    That way it is simple to restore to the previous state if the the fixing goes wrong.
+
+!!! note
+
+    There are some corner cases where the fixing algorithm may replace the wrong code snippet.
+    It is therefore recommended to manually inspect the result of the fixing before committing.
+
 
 ## Skipping Doctests
 

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -96,7 +96,7 @@ the document generation when an error is thrown. Use `doctest = false` keyword i
 [`Documenter.makedocs`](@ref) to disable doctesting.
 """
 function doctest(doc::Documents.Document)
-    if doc.user.doctest
+    if doc.user.doctest === :fix || doc.user.doctest
         println(" > running doctests.")
         for (src, page) in doc.internal.pages
             empty!(page.globals.meta)
@@ -131,7 +131,7 @@ function doctest(block::Markdown.Code, meta::Dict, doc::Documents.Document, page
         end
 
         # Normalise line endings.
-        code = replace(block.code, "\r\n" => "\n")
+        block.code = replace(block.code, "\r\n" => "\n")
 
         # parse keyword arguments to doctest
         d = Dict()
@@ -147,7 +147,7 @@ function doctest(block::Markdown.Code, meta::Dict, doc::Documents.Document, page
                         in '$(meta[:CurrentFile])'
 
                         ```$(lang)
-                        $(code)
+                        $(block.code)
                         ```
                         """
                         )
@@ -162,11 +162,11 @@ function doctest(block::Markdown.Code, meta::Dict, doc::Documents.Document, page
             Meta.isexpr(expr, :block) && (expr.head = :toplevel)
             eval(sandbox, expr)
         end
-        if contains(code, r"^julia> "m)
-            eval_repl(code, sandbox, meta, doc, page)
+        if contains(block.code, r"^julia> "m)
+            eval_repl(block, sandbox, meta, doc, page)
             block.language = "julia-repl"
-        elseif contains(code, r"^# output$"m)
-            eval_script(code, sandbox, meta, doc, page)
+        elseif contains(block.code, r"^# output$"m)
+            eval_script(block, sandbox, meta, doc, page)
             block.language = "julia"
         else
             push!(doc.internal.errors, :doctest)
@@ -175,7 +175,7 @@ function doctest(block::Markdown.Code, meta::Dict, doc::Documents.Document, page
                 Invalid doctest block. Requires `julia> ` or `# output` in '$(meta[:CurrentFile])'
 
                 ```$(lang)
-                $(code)
+                $(block.code)
                 ```
                 """
             )
@@ -194,23 +194,23 @@ end
 # Doctest evaluation.
 
 mutable struct Result
-    code   :: String # The entire code block that is being tested.
-    input  :: String # Part of `code` representing the current input.
-    output :: String # Part of `code` representing the current expected output.
+    block  :: Markdown.Code # The entire code block that is being tested.
+    input  :: String # Part of `block.code` representing the current input.
+    output :: String # Part of `block.code` representing the current expected output.
     file   :: String # File in which the doctest is written. Either `.md` or `.jl`.
     value  :: Any        # The value returned when evaluating `input`.
     hide   :: Bool       # Semi-colon suppressing the output?
     stdout :: IOBuffer   # Redirected stdout/stderr gets sent here.
     bt     :: Vector     # Backtrace when an error is thrown.
 
-    function Result(code, input, output, file)
-        new(code, input, rstrip(output, '\n'), file, nothing, false, IOBuffer())
+    function Result(block, input, output, file)
+        new(block, input, rstrip(output, '\n'), file, nothing, false, IOBuffer())
     end
 end
 
-function eval_repl(code, sandbox, meta::Dict, doc::Documents.Document, page)
-    for (input, output) in repl_splitter(code)
-        result = Result(code, input, output, meta[:CurrentFile])
+function eval_repl(block, sandbox, meta::Dict, doc::Documents.Document, page)
+    for (input, output) in repl_splitter(block.code)
+        result = Result(block, input, output, meta[:CurrentFile])
         for (ex, str) in Utilities.parseblock(input, doc, page; keywords = false)
             # Input containing a semi-colon gets suppressed in the final output.
             result.hide = Documenter.REPL.ends_with_semicolon(str)
@@ -232,14 +232,16 @@ function eval_repl(code, sandbox, meta::Dict, doc::Documents.Document, page)
     end
 end
 
-function eval_script(code, sandbox, meta::Dict, doc::Documents.Document, page)
+function eval_script(block, sandbox, meta::Dict, doc::Documents.Document, page)
     # TODO: decide whether to keep `# output` syntax for this. It's a bit ugly.
     #       Maybe use double blank lines, i.e.
     #
     #
     #       to mark `input`/`output` separation.
-    input, output = split(code, "\n# output\n", limit = 2)
-    result = Result(code, "", output, meta[:CurrentFile])
+    input, output = split(block.code, "# output\n", limit = 2)
+    input  = rstrip(input, '\n')
+    output = lstrip(output, '\n')
+    result = Result(block, input, output, meta[:CurrentFile])
     for (ex, str) in Utilities.parseblock(input, doc, page; keywords = false)
         (value, success, backtrace, text) = Utilities.withoutput() do
             Core.eval(sandbox, ex)
@@ -285,7 +287,11 @@ function checkresult(sandbox::Module, result::Result, meta::Dict, doc::Documents
         # Since checking for the prefix of an error won't catch the empty case we need
         # to check that manually with `isempty`.
         if isempty(head) || !startswith(str, head)
-            report(result, str, doc)
+            if doc.user.doctest === :fix
+                fix_doctest(result, str, doc)
+            else
+                report(result, str, doc)
+            end
         end
     else
         value = result.hide ? nothing : result.value # `;` hides output.
@@ -294,7 +300,13 @@ function checkresult(sandbox::Module, result::Result, meta::Dict, doc::Documents
         # Replace a standalone module name with `Main`.
         str = strip(replace(str, mod_regex_nodot => "Main"))
         str, output = filter_doctests((str, output), doc, meta)
-        str == output || report(result, str, doc)
+        if str != output
+            if doc.user.doctest === :fix
+                fix_doctest(result, str, doc)
+            else
+                report(result, str, doc)
+            end
+        end
     end
     return nothing
 end
@@ -343,8 +355,8 @@ function report(result::Result, str, doc::Documents.Document)
     println(ioc)
     printstyled(ioc, "> File: ", result.file, "\n", color=:cyan)
     printstyled(ioc, "\n> Code block:\n", color=:cyan)
-    println(ioc, "\n```jldoctest")
-    println(ioc, result.code)
+    println(ioc, "\n```$(result.block.language)")
+    println(ioc, result.block.code)
     println(ioc, "```")
     if !isempty(result.input)
         printstyled(ioc, "\n> Subexpression:\n", color=:cyan)
@@ -364,6 +376,43 @@ function print_indented(buffer::IO, str::AbstractString; indent = 4)
     for line in split(str, '\n')
         println(buffer, " "^indent, line)
     end
+end
+
+function fix_doctest(result::Result, str, doc::Documents.Document)
+    code = result.block.code
+    filename = Base.find_source_file(result.file)
+    # read the file containing the code block
+    content = open(f -> read(f, String), filename)
+    # output stream
+    io = Compat.IOBuffer(sizehint = sizeof(content))
+    # first look for the entire code block
+    codeidx = Compat.findnext(code, content, 1)
+    if codeidx === nothing
+        Utilities.warn("Could not find code block in source file")
+        return
+    end
+    # write everything up until the code block
+    write(io, content[1:prevind(content, first(codeidx))])
+    # next look for the particular input string in the given code block
+    inputidx = Compat.findnext(result.input, code, 1)
+    if inputidx === nothing
+        Utilities.warn("Could not find input line in code block")
+        return
+    end
+    # write everything up until the input string
+    write(io, code[1:last(inputidx)])
+    # replace old output with new output
+    newcode = replace(code[nextind(code, last(inputidx)):end], result.output => str, count = 1)
+    # replace internal code block too, needed if we come back
+    # looking to replace output in the same code block later
+    result.block.code = newcode
+    # write the rest of the code block, with replaced output
+    write(io, newcode)
+    # write rest of the file
+    write(io, content[nextind(content, last(codeidx)):end])
+    # write to file
+    open(f -> write(f, seekstart(io)), filename, "w")
+    return
 end
 
 # Remove terminal colors.

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -185,7 +185,7 @@ struct User
     build   :: String  # Parent directory is also `.root`. Where files are written to.
     format  :: Vector{Symbol} # What format to render the final document with?
     clean   :: Bool           # Empty the `build` directory before starting a new build?
-    doctest :: Bool           # Run doctests?
+    doctest :: Union{Bool,Symbol} # Run doctests?
     linkcheck::Bool           # Check external links..
     linkcheck_ignore::Vector{Union{String,Regex}}  # ..and then ignore (some of) them.
     checkdocs::Symbol         # Check objects missing from `@docs` blocks. `:none`, `:exports`, or `:all`.
@@ -241,7 +241,7 @@ function Document(;
         build    :: AbstractString   = "build",
         format   :: Any              = :markdown,
         clean    :: Bool             = true,
-        doctest  :: Bool             = true,
+        doctest  :: Union{Bool,Symbol} = true,
         linkcheck:: Bool             = false,
         linkcheck_ignore :: Vector   = [],
         checkdocs::Symbol            = :all,

--- a/test/doctests/broken.jl
+++ b/test/doctests/broken.jl
@@ -1,0 +1,62 @@
+module Foo
+"""
+```jldoctest
+julia> Int64[1, 2, 3, 4] * 2
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+
+julia> Int64[1, 2, 3, 4]
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+```
+```jldoctest
+julia> Int64[1, 2, 3, 4]
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+
+julia> Int64[1, 2, 3, 4] * 2
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+```
+```jldoctest
+julia> Int64[1, 2, 3, 4] * 2
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+
+julia> Int64[1, 2, 3, 4] * 2
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+```
+```jldoctest
+Int64[1, 2, 3, 4] * 2
+
+# output
+
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+```
+"""
+foo() = 1
+
+end # module

--- a/test/doctests/broken.md
+++ b/test/doctests/broken.md
@@ -1,0 +1,60 @@
+```@docs
+DocTestsTest.Foo.foo
+```
+
+```jldoctest
+julia> Int64[1, 2, 3, 4] * 2
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+
+julia> Int64[1, 2, 3, 4]
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+```
+```jldoctest
+julia> Int64[1, 2, 3, 4]
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+
+julia> Int64[1, 2, 3, 4] * 2
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+```
+```jldoctest
+julia> Int64[1, 2, 3, 4] * 2
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+
+julia> Int64[1, 2, 3, 4] * 2
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+```
+```jldoctest
+Int64[1, 2, 3, 4] * 2
+
+# output
+
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+```

--- a/test/doctests/doctests.jl
+++ b/test/doctests/doctests.jl
@@ -1,0 +1,27 @@
+module DocTestsTest
+using Documenter, Compat.Test
+using Compat: @info
+
+println("="^50)
+@info("Testing `doctest = :fix`")
+mktempdir(@__DIR__) do dir
+    srcdir = mktempdir(dir)
+    builddir = mktempdir(dir)
+    cp(joinpath(@__DIR__, "broken.md"), joinpath(srcdir, "index.md"))
+    cp(joinpath(@__DIR__, "broken.jl"), joinpath(srcdir, "src.jl"))
+    include(joinpath(srcdir, "src.jl"))
+    @eval using .Foo
+    # fix up
+    makedocs(modules = [Foo], source = srcdir, build = builddir, doctest = :fix)
+    # test that strict = true works
+    makedocs(modules = [Foo], source = srcdir, build = builddir, strict = true)
+    # also test that we obtain the expected output
+    @test open(f -> read(f, String), joinpath(srcdir, "index.md")) ==
+          open(f -> read(f, String), joinpath(@__DIR__, "fixed.md"))
+    @test open(f -> read(f, String), joinpath(srcdir, "src.jl")) ==
+          open(f -> read(f, String), joinpath(@__DIR__, "fixed.jl"))
+end
+@info("Done testing `doctest = :fix`")
+println("="^50)
+
+end # module

--- a/test/doctests/fixed.jl
+++ b/test/doctests/fixed.jl
@@ -1,0 +1,62 @@
+module Foo
+"""
+```jldoctest
+julia> Int64[1, 2, 3, 4] * 2
+4-element Array{Int64,1}:
+ 2
+ 4
+ 6
+ 8
+
+julia> Int64[1, 2, 3, 4]
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+```
+```jldoctest
+julia> Int64[1, 2, 3, 4]
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+
+julia> Int64[1, 2, 3, 4] * 2
+4-element Array{Int64,1}:
+ 2
+ 4
+ 6
+ 8
+```
+```jldoctest
+julia> Int64[1, 2, 3, 4] * 2
+4-element Array{Int64,1}:
+ 2
+ 4
+ 6
+ 8
+
+julia> Int64[1, 2, 3, 4] * 2
+4-element Array{Int64,1}:
+ 2
+ 4
+ 6
+ 8
+```
+```jldoctest
+Int64[1, 2, 3, 4] * 2
+
+# output
+
+4-element Array{Int64,1}:
+ 2
+ 4
+ 6
+ 8
+```
+"""
+foo() = 1
+
+end # module

--- a/test/doctests/fixed.md
+++ b/test/doctests/fixed.md
@@ -1,0 +1,60 @@
+```@docs
+DocTestsTest.Foo.foo
+```
+
+```jldoctest
+julia> Int64[1, 2, 3, 4] * 2
+4-element Array{Int64,1}:
+ 2
+ 4
+ 6
+ 8
+
+julia> Int64[1, 2, 3, 4]
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+```
+```jldoctest
+julia> Int64[1, 2, 3, 4]
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+
+julia> Int64[1, 2, 3, 4] * 2
+4-element Array{Int64,1}:
+ 2
+ 4
+ 6
+ 8
+```
+```jldoctest
+julia> Int64[1, 2, 3, 4] * 2
+4-element Array{Int64,1}:
+ 2
+ 4
+ 6
+ 8
+
+julia> Int64[1, 2, 3, 4] * 2
+4-element Array{Int64,1}:
+ 2
+ 4
+ 6
+ 8
+```
+```jldoctest
+Int64[1, 2, 3, 4] * 2
+
+# output
+
+4-element Array{Int64,1}:
+ 2
+ 4
+ 6
+ 8
+```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,9 @@ println("="^50)
     # DocSystem unit tests.
     include("docsystem.jl")
 
+    # DocTest unit tests.
+    include("doctests/doctests.jl")
+
     # DOM Tests.
     include("dom.jl")
 


### PR DESCRIPTION
This makes it easier to fix multiple outdated doctests in one command, which is useful to do e.g. when preparing a new release.

Not really sure how to test this.

fix #448