### PR TITLE
no rounding of search and version selector

### DIFF
--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -199,7 +199,6 @@ nav.toc select {
     margin: 0 auto;
     font-size: .83em;
     border: 1px solid #c9c9c9;
-    border-radius: 1em;
 
     /* TODO: doesn't seem to be centered on Safari */
     text-align: center;
@@ -231,7 +230,6 @@ nav.toc input {
     margin: 1.2em auto;
     padding: 0 1em;
     border: 1px solid #c9c9c9;
-    border-radius: 1em;
     font-size: .83em;
 }
 


### PR DESCRIPTION
I must admit that I find the rounding of the search and version selector quite ugly. This changes it to be just rectangular.

After:

<img width="336" alt="screen shot 2018-03-09 at 22 25 57" src="https://user-images.githubusercontent.com/1282691/37253904-3603d270-2538-11e8-95eb-89ec33649f5c.png">
