### PR TITLE
doctest = :fix with filters

### DIFF
--- a/docs/src/man/doctests.md
+++ b/docs/src/man/doctests.md
@@ -271,12 +271,12 @@ the new output.
 
 !!! note
 
-    The :fix option currently only works for LF line endings (`'\n'`)
+    The `:fix` option currently only works for LF line endings (`'\n'`)
 
 !!! note
 
     It is recommended to `git commit` any code changes before running the doctest fixing.
-    That way it is simple to restore to the previous state if the the fixing goes wrong.
+    That way it is simple to restore to the previous state if the fixing goes wrong.
 
 !!! note
 

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -135,7 +135,7 @@ function doctest(block::Markdown.Code, meta::Dict, doc::Documents.Document, page
 
         # parse keyword arguments to doctest
         d = Dict()
-        idx = Compat.findfirst(equalto(';'), lang)
+        idx = Compat.findfirst(c -> c == ';', lang)
         if idx !== nothing
             kwargs = Meta.parse("($(lang[nextind(lang, idx):end]),)")
             for kwarg in kwargs.args

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -295,12 +295,12 @@ function checkresult(sandbox::Module, result::Result, meta::Dict, doc::Documents
         end
     else
         value = result.hide ? nothing : result.value # `;` hides output.
-        output = replace(strip(sanitise(IOBuffer(result.output))), mod_regex => "")
+        output = replace(rstrip(sanitise(IOBuffer(result.output))), mod_regex => "")
         str = replace(result_to_string(result.stdout, value), mod_regex => "")
         # Replace a standalone module name with `Main`.
-        str = strip(replace(str, mod_regex_nodot => "Main"))
-        str, output = filter_doctests((str, output), doc, meta)
-        if str != output
+        str = rstrip(replace(str, mod_regex_nodot => "Main"))
+        filteredstr, filteredoutput = filter_doctests((str, output), doc, meta)
+        if filteredstr != filteredoutput
             if doc.user.doctest === :fix
                 fix_doctest(result, str, doc)
             else

--- a/test/doctests/broken.jl
+++ b/test/doctests/broken.jl
@@ -56,6 +56,10 @@ Int64[1, 2, 3, 4] * 2
  3
  4
 ```
+```jldoctest; filter = r"foo"
+julia> println("  foobar")
+  foobaz
+```
 """
 foo() = 1
 

--- a/test/doctests/broken.md
+++ b/test/doctests/broken.md
@@ -58,3 +58,7 @@ Int64[1, 2, 3, 4] * 2
  3
  4
 ```
+```jldoctest; filter = r"foo"
+julia> println("  foobar")
+  foobaz
+```

--- a/test/doctests/fixed.jl
+++ b/test/doctests/fixed.jl
@@ -56,6 +56,10 @@ Int64[1, 2, 3, 4] * 2
  6
  8
 ```
+```jldoctest; filter = r"foo"
+julia> println("  foobar")
+  foobar
+```
 """
 foo() = 1
 

--- a/test/doctests/fixed.md
+++ b/test/doctests/fixed.md
@@ -58,3 +58,7 @@ Int64[1, 2, 3, 4] * 2
  6
  8
 ```
+```jldoctest; filter = r"foo"
+julia> println("  foobar")
+  foobar
+```


### PR DESCRIPTION
Was about to push this to #656 but it got merged :)

This replaces the output with the unfiltered new output if the doctest fail.
Also don't strip leading whitespace, it is sometimes significant, see the testcase.