### PR TITLE
print line number range for failed doctests

### DIFF
--- a/test/doctests/doctests.jl
+++ b/test/doctests/doctests.jl
@@ -16,10 +16,10 @@ mktempdir(@__DIR__) do dir
     # test that strict = true works
     makedocs(modules = [Foo], source = srcdir, build = builddir, strict = true)
     # also test that we obtain the expected output
-    @test open(f -> read(f, String), joinpath(srcdir, "index.md")) ==
-          open(f -> read(f, String), joinpath(@__DIR__, "fixed.md"))
-    @test open(f -> read(f, String), joinpath(srcdir, "src.jl")) ==
-          open(f -> read(f, String), joinpath(@__DIR__, "fixed.jl"))
+    @test read(joinpath(srcdir, "index.md"), String) ==
+          read(joinpath(@__DIR__, "fixed.md"), String)
+    @test read(joinpath(srcdir, "src.jl"), String) ==
+          read(joinpath(@__DIR__, "fixed.jl"), String)
 end
 @info("Done testing `doctest = :fix`")
 println("="^50)


### PR DESCRIPTION
````
=====[Test Error]==============================

> Location: /home/fredrik/.julia/v0.7/TestPackage/src/TestPackage.jl:12-19        <--- Line info here is new.

> Code block:

```jldoctest; filter = r"[0-9\.]+ seconds \(.*\)"
julia> @time [1, 2, 3]
  5.0 seconds (5 allocations: 272 bytes)
3-element Array{Int64,1}:
 2
 4
 6
```

> Subexpression:

    @time [1, 2, 3]

> Output Diff:

  5.0 0.000002 seconds (5 allocations: 272 bytes)
3-element Array{Int64,1}:
 1
 2
 4
 63

=====[End Error]===============================
````