### PR TITLE
fix #689

### DIFF
--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -378,6 +378,7 @@ end
 url(remote, repo, doc) = url(remote, repo, doc.data[:module], doc.data[:path], linerange(doc))
 
 function url(remote, repo, mod, file, linerange)
+    file === nothing && return nothing # needed on julia v0.6, see #689
     remote = getremote(dirname(file))
     isabspath(file) && isempty(remote) && isempty(repo) && return nothing
 


### PR DESCRIPTION
julia v0.6 in combination with Revise sometimes causes `file` to be `nothing`.

This adds a check for this, and a fast return if so, fix #689.