### PR TITLE
Add support for `repo_root()` to function inside of git worktrees

### DIFF
--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -340,7 +340,17 @@ header_level(::Markdown.Header{N}) where {N} = N
 function repo_root(file; dbdir=".git")
     parent_dir, parent_dir_last = dirname(abspath(file)), ""
     while parent_dir !== parent_dir_last
-        isdir(joinpath(parent_dir, dbdir)) && return parent_dir
+        dbdir_path = joinpath(parent_dir, dbdir)
+        isdir(dbdir_path) && return parent_dir
+        # Let's see if this is a worktree checkout
+        if isfile(dbdir_path)
+            contents = chomp(read(dbdir_path, String))
+            if startswith(contents, "gitdir: ")
+                if isdir(contents[9:end])
+                    return parent_dir
+                end
+            end
+        end
         parent_dir, parent_dir_last = dirname(parent_dir), parent_dir
     end
     return nothing


### PR DESCRIPTION
Without this change, `repo_root()` returns `nothing` if it is run within a git repository that is a worktree (e.g. the result of using `git worktree add ...`) which is the case with all of my Julia build repositories.  This causes mysterious errors such as the following:

```
ERROR: LoadError: MethodError: no method matching startswith(::String, ::Nothing)
Closest candidates are:
  startswith(::String, ::String) at strings/util.jl:49
  startswith(::AbstractString, ::AbstractString) at strings/util.jl:22
  startswith(::AbstractString, ::Union{AbstractChar, Tuple{Vararg{AbstractChar,N} where N}, Set{#s55} where #s55<:AbstractChar, AbstractArray{#s56,1} where #s56<:AbstractChar}) at strings/util.jl:25
Stacktrace:
 [1] (::getfield(Documenter.Utilities, Symbol("##3#4")){String})() at /src/julia-master/doc/deps/v0.7/Documenter/src/Utilities/Utilities.jl:352
 [2] cd(::getfield(Documenter.Utilities, Symbol("##3#4")){String}, ::String) at ./file.jl:72
 [3] relpath_from_repo_root at /src/julia-master/doc/deps/v0.7/Documenter/src/Utilities/Utilities.jl:350 [inlined]
 [4] #url#7(::String, ::Function, ::String, ::String) at /src/julia-master/doc/deps/v0.7/Documenter/src/Utilities/Utilities.jl:366
 [5] (::getfield(Documenter.Utilities, Symbol("#kw##url")))(::NamedTuple{(:commit,),Tuple{String}}, ::typeof(Documenter.Utilities.url), ::String, ::String) at ./<missing>:0
 [6] render_article(::Documenter.Writers.HTMLWriter.HTMLContext, ::Documenter.Documents.NavNode) at /src/julia-master/doc/deps/v0.7/Documenter/src/Writers/HTMLWriter.jl:438
 [7] render_page(::Documenter.Writers.HTMLWriter.HTMLContext, ::Documenter.Documents.NavNode) at /src/julia-master/doc/deps/v0.7/Documenter/src/Writers/HTMLWriter.jl:186
 [8] render(::Documenter.Documents.Document) at /src/julia-master/doc/deps/v0.7/Documenter/src/Writers/HTMLWriter.jl:134
 [9] runner(::Type{Documenter.Writers.HTMLFormat}, ::Symbol, ::Documenter.Documents.Document) at /src/julia-master/doc/deps/v0.7/Documenter/src/Writers/Writers.jl:44
 [10] dispatch(::Type{Documenter.Writers.FormatSelector}, ::Symbol, ::Vararg{Any,N} where N) at /src/julia-master/doc/deps/v0.7/Documenter/src/Selectors.jl:168
 [11] render(::Documenter.Documents.Document) at /src/julia-master/doc/deps/v0.7/Documenter/src/Writers/Writers.jl:66
 [12] runner(::Type{Documenter.Builder.RenderDocument}, ::Documenter.Documents.Document) at /src/julia-master/doc/deps/v0.7/Documenter/src/Builder.jl:205
 [13] dispatch(::Type{Documenter.Builder.DocumentPipeline}, ::Documenter.Documents.Document, ::Vararg{Documenter.Documents.Document,N} where N) at /src/julia-master/doc/deps/v0.7/Documenter/src/Selectors.jl:168
 [14] #2 at /src/julia-master/doc/deps/v0.7/Documenter/src/Documenter.jl:205 [inlined]
 [15] cd(::getfield(Documenter, Symbol("##2#3")){Documenter.Documents.Document}, ::String) at ./file.jl:72
 [16] #makedocs#1 at /src/julia-master/doc/deps/v0.7/Documenter/src/Documenter.jl:204 [inlined]
 [17] (::getfield(Documenter, Symbol("#kw##makedocs")))(::NamedTuple{(:build, :modules, :clean, :doctest, :linkcheck, :linkcheck_ignore, :strict, :checkdocs, :format, :sitename, :authors, :analytics, :pages, :html_prettyurls, :html_canonical),Tuple{String,Array{Module,1},Bool,Bool,Bool,Array{String,1},Bool,Symbol,Symbol,String,String,String,Array{Any,1},Bool,Nothing}}, ::typeof(makedocs)) at ./<missing>:0
 [18] top-level scope
 [19] include at ./boot.jl:306 [inlined]
 [20] include_relative(::Module, ::String) at ./loading.jl:1067
 [21] include(::Module, ::String) at ./sysimg.jl:29
 [22] exec_options(::Base.JLOptions) at ./client.jl:327
 [23] _start() at ./client.jl:455
in expression starting at /src/julia-master/doc/make.jl:149
```

This is because a git worktree creates a `.git` _file_ (not a directory) that simply has the contents `gitdir: path/to/bare/repository`.  With this change, we can deal with these kinds of repositories as well.