### PR TITLE
Add EditURL key to at-meta block

### DIFF
--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -205,8 +205,18 @@ Use [`for i = 1:10 ...`](@ref for) to loop over all the numbers from 1 to 10.
 ## `@meta` block
 
 This block type is used to define metadata key/value pairs that can be used elsewhere in the
-page. Currently `CurrentModule`, [`DocTestSetup`](@ref Setup-Code),
-[`DocTestFilters`](@ref Filtering-Doctests) and `EditURL` are the only recognised keys.
+page. Currently recognised keys:
+- `CurrentModule`: module where Documenter evaluates, for example, [`@docs`-block](@ref)
+  and [`@ref`-link](@ref)s.
+- `DocTestSetup`: code to be evaluated before a doctest, see the [Setup Code](@ref)
+  section under [Doctests](@ref).
+- `DocTestFilters`: filters to deal with, for example, unpredictable output from doctests,
+  see the [Filtering Doctests](@ref) section under [Doctests](@ref).
+- `EditURL`: link to where the page can be edited. This defaults to the `.md` page itself,
+  but if the source is something else (for example if the `.md` page is generated as part of
+  the doc build) this can be set, either as a local link, or an absolute url.
+
+Example:
 
 ````markdown
 ```@meta
@@ -215,7 +225,7 @@ DocTestSetup  = quote
     using MyPackage
 end
 DocTestFilters = [r"Stacktrace:[\s\S]+"]
-EditURL = "https://link-to-where-this-page-can-be-edited.org/"
+EditURL = "link/to/source/file"
 ```
 ````
 

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -205,7 +205,8 @@ Use [`for i = 1:10 ...`](@ref for) to loop over all the numbers from 1 to 10.
 ## `@meta` block
 
 This block type is used to define metadata key/value pairs that can be used elsewhere in the
-page. Currently `CurrentModule`, `DocTestSetup` and `DocTestFilters` are the only recognised keys.
+page. Currently `CurrentModule`, [`DocTestSetup`](@ref Setup-Code),
+[`DocTestFilters`](@ref Filtering-Doctests) and `EditURL` are the only recognised keys.
 
 ````markdown
 ```@meta
@@ -214,12 +215,11 @@ DocTestSetup  = quote
     using MyPackage
 end
 DocTestFilters = [r"Stacktrace:[\s\S]+"]
+EditURL = "https://link-to-where-this-page-can-be-edited.org/"
 ```
 ````
 
 Note that `@meta` blocks are always evaluated in `Main`.
-
-See [Setup Code](@ref) section of the Doctests page for an explanation of `DocTestSetup`.
 
 ## `@index` block
 

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -435,7 +435,8 @@ function render_article(ctx, navnode)
     end
 
     if !ctx.doc.user.html_disable_git
-        url = Utilities.url(ctx.doc.user.repo, getpage(ctx, navnode).source, commit=ctx.doc.user.html_edit_branch)
+        url = get(getpage(ctx, navnode).globals.meta, :EditURL,
+            Utilities.url(ctx.doc.user.repo, getpage(ctx, navnode).source, commit=ctx.doc.user.html_edit_branch))
         if url !== nothing
             push!(topnav.nodes, a[".edit-page", :href => url](span[".fa"](logo), " Edit on $host"))
         end

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -435,8 +435,16 @@ function render_article(ctx, navnode)
     end
 
     if !ctx.doc.user.html_disable_git
-        url = get(getpage(ctx, navnode).globals.meta, :EditURL,
-            Utilities.url(ctx.doc.user.repo, getpage(ctx, navnode).source, commit=ctx.doc.user.html_edit_branch))
+        pageurl = get(getpage(ctx, navnode).globals.meta, :EditURL, getpage(ctx, navnode).source)
+        if Utilities.isabsurl(pageurl)
+            url = pageurl
+        else
+            if !(pageurl == getpage(ctx, navnode).source)
+                # need to set users path relative the page itself
+                pageurl = joinpath(first(splitdir(getpage(ctx, navnode).source)), pageurl)
+            end
+            url = Utilities.url(ctx.doc.user.repo, pageurl, commit=ctx.doc.user.html_edit_branch)
+        end
         if url !== nothing
             push!(topnav.nodes, a[".edit-page", :href => url](span[".fa"](logo), " Edit on $host"))
         end


### PR DESCRIPTION
This lets the user specify the link for `"Edit on GitHub"` which can be useful if the page is, for example, generated during doc build and you want to point the link to the source from where the page was generated.