### PR TITLE
stop deploying to the release- folder

### DIFF
--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -264,6 +264,10 @@ deploydocs(
 )
 ```
 
+When building the docs for a tag (i.e. a release) the documentation is deployed to
+a directory with the tag name (i.e. `vX.Y.Z`) and to the `stable` directory.
+Otherwise the docs are deployed to the `latest` directory.
+
 # Required keyword arguments
 
 **`julia`** is the version of Julia that will be used to deploy generated documentation.
@@ -452,6 +456,9 @@ end
     )
 
 Handles pushing changes to the remote documentation branch.
+When `tag` is empty the docs are deployed to the `latest` directory,
+and when building docs for a tag they are deployed to a `vX.Y.Z` directory,
+and also to the `stable` directory.
 """
 function git_push(
         root, temp, repo;
@@ -518,10 +525,6 @@ function git_push(
                     end
                     gitrm_copy(target_dir, tagged_dir)
                     Writers.HTMLWriter.generate_siteinfo_file(tagged_dir, tag)
-                    # Build a `release-*.*` folder as well
-                    release = "release-$(version.major).$(version.minor)"
-                    gitrm_copy(target_dir, joinpath(dirname, release))
-                    Writers.HTMLWriter.generate_siteinfo_file(joinpath(dirname, release), release)
                 end
 
                 # Create the versions.js file containing a list of all docs

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -495,7 +495,7 @@ function generate_version_file(dir::AbstractString)
     sort!(release_folders, lt = (x, y) -> vnum(x) < vnum(y), rev = true)
     open(joinpath(dir, "versions.js"), "w") do buf
         println(buf, "var DOC_VERSIONS = [")
-        for group in (named_folders, release_folders, tag_folders)
+        for group in (named_folders, tag_folders, release_folders)
             for folder in group
                 println(buf, "  \"", folder, "\",")
             end

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -479,23 +479,18 @@ end
 
 function generate_version_file(dir::AbstractString)
     named_folders = []
-    release_folders = []
     tag_folders = []
     for each in readdir(dir)
         each in ("stable", "latest")         ? push!(named_folders,   each) :
-        occursin(r"release\-\d+\.\d+", each) ? push!(release_folders, each) :
         occursin(Base.VERSION_REGEX, each)   ? push!(tag_folders,     each) : nothing
     end
     # put stable before latest
     sort!(named_folders, rev = true)
     # sort tags by version number
     sort!(tag_folders, lt = (x, y) -> VersionNumber(x) < VersionNumber(y), rev = true)
-    # sort release- folders by version number
-    vnum(x) = VersionNumber(match(r"release\-(\d+\.\d+)", x)[1])
-    sort!(release_folders, lt = (x, y) -> vnum(x) < vnum(y), rev = true)
     open(joinpath(dir, "versions.js"), "w") do buf
         println(buf, "var DOC_VERSIONS = [")
-        for group in (named_folders, tag_folders, release_folders)
+        for group in (named_folders, tag_folders)
             for folder in group
                 println(buf, "  \"", folder, "\",")
             end

--- a/test/htmlwriter.jl
+++ b/test/htmlwriter.jl
@@ -21,7 +21,7 @@ import Documenter.Writers.HTMLWriter: jsescape, generate_version_file
     @test jsescape("policy to  delete.") == "policy to\\u2028 delete."
 
     mktempdir() do tmpdir
-        versions = ["stable", "latest", "release-0.2", "release-0.1", "v0.2.6", "v0.1.1", "v0.1.0"]
+        versions = ["stable", "latest", "v0.2.6", "v0.1.1", "v0.1.0", "release-0.2", "release-0.1"]
         cd(tmpdir) do
             mkdir("foobar")
             for version in versions

--- a/test/htmlwriter.jl
+++ b/test/htmlwriter.jl
@@ -21,7 +21,7 @@ import Documenter.Writers.HTMLWriter: jsescape, generate_version_file
     @test jsescape("policy to  delete.") == "policy to\\u2028 delete."
 
     mktempdir() do tmpdir
-        versions = ["stable", "latest", "v0.2.6", "v0.1.1", "v0.1.0", "release-0.2", "release-0.1"]
+        versions = ["stable", "latest", "v0.2.6", "v0.1.1", "v0.1.0"]
         cd(tmpdir) do
             mkdir("foobar")
             for version in versions


### PR DESCRIPTION
This should actually be safe since Documenter don't remove the old directories, so links should still work.