### PR TITLE
sort correctly by version number

### DIFF
--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -486,10 +486,17 @@ function generate_version_file(dir::AbstractString)
         occursin(r"release\-\d+\.\d+", each) ? push!(release_folders, each) :
         occursin(Base.VERSION_REGEX, each)   ? push!(tag_folders,     each) : nothing
     end
+    # put stable before latest
+    sort!(named_folders, rev = true)
+    # sort tags by version number
+    sort!(tag_folders, lt = (x, y) -> VersionNumber(x) < VersionNumber(y), rev = true)
+    # sort release- folders by version number
+    vnum(x) = VersionNumber(match(r"release\-(\d+\.\d+)", x)[1])
+    sort!(release_folders, lt = (x, y) -> vnum(x) < vnum(y), rev = true)
     open(joinpath(dir, "versions.js"), "w") do buf
         println(buf, "var DOC_VERSIONS = [")
         for group in (named_folders, release_folders, tag_folders)
-            for folder in sort!(group, rev = true)
+            for folder in group
                 println(buf, "  \"", folder, "\",")
             end
         end

--- a/test/htmlwriter.jl
+++ b/test/htmlwriter.jl
@@ -3,7 +3,7 @@ module HTMLWriterTests
 using Compat.Test
 using Compat
 
-import Documenter.Writers.HTMLWriter: jsescape
+import Documenter.Writers.HTMLWriter: jsescape, generate_version_file
 
 @testset "HTMLWriter" begin
     @test jsescape("abc123") == "abc123"
@@ -20,6 +20,31 @@ import Documenter.Writers.HTMLWriter: jsescape
     @test jsescape("\u2028") == "\\u2028"
     @test jsescape("\u2029") == "\\u2029"
     @test jsescape("policy to  delete.") == "policy to\\u2028 delete."
+
+    mktempdir() do tmpdir
+        versions = ["stable", "latest", "release-0.2", "release-0.1", "v0.2.6", "v0.1.1", "v0.1.0"]
+        cd(tmpdir) do
+            mkdir("foobar")
+            for version in versions
+                mkdir(version)
+            end
+        end
+
+        generate_version_file(tmpdir)
+
+        versions_file = joinpath(tmpdir, "versions.js")
+        @test isfile(versions_file)
+        contents = String(read(versions_file))
+        @test !occursin("foobar", contents) # only specific directories end up in the versions file
+        # let's make sure they're in the right order -- they should be sorted in the output file
+        last = 0:0
+        for version in versions
+            this = Compat.findfirst(version, contents)
+            @test this !== nothing
+            @test first(last) < first(this)
+            last = this
+        end
+    end
 end
 
 end


### PR DESCRIPTION
Currently in e.g. Documenters manual `v0.6.x` sort before `v0.10.x`. This sorts tagged dirs and release- dirs according to version number instead.