### PR TITLE
Add a note on double-escaping the dollar sign

### DIFF
--- a/docs/src/man/latex.md
+++ b/docs/src/man/latex.md
@@ -36,6 +36,14 @@ This is the binomial coefficient.
 func(x) = # ...
 ```
 
+A related issue is how to add dollar signs to a docstring. They need to be
+double-escaped as follows:
+```julia
+"""
+The cost was \\\$1.
+"""
+```
+
 ## Inline equations
 
 ```markdown


### PR DESCRIPTION
I just ran into https://github.com/JuliaDocs/Documenter.jl/issues/543 and had no idea how to track down the missing `mdflatten` error. 

I ended up adding each line at a time until I found that it was the dollar signs. 

Reading the discussion, I'm not sure what the right answer is, but at the very least this would have been helpful to read in the docs.