### PR TITLE
Remove AppVeyor allowed failures

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,12 +7,6 @@ environment:
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
-matrix:
-  allow_failures:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
-
 notifications:
   - provider: Email
     on_build_success: false


### PR DESCRIPTION
It looks like that all the Windows binaries have caught up and the tests pass without issues on 0.7.