### PR TITLE
fix pdf generation in prescence of hidden pages

### DIFF
--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -506,6 +506,14 @@ function files!(out::Vector, v::Vector, depth)
     return out
 end
 
+# Tuples comde from `hide(page)` with either
+# (visible, nothing,    page,         children) or
+# (visible, page.first, pages.second, children)
+function files!(out::Vector, v::Tuple, depth)
+    files!(out, v[2] == nothing ? v[3] : v[2] => v[3], depth)
+    files!(out, v[4], depth)
+end
+
 files!(out, s::AbstractString, depth) = push!(out, ("", s, depth))
 
 function files!(out, p::Pair{S, T}, depth) where {S <: AbstractString, T <: AbstractString}

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -506,7 +506,7 @@ function files!(out::Vector, v::Vector, depth)
     return out
 end
 
-# Tuples comde from `hide(page)` with either
+# Tuples come from `hide(page)` with either
 # (visible, nothing,    page,         children) or
 # (visible, page.first, pages.second, children)
 function files!(out::Vector, v::Tuple, depth)

--- a/test/formats/latex.jl
+++ b/test/formats/latex.jl
@@ -25,7 +25,7 @@ doc = makedocs(
             "man/doctests.md",
             "man/hosting.md",
             "man/latex.md",
-            "man/contributing.md",
+            hide("man/contributing.md"), # test hiding
         ],
         "Library" => Any[
             "Public" => "lib/public.md",


### PR DESCRIPTION
`hide(page)` inserts a four-component tuple into `doc.user.pages`. This case is unhandled in the `files!` function of the `LaTeXWriter`. This means that generating pdf for the manual in Julia Base is currently broken since it uses hidden pages.

This should hopefully fix that. With this patch, the pdf is generated. FWIW a "naked" four-component tuple like this feels a bit brittle.