### PR TITLE
Better error message for failing to evaluate setup code, fix #785.

### DIFF
--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -102,7 +102,14 @@ function doctest(block::Markdown.Code, meta::Dict, doc::Documents.Document, page
 
         for expr in [get(meta, :DocTestSetup, []); get(meta[:LocalDocTestArguments], :setup, [])]
             Meta.isexpr(expr, :block) && (expr.head = :toplevel)
-            Core.eval(sandbox, expr)
+            try
+                Core.eval(sandbox, expr)
+            catch e
+                push!(doc.internal.errors, :doctest)
+                @error("could not evaluate expression from doctest setup.",
+                    expression = expr, exception = e)
+                return false
+            end
         end
         if occursin(r"^julia> "m, block.code)
             eval_repl(block, sandbox, meta, doc, page)


### PR DESCRIPTION
```
┌ Warning: Error evaluating expression from doctest setup, ignoring.
│   expr = :(a = srand())
└ @ Documenter.DocChecks ~/.julia/dev/Documenter/src/DocChecks.jl:185
```