### PR TITLE
Bump Julia require to 0.7, stop testing on 0.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os:
   - osx
 
 julia:
-  - 0.6
   - 0.7
   - 1.0
   - nightly

--- a/README.md
+++ b/README.md
@@ -3,16 +3,18 @@
 
 *A documentation generator for Julia.*
 
-| **Documentation**                                                               | **PackageEvaluator**                                                                            | **Build Status**                                                                                |
-|:-------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
-| [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] | [![][pkg-0.6-img]][pkg-0.6-url] [![][pkg-0.7-img]][pkg-0.7-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] [![][codecov-img]][codecov-url] |
+| **Documentation**                                                               | **Build Status**                                                                                |
+|:-------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
+| [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] [![][codecov-img]][codecov-url] |
 
 
 ## Installation
 
-The package is registered in `METADATA.jl` and can be installed with `Pkg.add`.
+The package can be installed with Julias package manager:
 
 ```julia
+julia> import Pkg
+
 julia> Pkg.add("Documenter")
 ```
 
@@ -23,9 +25,9 @@ julia> Pkg.add("Documenter")
 
 ## Project Status
 
-The package is tested against Julia `0.6` and *current* `0.7-dev` on Linux, OS X, and Windows.
+The package is tested against Julia `0.7`, `1.0` and *current* `1.1-dev` on Linux, OS X, and Windows.
 
-Support for Julia `0.4` and `0.5` has been dropped in the latest version, but older versions of Documenter may still work with those Julia versions (the `0.8` and `0.11` branches for either Julia version, respectively).
+Support for Julia `0.4`, `0.5` and `0.6` has been dropped in the latest version, but older versions of Documenter may still work with those Julia versions (the `0.8`, `0.11` and `0.19` branches for Julia versions `0.4`, `0.5` and `0.6`, respectively).
 
 ## Questions and Contributions
 
@@ -53,8 +55,3 @@ Contributions are very welcome, as are feature requests and suggestions. Please 
 [codecov-url]: https://codecov.io/gh/JuliaDocs/Documenter.jl
 
 [issues-url]: https://github.com/JuliaDocs/Documenter.jl/issues
-
-[pkg-0.6-img]: http://pkg.julialang.org/badges/Documenter_0.6.svg
-[pkg-0.6-url]: http://pkg.julialang.org/?pkg=Documenter&ver=0.6
-[pkg-0.7-img]: http://pkg.julialang.org/badges/Documenter_0.7.svg
-[pkg-0.7-url]: http://pkg.julialang.org/?pkg=Documenter&ver=0.7

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
 julia 0.7
-Compat 0.70.0 # reduce(; init=...) / Compat#590
 DocStringExtensions 0.2

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6
+julia 0.7
 Compat 0.70.0 # reduce(; init=...) / Compat#590
 DocStringExtensions 0.2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-  - julia_version: 0.6
   - julia_version: 0.7
   - julia_version: 1.0
   - julia_version: latest

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -317,7 +317,7 @@ Code blocks may have some content that does not need to be displayed in the fina
 
 ````markdown
 ```@example
-using Compat.Random # hide
+using Random # hide
 srand(1) # hide
 A = rand(3, 3)
 b = [1, 2, 3]

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -317,8 +317,8 @@ Code blocks may have some content that does not need to be displayed in the fina
 
 ````markdown
 ```@example
-using Random # hide
-srand(1) # hide
+import Random # hide
+Random.seed!(1) # hide
 A = rand(3, 3)
 b = [1, 2, 3]
 A \ b

--- a/src/Anchors.jl
+++ b/src/Anchors.jl
@@ -5,7 +5,7 @@ Defines the [`Anchor`](@ref) and [`AnchorMap`](@ref) types.
 """
 module Anchors
 
-using Compat, DocStringExtensions
+using DocStringExtensions
 
 # Types.
 # ------

--- a/src/Builder.jl
+++ b/src/Builder.jl
@@ -15,7 +15,7 @@ import ..Documenter:
 
 import .Utilities: Selectors
 
-using Compat, DocStringExtensions
+using DocStringExtensions
 
 # Document Pipeline.
 # ------------------
@@ -109,7 +109,7 @@ function Selectors.runner(::Type{SetupBuildDirectory}, doc::Documents.Document)
                 push!(mdpages, Utilities.srcpath(source, root, file))
                 Documents.addpage!(doc, src, dst)
             else
-                Compat.cp(src, dst; force = true)
+                cp(src, dst; force = true)
             end
         end
     end

--- a/src/CrossReferences.jl
+++ b/src/CrossReferences.jl
@@ -12,8 +12,8 @@ import ..Documenter:
     Documenter,
     Utilities
 
-using Compat, DocStringExtensions
-import Compat.Markdown
+using DocStringExtensions
+import Markdown
 
 """
 $(SIGNATURES)

--- a/src/Deps.jl
+++ b/src/Deps.jl
@@ -7,7 +7,7 @@ module Deps
 
 export pip
 
-using Compat, DocStringExtensions
+using DocStringExtensions
 
 """
 $(SIGNATURES)
@@ -37,8 +37,8 @@ end
 
 
 function localbin()
-    Compat.Sys.islinux() ? joinpath(homedir(), ".local", "bin") :
-    Compat.Sys.isapple() ? joinpath(homedir(), "Library", "Python", "2.7", "bin") : ""
+    Sys.islinux() ? joinpath(homedir(), ".local", "bin") :
+    Sys.isapple() ? joinpath(homedir(), "Library", "Python", "2.7", "bin") : ""
 end
 
 function updatepath!(p = localbin())

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -9,8 +9,8 @@ import ..Documenter:
     Utilities,
     IdDict
 
-using Compat, DocStringExtensions
-import Compat: Markdown
+using DocStringExtensions
+import Markdown
 
 # Missing docstrings.
 # -------------------
@@ -37,7 +37,7 @@ function missingdocs(doc::Documents.Document)
             end
         end
     end
-    n = Compat.reduce(+, map(length, values(bindings)), init=0)
+    n = reduce(+, map(length, values(bindings)), init=0)
     if n > 0
         b = IOBuffer()
         println(b, "$n docstring$(n ≡ 1 ? "" : "s") potentially missing:\n")
@@ -76,7 +76,7 @@ meta(m) = Docs.meta(m)
 nameof(x::Function)          = typeof(x).name.mt.name
 nameof(b::Base.Docs.Binding) = b.var
 nameof(x::DataType)          = x.name.name
-nameof(m::Module)            = Compat.nameof(m)
+nameof(m::Module)            = nameof(m)
 
 sigs(x::Base.Docs.MultiDoc) = x.order
 sigs(::Any) = Type[Union{}]

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -6,8 +6,7 @@ module DocChecks
 
 import ..Documenter:
     Documents,
-    Utilities,
-    IdDict
+    Utilities
 
 using DocStringExtensions
 import Markdown
@@ -61,7 +60,7 @@ end
 
 function allbindings(checkdocs::Symbol, mod::Module, out = Dict{Utilities.Binding, Set{Type}}())
     for (obj, doc) in meta(mod)
-        isa(obj, IdDict) && continue
+        isa(obj, IdDict{Any,Any}) && continue
         name = nameof(obj)
         isexported = Base.isexported(mod, name)
         if checkdocs === :all || (isexported && checkdocs === :exports)

--- a/src/DocSystem.jl
+++ b/src/DocSystem.jl
@@ -4,8 +4,8 @@ docsystem in both `0.4` and `0.5`.
 """
 module DocSystem
 
-using Compat, DocStringExtensions
-import Compat.Markdown
+using DocStringExtensions
+import Markdown
 import Base.Docs: MultiDoc, parsedoc, formatdoc, DocStr
 import ..IdDict
 
@@ -43,7 +43,7 @@ binding(f::Function)     = binding(typeof(f).name.module, typeof(f).name.mt.name
 #
 # Note that `IntrinsicFunction` is exported from `Base` in `0.4`, but not in `0.5`.
 #
-let INTRINSICS = Dict(map(s -> getfield(Core.Intrinsics, s) => s, Compat.names(Core.Intrinsics, all=true)))
+let INTRINSICS = Dict(map(s -> getfield(Core.Intrinsics, s) => s, names(Core.Intrinsics, all=true)))
     global binding(i::Core.IntrinsicFunction) = binding(Core.Intrinsics, INTRINSICS[i]::Symbol)
 end
 
@@ -78,7 +78,7 @@ binding(m::Module, λ::Any) = binding(λ)
 
 function signature(x, str::AbstractString)
     ts = Base.Docs.signature(x)
-    (Meta.isexpr(x, :macrocall, 1 + Compat.macros_have_sourceloc) && !endswith(strip(str), "()")) ? :(Union{}) : ts
+    (Meta.isexpr(x, :macrocall, 2) && !endswith(strip(str), "()")) ? :(Union{}) : ts
 end
 
 ## Docstring containers. ##

--- a/src/DocSystem.jl
+++ b/src/DocSystem.jl
@@ -7,7 +7,6 @@ module DocSystem
 using DocStringExtensions
 import Markdown
 import Base.Docs: MultiDoc, parsedoc, formatdoc, DocStr
-import ..IdDict
 
 ## Bindings ##
 
@@ -143,19 +142,19 @@ Converts a `0.4`-style docstring cache into a `0.5` one.
 
 The original docstring cache is not modified.
 """
-function convertmeta(meta::IdDict)
+function convertmeta(meta::IdDict{Any,Any})
     if !haskey(CACHED, meta)
-        docs = IdDict()
+        docs = IdDict{Any,Any}()
         for (k, v) in meta
-            if !isa(k, Union{Number, AbstractString, IdDict})
+            if !isa(k, Union{Number, AbstractString, IdDict{Any,Any}})
                 docs[binding(k)] = multidoc(v)
             end
         end
         CACHED[meta] = docs
     end
-    CACHED[meta]::IdDict
+    CACHED[meta]::IdDict{Any,Any}
 end
-const CACHED = IdDict()
+const CACHED = IdDict{Any,Any}()
 
 
 ## Get docs from modules.

--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -10,7 +10,7 @@ import ..Documenter:
     Documents,
     Utilities
 
-import Markdown
+import Markdown, REPL
 
 # Julia code block testing.
 # -------------------------
@@ -156,7 +156,7 @@ function eval_repl(block, sandbox, meta::Dict, doc::Documents.Document, page)
         result = Result(block, input, output, meta[:CurrentFile])
         for (ex, str) in Utilities.parseblock(input, doc, page; keywords = false)
             # Input containing a semi-colon gets suppressed in the final output.
-            result.hide = Documenter.REPL.ends_with_semicolon(str)
+            result.hide = REPL.ends_with_semicolon(str)
             (value, success, backtrace, text) = Utilities.withoutput() do
                 disable_color() do
                     Core.eval(sandbox, ex)
@@ -276,7 +276,7 @@ funcsym() = CAN_INLINE[] ? :disable_color : :eval
 function error_to_string(buf, er, bt)
     fs = funcsym()
     # Remove unimportant backtrace info.
-    index = findlast(ptr -> Documenter.ip_matches_func(ptr, fs), bt)
+    index = findlast(ptr -> Base.ip_matches_func(ptr, fs), bt)
     # Print a REPL-like error message.
     disable_color() do
         print(buf, "ERROR: ")

--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -8,8 +8,7 @@ using DocStringExtensions
 import ..Documenter:
     Documenter,
     Documents,
-    Utilities,
-    IdDict
+    Utilities
 
 import Markdown
 

--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -3,7 +3,6 @@ Provides the [`doctest`](@ref) function that makes sure that the `jldoctest` cod
 in the documents and docstrings run and are up to date.
 """
 module DocTests
-using Compat
 using DocStringExtensions
 
 import ..Documenter:
@@ -12,7 +11,7 @@ import ..Documenter:
     Utilities,
     IdDict
 
-import Compat: Markdown
+import Markdown
 
 # Julia code block testing.
 # -------------------------
@@ -26,7 +25,7 @@ function find_codeblock_in_file(code, file)
     content = replace(content, "\r\n" => "\n")
     # make a regex of the code that matches leading whitespace
     rcode = "\\h*" * replace(regex_escape(code), "\\n" => "\\n\\h*")
-    blockidx = Compat.findfirst(Regex(rcode), content)
+    blockidx = findfirst(Regex(rcode), content)
     if blockidx !== nothing
         startline = countlines(IOBuffer(content[1:prevind(content, first(blockidx))]))
         endline = startline + countlines(IOBuffer(code)) + 1 # +1 to include the closing ```
@@ -78,7 +77,7 @@ function doctest(block::Markdown.Code, meta::Dict, doc::Documents.Document, page
 
         # parse keyword arguments to doctest
         d = Dict()
-        idx = Compat.findfirst(c -> c == ';', lang)
+        idx = findfirst(c -> c == ';', lang)
         if idx !== nothing
             kwargs = Meta.parse("($(lang[nextind(lang, idx):end]),)")
             for kwarg in kwargs.args
@@ -278,7 +277,7 @@ funcsym() = CAN_INLINE[] ? :disable_color : :eval
 function error_to_string(buf, er, bt)
     fs = funcsym()
     # Remove unimportant backtrace info.
-    index = Compat.findlast(ptr -> Documenter.ip_matches_func(ptr, fs), bt)
+    index = findlast(ptr -> Documenter.ip_matches_func(ptr, fs), bt)
     # Print a REPL-like error message.
     disable_color() do
         print(buf, "ERROR: ")
@@ -335,12 +334,12 @@ function fix_doctest(result::Result, str, doc::Documents.Document)
     # read the file containing the code block
     content = read(filename, String)
     # output stream
-    io = Compat.IOBuffer(sizehint = sizeof(content))
+    io = IOBuffer(sizehint = sizeof(content))
     # first look for the entire code block
     # make a regex of the code that matches leading whitespace
     rcode = "(\\h*)" * replace(regex_escape(code), "\\n" => "\\n\\h*")
     r = Regex(rcode)
-    codeidx = Compat.findfirst(r, content)
+    codeidx = findfirst(r, content)
     if codeidx === nothing
         Utilities.warn("Could not find code block in source file")
         return
@@ -353,7 +352,7 @@ function fix_doctest(result::Result, str, doc::Documents.Document)
     # make a regex of the input that matches leading whitespace (for multiline input)
     rinput = "\\h*" * replace(regex_escape(result.input), "\\n" => "\\n\\h*")
     r = Regex(rinput)
-    inputidx = Compat.findfirst(r, code)
+    inputidx = findfirst(r, code)
     if inputidx === nothing
         Utilities.warn("Could not find input line in code block")
         return

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -20,12 +20,6 @@ using DocStringExtensions
 import Base64: base64decode
 import Pkg
 
-@static if VERSION < v"0.7.0-DEV.3439"
-    const IdDict = Base.ObjectIdDict
-else
-    const IdDict = Base.IdDict{Any,Any}
-end
-
 @static if VERSION < v"0.7.0-DEV.3500"
     import Base.REPL
     using Base.REPL: ip_matches_func

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -1,5 +1,3 @@
-__precompile__(true)
-
 """
 Main module for `Documenter.jl` -- a documentation generation package for Julia.
 

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -20,14 +20,6 @@ using DocStringExtensions
 import Base64: base64decode
 import Pkg
 
-@static if VERSION < v"0.7.0-DEV.3500"
-    import Base.REPL
-    using Base.REPL: ip_matches_func
-else
-    import REPL
-    using Base: ip_matches_func
-end
-
 # Submodules
 # ----------
 

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -16,10 +16,9 @@ $(EXPORTS)
 """
 module Documenter
 
-using Compat, DocStringExtensions
-import Compat.Base64: base64decode
-import Compat: @info
-import Compat.Pkg
+using DocStringExtensions
+import Base64: base64decode
+import Pkg
 
 @static if VERSION < v"0.7.0-DEV.3439"
     const IdDict = Base.ObjectIdDict
@@ -387,7 +386,7 @@ function deploydocs(;
 
     # Sanity checks
     if !isempty(travis_repo_slug) && !occursin(travis_repo_slug, repo)
-        Compat.@warn("repo $repo does not match $travis_repo_slug")
+        @warn("repo $repo does not match $travis_repo_slug")
     end
 
     # When should a deploy be attempted?
@@ -403,13 +402,13 @@ function deploydocs(;
 
     # check that the tag is valid
     if should_deploy && !isempty(travis_tag) && !occursin(Base.VERSION_REGEX, travis_tag)
-        Compat.@warn("tag `$(travis_tag)` is not a valid VersionNumber")
+        @warn("tag `$(travis_tag)` is not a valid VersionNumber")
         should_deploy = false
     end
 
     # check DOCUMENTER_KEY only if the branch, Julia version etc. check out
     if should_deploy && isempty(documenter_key)
-        Compat.@warn("""
+        @warn("""
             DOCUMENTER_KEY environment variable missing, unable to deploy.
               Note that in Documenter v0.9.0 old deprecated authentication methods were removed.
               DOCUMENTER_KEY is now the only option. See the documentation for more information.""")
@@ -532,7 +531,7 @@ function git_push(
                     version = VersionNumber(tag)
                     # only push to stable if this is the latest stable release
                     versions = filter!(x -> occursin(Base.VERSION_REGEX, x), readdir(dirname))
-                    maxver = Compat.mapreduce(x -> VersionNumber(x), max, versions; init=v"0.0.0")
+                    maxver = mapreduce(x -> VersionNumber(x), max, versions; init=v"0.0.0")
                     if version >= maxver && version.prerelease == () # don't deploy to stable for prereleases
                         gitrm_copy(target_dir, stable_dir)
                         Writers.HTMLWriter.generate_siteinfo_file(stable_dir, "stable")
@@ -578,7 +577,7 @@ first, `git add -A` will not detect case changes in filenames.
 function gitrm_copy(src, dst)
     # --ignore-unmatch so that we wouldn't get errors if dst does not exist
     run(`git rm -rf --ignore-unmatch $(dst)`)
-    Compat.cp(src, dst; force=true)
+    cp(src, dst; force=true)
 end
 
 function withfile(func, file::AbstractString, contents::AbstractString)

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -15,9 +15,9 @@ import ..Documenter:
     Utilities,
     IdDict
 
-using Compat, DocStringExtensions
-import Compat.Markdown
-using Compat.Unicode
+using DocStringExtensions
+import Markdown
+using Unicode
 
 # Pages.
 # ------

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -12,8 +12,7 @@ module Documents
 import ..Documenter:
     Anchors,
     Formats,
-    Utilities,
-    IdDict
+    Utilities
 
 using DocStringExtensions
 import Markdown
@@ -47,12 +46,12 @@ struct Page
     element does not need expanding or some other object, such as a `DocsNode` in the case
     of `@docs` code blocks.
     """
-    mapping  :: IdDict
+    mapping  :: IdDict{Any,Any}
     globals  :: Globals
 end
 function Page(source::AbstractString, build::AbstractString)
     elements = Markdown.parse(read(source, String)).content
-    Page(source, build, elements, IdDict(), Globals())
+    Page(source, build, elements, IdDict{Any,Any}(), Globals())
 end
 
 # Document Nodes.
@@ -216,8 +215,8 @@ struct Internal
     navlist :: Vector{NavNode}           # An ordered list of `NavNode`s that point to actual pages
     headers :: Anchors.AnchorMap         # See `modules/Anchors.jl`. Tracks `Markdown.Header` objects.
     docs    :: Anchors.AnchorMap         # See `modules/Anchors.jl`. Tracks `@docs` docstrings.
-    bindings:: IdDict                    # Tracks insertion order of object per-binding.
-    objects :: IdDict                    # Tracks which `Utilities.Objects` are included in the `Document`.
+    bindings:: IdDict{Any,Any}           # Tracks insertion order of object per-binding.
+    objects :: IdDict{Any,Any}           # Tracks which `Utilities.Objects` are included in the `Document`.
     contentsnodes :: Vector{ContentsNode}
     indexnodes    :: Vector{IndexNode}
     locallinks :: Dict{Markdown.Link, String}
@@ -303,8 +302,8 @@ function Document(;
         [],
         Anchors.AnchorMap(),
         Anchors.AnchorMap(),
-        IdDict(),
-        IdDict(),
+        IdDict{Any,Any}(),
+        IdDict{Any,Any}(),
         [],
         [],
         Dict{Markdown.Link, String}(),

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -20,7 +20,7 @@ import .Documents:
 
 import .Utilities: Selectors
 
-import Markdown
+import Markdown, REPL
 import Base64: stringmime
 
 
@@ -542,7 +542,7 @@ function Selectors.runner(::Type{REPLBlocks}, x, page, doc)
         end
         result = value
         output = if success
-            hide = Documenter.REPL.ends_with_semicolon(input)
+            hide = REPL.ends_with_semicolon(input)
             Documenter.DocTests.result_to_string(buffer, hide ? nothing : value)
         else
             Documenter.DocTests.error_to_string(buffer, value, [])

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -20,9 +20,8 @@ import .Documents:
 
 import .Utilities: Selectors
 
-using Compat
-import Compat.Markdown
-import Compat.Base64: stringmime
+import Markdown
+import Base64: stringmime
 
 
 function expand(doc::Documents.Document)

--- a/src/Formats.jl
+++ b/src/Formats.jl
@@ -7,7 +7,7 @@ module Formats
 
 import ..Documenter
 
-using Compat, DocStringExtensions
+using DocStringExtensions
 
 """
 Represents the output format. Possible values are `Markdown`, `LaTeX`, and `HTML`.

--- a/src/Generator.jl
+++ b/src/Generator.jl
@@ -4,7 +4,6 @@ Provides the functions related to generating documentation stubs.
 module Generator
 
 using DocStringExtensions
-using Compat: @info
 
 """
 $(SIGNATURES)

--- a/src/Travis.jl
+++ b/src/Travis.jl
@@ -5,13 +5,13 @@ $(EXPORTS)
 """
 module Travis
 
-using Compat, DocStringExtensions
-import Compat.Pkg
-import Compat.Base64: base64encode
+using DocStringExtensions
+import Pkg
+import Base64: base64encode
 
 export genkeys
 
-import Compat.LibGit2.GITHUB_REGEX
+import LibGit2.GITHUB_REGEX
 
 
 """
@@ -77,7 +77,7 @@ function genkeys(package; remote="origin")
 
         # Prompt user to add public key to github then remove the public key.
         let url = "https://github.com/$user/$repo/settings/keys"
-            Compat.@info("add the public key below to $url with read/write access:")
+            @info("add the public key below to $url with read/write access:")
             println("\n", read("$filename.pub", String))
             rm("$filename.pub")
         end
@@ -86,7 +86,7 @@ function genkeys(package; remote="origin")
         # *not* encoded for the sake of security, but instead to make it easier to
         # copy/paste it over to travis without having to worry about whitespace.
         let url = "https://travis-ci.org/$user/$repo/settings"
-            Compat.@info("add a secure environment variable named 'DOCUMENTER_KEY' to $url with value:")
+            @info("add a secure environment variable named 'DOCUMENTER_KEY' to $url with value:")
             println("\n", base64encode(read(".documenter", String)), "\n")
             rm(filename)
         end

--- a/src/Utilities/DOM.jl
+++ b/src/Utilities/DOM.jl
@@ -96,8 +96,6 @@ module DOM
 
 import ..Utilities
 
-using Compat
-
 tostr(p::Pair) = p
 
 export @tags

--- a/src/Utilities/MDFlatten.jl
+++ b/src/Utilities/MDFlatten.jl
@@ -11,9 +11,7 @@ export mdflatten
 
 import ..Utilities
 
-using Compat
-
-import Compat.Markdown:
+import Markdown:
     MD, BlockQuote, Bold, Code, Header, HorizontalRule,
     Image, Italic, LaTeX, LineBreak, Link, List, Paragraph, Table,
     Footnote, Admonition

--- a/src/Utilities/Selectors.jl
+++ b/src/Utilities/Selectors.jl
@@ -69,8 +69,7 @@ The module provides the following interface for creating selectors:
 """
 module Selectors
 
-using Compat
-import Compat.InteractiveUtils: subtypes
+import InteractiveUtils: subtypes
 
 """
 Root selector type. Each user-defined selector must subtype from this, i.e.

--- a/src/Utilities/TextDiff.jl
+++ b/src/Utilities/TextDiff.jl
@@ -1,6 +1,5 @@
 module TextDiff
 
-using Compat
 using DocStringExtensions
 
 # Utilities.

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -540,19 +540,7 @@ newlines(other) = 0
 
 # Output redirection.
 # -------------------
-@static if VERSION < v"0.7.0-DEV.3951"
-    link_pipe!(pipe; reader_supports_async = true, writer_supports_async = true) =
-        Base.link_pipe(pipe, julia_only_read = reader_supports_async, julia_only_write = writer_supports_async)
-else
-    import Base: link_pipe!
-end
-@static if isdefined(Base, :with_logger)
-    using Logging
-else # make things a no-op since warnings/info already print to stdout
-    struct ConsoleLogger end
-    ConsoleLogger(io) = ConsoleLogger()
-    with_logger(f, logger) = f()
-end
+using Logging
 
 """
 Call a function and capture all `stdout` and `stderr` output.
@@ -575,7 +563,7 @@ function withoutput(f)
 
     # Redirect both the `stdout` and `stderr` streams to a single `Pipe` object.
     pipe = Pipe()
-    link_pipe!(pipe; reader_supports_async = true, writer_supports_async = true)
+    Base.link_pipe!(pipe; reader_supports_async = true, writer_supports_async = true)
     redirect_stdout(pipe.in)
     redirect_stderr(pipe.in)
     # Also redirect logging stream to the same pipe

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -3,11 +3,11 @@ Provides a collection of utility functions and types that are used in other subm
 """
 module Utilities
 
-using Base.Meta, Compat
+using Base.Meta
 import Base: isdeprecated, Docs.Binding
 using DocStringExtensions
-import Compat.Markdown
-import Compat.Base64: stringmime
+import Markdown, LibGit2
+import Base64: stringmime
 
 # Logging output.
 
@@ -175,7 +175,7 @@ function submodules(modules::Vector{Module})
 end
 function submodules(root::Module, seen = Set{Module}())
     push!(seen, root)
-    for name in Compat.names(root, all=true)
+    for name in names(root, all=true)
         if Base.isidentifier(name) && isdefined(root, name) && !isdeprecated(root, name)
             object = getfield(root, name)
             if isa(object, Module) && !(object in seen)
@@ -222,7 +222,7 @@ Returns a expression that, when evaluated, returns an [`Object`](@ref) represent
 function object(ex::Union{Symbol, Expr}, str::AbstractString)
     binding   = Expr(:call, Binding, splitexpr(Docs.namify(ex))...)
     signature = Base.Docs.signature(ex)
-    isexpr(ex, :macrocall, 1 + Compat.macros_have_sourceloc) && !endswith(str, "()") && (signature = :(Union{}))
+    isexpr(ex, :macrocall, 2) && !endswith(str, "()") && (signature = :(Union{}))
     Expr(:call, Object, binding, signature)
 end
 
@@ -254,7 +254,7 @@ function docs end
 
 # Macro representation changed between 0.4 and 0.5.
 function docs(ex::Union{Symbol, Expr}, str::AbstractString)
-    isexpr(ex, :macrocall, 1 + Compat.macros_have_sourceloc) && !endswith(rstrip(str), "()") && (ex = quot(ex))
+    isexpr(ex, :macrocall, 2) && !endswith(rstrip(str), "()") && (ex = quot(ex))
     :(Base.Docs.@doc $ex)
 end
 docs(qn::QuoteNode, str::AbstractString) = :(Base.Docs.@doc $(qn.value))
@@ -450,7 +450,7 @@ function getremote(dir::AbstractString)
         catch err
             ""
         end
-    m = match(Compat.LibGit2.GITHUB_REGEX, remote)
+    m = match(LibGit2.GITHUB_REGEX, remote)
     if m === nothing
         travis = get(ENV, "TRAVIS_REPO_SLUG", "")
         isempty(travis) ? "" : travis
@@ -526,7 +526,7 @@ struct LineRangeFormatting
     end
 end
 
-function format_line(range::Compat.AbstractRange, format::LineRangeFormatting)
+function format_line(range::AbstractRange, format::LineRangeFormatting)
     if length(range) <= 1
         string(format.prefix, first(range))
     else

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -64,8 +64,7 @@ Adding an ICO asset is primarilly useful for setting a custom `favicon`.
 """
 module HTMLWriter
 
-using Compat
-import Compat.Markdown
+import Markdown
 
 import ...Documenter:
     Anchors,
@@ -163,7 +162,7 @@ function copy_asset(file, doc)
     else
         ispath(dirname(dst)) || mkpath(dirname(dst))
         ispath(dst) && Utilities.warn("Overwriting '$dst'.")
-        Compat.cp(src, dst, force=true)
+        cp(src, dst, force=true)
     end
     assetpath = normpath(joinpath("assets", file))
     # Replace any backslashes in links, if building the docs on Windows
@@ -989,7 +988,7 @@ function fixlinks!(ctx, navnode, link::Markdown.Link)
     startswith(link.url, '#') && return
 
     s = split(link.url, "#", limit = 2)
-    if Compat.Sys.iswindows() && ':' in first(s)
+    if Sys.iswindows() && ':' in first(s)
         Utilities.warn("Invalid local link: colons not allowed in paths on Windows\n    '$(link.url)' in $(navnode.page)")
         return
     end
@@ -1014,7 +1013,7 @@ end
 function fixlinks!(ctx, navnode, img::Markdown.Image)
     Utilities.isabsurl(img.url) && return
 
-    if Compat.Sys.iswindows() && ':' in img.url
+    if Sys.iswindows() && ':' in img.url
         Utilities.warn("Invalid local image: colons not allowed in paths on Windows\n    '$(img.url)' in $(navnode.page)")
         return
     end

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -13,8 +13,7 @@ import ...Documenter:
     Utilities,
     Writers
 
-using Compat
-import Compat.Markdown
+import Markdown
 
 mutable struct Context{I <: IO} <: IO
     io::I
@@ -80,9 +79,9 @@ function render(doc::Documents.Document)
                     run(`latexmk -f -interaction=nonstopmode -view=none -lualatex -shell-escape $file`)
                 catch err
                     Utilities.warn("failed to compile. Check generated LaTeX file.")
-                    Compat.cp(file, joinpath(outdir, file); force = true)
+                    cp(file, joinpath(outdir, file); force = true)
                 end
-                Compat.cp(pdf, joinpath(outdir, pdf); force = true)
+                cp(pdf, joinpath(outdir, pdf); force = true)
             else
                 Utilities.warn("`latexmk` and `lualatex` required for PDF generation.")
             end
@@ -92,7 +91,7 @@ end
 
 function writeheader(io::IO, doc::Documents.Document)
     custom = joinpath(doc.user.root, doc.user.source, "assets", "custom.sty")
-    isfile(custom) ? Compat.cp(custom, "custom.sty"; force = true) : touch("custom.sty")
+    isfile(custom) ? cp(custom, "custom.sty"; force = true) : touch("custom.sty")
     preamble =
         """
         \\documentclass{memoir}

--- a/src/Writers/MarkdownWriter.jl
+++ b/src/Writers/MarkdownWriter.jl
@@ -12,8 +12,7 @@ import ...Documenter:
     Documenter,
     Utilities
 
-import Compat
-import Compat.Markdown
+import Markdown
 
 function render(doc::Documents.Document)
     copy_assets(doc)
@@ -38,7 +37,7 @@ function copy_assets(doc::Documents.Document)
             src = joinpath(assets, each)
             dst = joinpath(builddir, each)
             ispath(dst) && Utilities.warn("Overwriting '$dst'.")
-            Compat.cp(src, dst; force = true)
+            cp(src, dst; force = true)
         end
     else
         error("assets directory '$(abspath(assets))' is missing.")

--- a/src/Writers/Writers.jl
+++ b/src/Writers/Writers.jl
@@ -20,8 +20,6 @@ import ..Documenter:
 
 import .Utilities: Selectors
 
-using Compat
-
 #
 # Format selector definitions.
 #

--- a/test/docsystem.jl
+++ b/test/docsystem.jl
@@ -1,7 +1,6 @@
 module DocSystemTests
 
-using Compat.Test
-using Compat
+using Test
 
 import Documenter: Documenter, DocSystem
 

--- a/test/docsystem.jl
+++ b/test/docsystem.jl
@@ -6,8 +6,6 @@ import Documenter: Documenter, DocSystem
 
 const alias_of_getdocs = DocSystem.getdocs # NOTE: won't get docstrings if in a @testset
 
-PACKAGES_LOADED_MAIN = VERSION < v"0.7.0-DEV.1877"
-
 @testset "DocSystem" begin
     ## Bindings.
     @test_throws ArgumentError DocSystem.binding(9000)
@@ -19,7 +17,7 @@ PACKAGES_LOADED_MAIN = VERSION < v"0.7.0-DEV.1877"
         @test b.var === :Document
     end
     let b = DocSystem.binding(Documenter)
-        @test b.mod === (PACKAGES_LOADED_MAIN ? Main : Documenter)
+        @test b.mod === (Documenter)
         @test b.var === :Documenter
     end
     let b = DocSystem.binding(:Main)
@@ -31,7 +29,7 @@ PACKAGES_LOADED_MAIN = VERSION < v"0.7.0-DEV.1877"
         @test b.var === :binding
     end
     let b = DocSystem.binding(Documenter, :Documenter)
-        @test b.mod === (PACKAGES_LOADED_MAIN ? Main : Documenter)
+        @test b.mod === (Documenter)
         @test b.var === :Documenter
     end
 

--- a/test/doctests/doctests.jl
+++ b/test/doctests/doctests.jl
@@ -1,6 +1,5 @@
 module DocTestsTest
-using Documenter, Compat.Test
-using Compat: @info
+using Documenter, Test
 
 println("="^50)
 @info("Testing `doctest = :fix`")

--- a/test/dom.jl
+++ b/test/dom.jl
@@ -1,7 +1,6 @@
 module DOMTests
 
-using Compat.Test
-using Compat
+using Test
 
 import Documenter.Utilities.DOM: DOM, @tags, HTMLDocument
 

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -1,6 +1,3 @@
-using Compat
-using Compat: @info
-
 # Defines the modules referred to in the example docs (under src/) and then builds them.
 # It can be called separately to build the examples/, or as part of the test suite.
 #

--- a/test/examples/src/lib/functions.md
+++ b/test/examples/src/lib/functions.md
@@ -121,8 +121,8 @@ b = ans
 ```
 
 ```@repl
-using Random # hide
-@static if VERSION < v"1.0.0-" srand(1) else Random.seed!(1) end; # hide
+using Random    # hide
+Random.seed!(1) # hide
 nothing
 rand()
 a = 1

--- a/test/examples/src/lib/functions.md
+++ b/test/examples/src/lib/functions.md
@@ -121,7 +121,7 @@ b = ans
 ```
 
 ```@repl
-using Compat.Random # hide
+using Random # hide
 @static if VERSION < v"1.0.0-" srand(1) else Random.seed!(1) end; # hide
 nothing
 rand()

--- a/test/examples/src/man/tutorial.md
+++ b/test/examples/src/man/tutorial.md
@@ -39,7 +39,7 @@ a + b
 DocTestSetup =
     quote
         using Documenter
-        using Compat.Random
+        using Random
         @static if VERSION < v"1.0.0-"
             srand(1)
         else
@@ -69,7 +69,7 @@ julia> a / b
 ```
 
 ```@eval
-import Compat.Markdown
+import Markdown
 code = string(sprint(Base.banner), "julia>")
 Markdown.Code(code)
 ```

--- a/test/examples/src/man/tutorial.md
+++ b/test/examples/src/man/tutorial.md
@@ -40,11 +40,7 @@ DocTestSetup =
     quote
         using Documenter
         using Random
-        @static if VERSION < v"1.0.0-"
-            srand(1)
-        else
-            Random.seed!(1)
-        end
+        Random.seed!(1)
     end
 ```
 

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -1,5 +1,4 @@
-using Compat.Test
-using Compat
+using Test
 
 # Compat for Julia 0.6
 if !isdefined(Base, Symbol("@isdefined"))

--- a/test/formats/latex.jl
+++ b/test/formats/latex.jl
@@ -1,7 +1,6 @@
 module LaTeXFormatTests
 
-using Compat.Test
-using Compat: @info
+using Test
 
 using Documenter
 

--- a/test/formats/markdown.jl
+++ b/test/formats/markdown.jl
@@ -1,8 +1,7 @@
 module MarkdownFormatTests
 
-using Compat.Test
-using Compat.Random
-using Compat: @info
+using Test
+using Random
 
 using Documenter
 

--- a/test/generate.jl
+++ b/test/generate.jl
@@ -1,7 +1,7 @@
 module GenerateTests
 
-using Compat.Test
-import Compat.Random: randstring
+using Test
+import Random: randstring
 using Documenter
 
 @testset "Generate" begin

--- a/test/generate.jl
+++ b/test/generate.jl
@@ -17,14 +17,14 @@ using Documenter
         end
     end
 
-    # TODO: these tests should be reviewed. Documenter.generate() does not really
-    # support Pkg3 / Julia 0.7 at the moment.
-    @test_throws ErrorException Documenter.generate("Documenter")
-    if VERSION < v"0.7.0-"
-        @test_throws ErrorException Documenter.generate(randstring())
-    else
-        @test_throws MethodError Documenter.generate(randstring())
-    end
+    # # TODO: these tests should be reviewed. Documenter.generate() does not really
+    # # support Pkg3 / Julia 0.7 at the moment.
+    # @test_throws ErrorException Documenter.generate("Documenter")
+    # if VERSION < v"0.7.0-"
+    #     @test_throws ErrorException Documenter.generate(randstring())
+    # else
+    #     @test_throws MethodError Documenter.generate(randstring())
+    # end
 end
 
 end

--- a/test/htmlwriter.jl
+++ b/test/htmlwriter.jl
@@ -1,7 +1,6 @@
 module HTMLWriterTests
 
-using Compat.Test
-using Compat
+using Test
 
 import Documenter.Writers.HTMLWriter: jsescape, generate_version_file
 
@@ -39,7 +38,7 @@ import Documenter.Writers.HTMLWriter: jsescape, generate_version_file
         # let's make sure they're in the right order -- they should be sorted in the output file
         last = 0:0
         for version in versions
-            this = Compat.findfirst(version, contents)
+            this = findfirst(version, contents)
             @test this !== nothing
             @test first(last) < first(this)
             last = this

--- a/test/mdflatten.jl
+++ b/test/mdflatten.jl
@@ -1,8 +1,8 @@
 module MDFlattenTests
 
-using Compat.Test
+using Test
 
-import Compat.Markdown
+import Markdown
 using Documenter.Utilities.MDFlatten
 
 @testset "MDFlatten" begin

--- a/test/navnode.jl
+++ b/test/navnode.jl
@@ -1,8 +1,7 @@
 module NavNodeTests
 
-using Compat.Test
+using Test
 
-using Compat
 import Documenter: Documents, Builder
 import Documenter.Documents: NavNode
 

--- a/test/nongit/tests.jl
+++ b/test/nongit/tests.jl
@@ -1,9 +1,7 @@
-using Compat
-
 mktempdir() do tmpdir
-    Compat.@info("Buiding 'nongit' in $tmpdir")
+    @info("Buiding 'nongit' in $tmpdir")
     cp(joinpath(@__DIR__, "docs"), joinpath(tmpdir, "docs"))
     include(joinpath(tmpdir, "docs/make.jl"))
     # Copy the build/ directory back so that it would be possible to inspect the output.
-    Compat.cp(joinpath(tmpdir, "docs/build"), joinpath(@__DIR__, "build"); force=true)
+    cp(joinpath(tmpdir, "docs/build"), joinpath(@__DIR__, "build"); force=true)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
-using Compat.Test
-using Compat: @info
+using Test
 
 # Build the real docs first.
 include("../docs/make.jl")

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -1,9 +1,7 @@
 module UtilitiesTests
 
-import Compat
-using Compat.Test
-import Compat: occursin
-import Compat.Base64: stringmime
+using Test
+import Base64: stringmime
 
 import Documenter
 import Documenter: IdDict
@@ -117,9 +115,9 @@ end
 
     # URL building
     filepath = string(first(methods(Documenter.Utilities.url)).file)
-    Compat.Sys.iswindows() && (filepath = replace(filepath, "/" => "\\")) # work around JuliaLang/julia#26424
+    Sys.iswindows() && (filepath = replace(filepath, "/" => "\\")) # work around JuliaLang/julia#26424
     let expected_filepath = "/src/Utilities/Utilities.jl"
-        Compat.Sys.iswindows() && (expected_filepath = replace(expected_filepath, "/" => "\\"))
+        Sys.iswindows() && (expected_filepath = replace(expected_filepath, "/" => "\\"))
         @test endswith(filepath, expected_filepath)
         @show filepath expected_filepath
     end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -4,7 +4,6 @@ using Test
 import Base64: stringmime
 
 import Documenter
-import Documenter: IdDict
 
 module UnitTests
     module SubModule end
@@ -135,7 +134,7 @@ end
     @test Documenter.Utilities.relpath_from_repo_root(tempname()) == nothing
 
     import Documenter.Documents: Document, Page, Globals
-    let page = Page("source", "build", [], IdDict(), Globals()), doc = Document()
+    let page = Page("source", "build", [], IdDict{Any,Any}(), Globals()), doc = Document()
         code = """
         x += 3
         γγγ_γγγ


### PR DESCRIPTION
I think it might be easier to first get this in, then clean up after, since there will be quite a lot of changes for the next Documenter release. Thoughts?

I also removed PackageEval results from README. We can add it back when that actually works.