### PR TITLE
Add --max-time 10 to curl call

### DIFF
--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -177,7 +177,7 @@ function linkcheck(link::Markdown.Link, doc::Documents.Document)
     if !haskey(doc.internal.locallinks, link)
         local result
         try
-            result = read(`curl -sI $(link.url)`, String)
+            result = read(`curl -sI $(link.url) --max-time 10`, String)
         catch err
             push!(doc.internal.errors, :linkcheck)
             Utilities.warn("`curl -sI $(link.url)` failed:\n\n$(err)")


### PR DESCRIPTION
Currently ``run(`curl -sI http://shields.io`)`` never returns, and thus Documenters doc-build hangs.