### PR TITLE
Remove julia and osname kwarg from deploydocs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ after_success:
 
 jobs:
   include:
-    - stage: "Deploy docs"
+    - stage: "Documentation"
       julia: 1.0
       os: linux
       script:

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -51,7 +51,6 @@ makedocs(
 deploydocs(
     repo = "github.com/JuliaDocs/Documenter.jl.git",
     target = "build",
-    julia = "1.0",
     deps = nothing,
     make = nothing,
 )


### PR DESCRIPTION
Remove julia and osname kwarg from deploydocs and recommend using Travis Build Stages instead.