### PR TITLE
Filter out empty expressions in parseblock

### DIFF
--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -137,7 +137,10 @@ function parseblock(code::AbstractString, doc, page; skip = 0, keywords = true)
                     break
                 end
             end
-        push!(results, (ex, SubString(code, cursor, prevind(code, ncursor))))
+        str = SubString(code, cursor, prevind(code, ncursor))
+        if !isempty(strip(str))
+            push!(results, (ex, str))
+        end
         cursor = ncursor
     end
     results

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -178,16 +178,14 @@ end
         end
     end
 
-    @testset "issue #749, #790" begin
+    @testset "issues #749, #790, #823" begin
         let parse(x) = Documenter.Utilities.parseblock(x, nothing, nothing)
             for LE in ("\r\n", "\n")
-                l1, l2, l3 = parse("x = Int[]$(LE)$(LE)push!(x, 1)$(LE)")
+                l1, l2 = parse("x = Int[]$(LE)$(LE)push!(x, 1)$(LE)")
                 @test l1[1] == :(x = Int[])
                 @test l1[2] == "x = Int[]$(LE)"
-                @test l2[1] == QuoteNode(Symbol(""))
-                @test l2[2] == "$(LE)"
-                @test l3[1] == :(push!(x, 1))
-                @test l3[2] == "push!(x, 1)$(LE)"
+                @test l2[1] == :(push!(x, 1))
+                @test l2[2] == "push!(x, 1)$(LE)"
             end
         end
     end


### PR DESCRIPTION
Fix #823