### PR TITLE
Recommend develop instead of add.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ jobs:
       julia: 1.0
       os: linux
       script:
-        - julia --project=docs/ -e 'using Pkg; Pkg.instantiate(); Pkg.add(PackageSpec(path=pwd()))'
+        - julia --project=docs/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
         - julia --project=docs/ docs/make.jl
       after_success: skip

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -112,7 +112,7 @@ jobs:
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.instantiate();
-                                    Pkg.add(PackageSpec(path=pwd()))'
+                                    Pkg.develop(PackageSpec(path=pwd()))'
         - julia --project=docs/ docs/make.jl
       after_success: skip
 ```


### PR DESCRIPTION
@KristofferC pointed out that this is better since `add` does a (full ?) clone of the package, but we already have that clone so we can just point to it with `develop`.