### PR TITLE
Make sidebar scrollbar less intrusive

### DIFF
--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -317,6 +317,21 @@ nav.toc li.current > .toctext {
     background-color: white;
 }
 
+nav.toc ul::-webkit-scrollbar {
+    width: .4em;
+    background: none;
+}
+
+nav.toc ul::-webkit-scrollbar-thumb {
+    border-radius: 5px;
+    background: #c9c9c9;
+}
+
+nav.toc ul::-webkit-scrollbar-thumb:hover {
+    border-radius: 5px;
+    background: #aaaaaa;
+}
+
 article {
     margin-left: 20em;
     min-width: 20em;


### PR DESCRIPTION
![scrollbar](https://user-images.githubusercontent.com/147757/46765486-9d435400-cd3b-11e8-95bc-41c72116e6e0.png)

Will only work in WebKit-based browsers (Chrome, Safari). Does nothing on Firefox, but at least on my system the scrollbars already look quite nice. Not sure about IE/Edge.