### PR TITLE
Fix scroll and put nav visually "in front" for narrow/mobile screens

### DIFF
--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -564,7 +564,7 @@ article section.docstring a.source-link {
     }
 
     article > header div#topbar span {
-        position: fixed;
+        position: relative;
         width: 80%;
         height: 1.5em;
         margin-top: -0.1em;

--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -502,7 +502,6 @@ article section.docstring a.source-link {
 @media only screen and (max-width: 768px) {
     nav.toc {
         position: fixed;
-        overflow-y: scroll;
         width: 16em;
         left: -16em;
         -webkit-overflow-scrolling: touch;
@@ -513,6 +512,11 @@ article section.docstring a.source-link {
         -webkit-transition-timing-function: ease-out; /* Safari */
         transition-timing-function: ease-out;
         z-index: 2;
+        box-shadow: 5px 0px 5px 0px rgb(210,210,210);
+    }
+
+    nav.toc > ul {
+        overflow-y: scroll;
     }
 
     nav.toc.show {

--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -515,10 +515,6 @@ article section.docstring a.source-link {
         box-shadow: 5px 0px 5px 0px rgb(210,210,210);
     }
 
-    nav.toc > ul {
-        overflow-y: scroll;
-    }
-
     nav.toc.show {
         left: 0;
     }
@@ -564,7 +560,6 @@ article section.docstring a.source-link {
     }
 
     article > header div#topbar span {
-        position: relative;
         width: 80%;
         height: 1.5em;
         margin-top: -0.1em;


### PR DESCRIPTION
Sorry, I should've caught this earlier, but after https://github.com/JuliaDocs/Documenter.jl/pull/792 on desktop, the `overflow: scroll` adds an additional visible, but unusable, scroll bar for narrow screens! :smile: I took the opportunity to also "lift up" the navigation menu, by removing the inset from the shadow in this case, as I think there is something visually unappealing about a sliding menu, that looks sort of like it folds the page backwards on itself.