### PR TITLE
Allow arbitrary variables to be passed to be stored in User and Internal

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -45,9 +45,11 @@ makedocs(
         ],
         "contributing.md",
     ],
-    # Use clean URLs, unless built as a "local" build
-    html_prettyurls = !("local" in ARGS),
-    html_canonical = "https://juliadocs.github.io/Documenter.jl/stable/",
+    Documenter.HTML(
+        # Use clean URLs, unless built as a "local" build
+        prettyurls = !("local" in ARGS),
+        canonical = "https://juliadocs.github.io/Documenter.jl/stable/",
+    ),
 )
 
 deploydocs(

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -16,6 +16,19 @@ module Documenter
 using DocStringExtensions
 import Base64: base64decode
 
+"""
+Any plugin that needs to either solicit user input or store information in a
+[`Documents.Document`](@ref) should create a subtype of [`Plugin`](@ref). The
+subtype, `T <: Documenter.Plugin`, must have an empty constructor `T()` that
+initialized `T` with the appropriate default values.
+
+To retrieve the values stored in `T`, the plugin can call [`Documents.getplugin`](@ref).
+If `T` was passed to [`makedocs`](@ref), the passed type will be returned. Otherwise,
+a new `T` object will be created.
+"""
+abstract type Plugin end
+
+
 # Submodules
 # ----------
 
@@ -33,13 +46,13 @@ include("Writers/Writers.jl")
 include("Deps.jl")
 
 import .Utilities: Selectors
+import .Writers.HTMLWriter: HTML
 
 
 # User Interface.
 # ---------------
 
 export Deps, makedocs, deploydocs, hide
-
 """
     makedocs(
         root    = "<current-directory>",
@@ -161,13 +174,14 @@ ignored.
 any errors with the document in the previous build phases.
 
 ## Output formats
+**`format`** allows the output format to be specified. The default value is `:html`. Other
+formats can be enabled by using other packages. For examples, see the `DocumenterMarkdown`
+and `DocumenterLaTeX` packages.
 
-**`format`** allows the output format to be specified. The default value is `:html`, but
-additional values are supported via plugins (see below).
-
-The different output formats may require additional keywords to be specified. The
-format-specific keywords for the default HTML output are documented at the
-[`Writers.HTMLWriter`](@ref) module.
+Documenter is designed to support multiple output formats. By default it is creates a set of
+HTML files, but the output format can be controlled with the `format` keyword. The different
+output formats may require additional keywords to be specified via plugins. The keywords for
+the default HTML output are documented for the [`Writers.HTMLWriter.HTML`](@ref) type.
 
 The default `:html` output format creates a set of HTML files, but Documenter is designed to
 support multiple output formats. Via plugin packages, Documenter also supports e.g. Markdown

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -178,8 +178,8 @@ support multiple output formats. Via plugin packages, Documenter also supports e
 A guide detailing how to document a package using Documenter's [`makedocs`](@ref) is provided
 in the [setup guide in the manual](@ref Package-Guide).
 """
-function makedocs(; debug = false, args...)
-    document = Documents.Document(; args...)
+function makedocs(components...; debug = false, kwargs...)
+    document = Documents.Document(components; kwargs...)
     cd(document.user.root) do
         Selectors.dispatch(Builder.DocumentPipeline, document)
     end

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -390,12 +390,12 @@ Retrieves the [`Plugin`](@ref) type for `T` stored in `doc`. If `T` was passed t
 [`makedocs`](@ref), the passed type will be returned. Otherwise, a new `T` object
 will be created using the default constructor `T()`.
 """
-function getplugin(doc::Document, type::Type{T}) where T <: Plugin
-    if !haskey(doc.plugins, type)
-        doc.plugins[type] = type()
+function getplugin(doc::Document, plugin_type::Type{T}) where T <: Plugin
+    if !haskey(doc.plugins, plugin_type)
+        doc.plugins[plugin_type] = plugin_type()
     end
 
-    doc.plugins[type]
+    doc.plugins[plugin_type]
 end
 
 ## Methods

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -112,7 +112,6 @@ function check_kwargs(kws)
     for (k, v) in kws
         println(out, "  ", k, " = ", v)
     end
-    println(out, "It is possible that the specified format will use these arguments.")
     warn(String(take!(out)))
 end
 

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -112,6 +112,7 @@ function check_kwargs(kws)
     for (k, v) in kws
         println(out, "  ", k, " = ", v)
     end
+    println(out, "It is possible that the specified format will use these arguments.")
     warn(String(take!(out)))
 end
 

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -5,7 +5,9 @@ A module for rendering `Document` objects to HTML.
 
 [`HTMLWriter`](@ref) uses the following additional keyword arguments that can be passed to
 [`Documenter.makedocs`](@ref): `assets`, `sitename`, `analytics`, `authors`, `pages`,
-`version`, `html_prettyurls`, `html_disable_git`.
+`version`. The behavior of [`HTMLWriter`](@ref) can be further customized by passing
+[`Documenter.makedocs`](@ref) a [`HTML`](@ref), which accepts the following keyword
+arguments: `prettyurls`, `disable_git`, `edit_branch`, `canonical`.
 
 **`sitename`** is the site's title displayed in the title bar and at the top of the
 *navigation menu. This argument is mandatory for [`HTMLWriter`](@ref).
@@ -24,27 +26,10 @@ selected option in the version selector. If this is left empty (default) the ver
 selector will be hidden. The special value `git-commit` sets the value in the output to
 `git:{commit}`, where `{commit}` is the first few characters of the current commit hash.
 
-**`html_prettyurls`** (default `true`) -- allows disabling the pretty URLs feature, which
-generates an output directory structre that hides the `.html` suffixes from the URLs (e.g.
-by default `src/foo.md` becomes `src/foo/index.html`). This does not work when browsing
-documentation in local files since browsers do not resolve `foo/` to `foo/index.html`
-for local files. If `html_prettyurls = false`, then Documenter generate `src/foo.html`
-instead and sets up the internal links accordingly, suitable for local documentation builds.
+# `HTML` `Plugin` options
 
-**`html_disable_git`** can be used to disable calls to `git` when the document is not
-in a Git-controlled repository. Without setting this to `true`, Documenter will throw
-an error and exit if any of the Git commands fail. The calls to Git are mainly used to
-gather information about the current commit hash and file paths, necessary for constructing
-the links to the remote repository.
-
-**`html_edit_branch`** specifies which branch, tag or commit the "Edit on GitHub" links
-point to. It defaults to `master`. If it set to `nothing`, the current commit will be used.
-
-**`html_canonical`** specifies the canonical URL for your documentation. We recommend
-you set this to the base url of your stable documentation, e.g. `https://juliadocs.github.io/Documenter.jl/stable`.
-This allows search engines to know which version to send their users to. [See
-wikipedia for more information](https://en.wikipedia.org/wiki/Canonical_link_element).
-Default is `nothing`, in which case no canonical link is set.
+The [`HTML`](@ref) [`Documenter.Plugin`](@ref) provides additional customization options
+for the [`HTMLWriter`](@ref). For more information, see the [`HTML`](@ref) documentation.
 
 # Page outline
 
@@ -100,8 +85,37 @@ using ...Utilities.MDFlatten
 
 export HTML
 
-# TODO: Document this
-struct HTML <: Documents.DocumenterPlugin
+"""
+    HTML(kwargs...)
+
+Sets the behavior of [`HTMLWriter`](@ref).
+
+# Keyword arguments
+
+**`prettyurls`** (default `true`) -- allows disabling the pretty URLs feature, which
+generates an output directory structre that hides the `.html` suffixes from the URLs (e.g.
+by default `src/foo.md` becomes `src/foo/index.html`). This does not work when browsing
+documentation in local files since browsers do not resolve `foo/` to `foo/index.html`
+for local files. If `html_prettyurls = false`, then Documenter generate `src/foo.html`
+instead and sets up the internal links accordingly, suitable for local documentation builds.
+
+**`disable_git`** can be used to disable calls to `git` when the document is not
+in a Git-controlled repository. Without setting this to `true`, Documenter will throw
+an error and exit if any of the Git commands fail. The calls to Git are mainly used to
+gather information about the current commit hash and file paths, necessary for constructing
+the links to the remote repository.
+
+**`edit_branch`** specifies which branch, tag or commit the "Edit on GitHub" links
+point to. It defaults to `master`. If it set to `nothing`, the current commit will be used.
+
+**`canonical`** specifies the canonical URL for your documentation. We recommend
+you set this to the base url of your stable documentation, e.g. `https://juliadocs.github.io/Documenter.jl/stable`.
+This allows search engines to know which version to send their users to. [See
+wikipedia for more information](https://en.wikipedia.org/wiki/Canonical_link_element).
+Default is `nothing`, in which case no canonical link is set.
+
+"""
+struct HTML <: Documenter.Plugin
     prettyurls::Bool
     disable_git:: Bool
     edit_branch:: Union{String, Nothing}
@@ -138,7 +152,7 @@ mutable struct HTMLContext
     search_navnode :: Documents.NavNode
     local_assets :: Vector{String}
 end
-HTMLContext(doc) = HTMLContext(doc, Documents.plugin_settings(doc, HTML), "", [], "", "", IOBuffer(), "", Documents.NavNode("search", "Search", nothing), [])
+HTMLContext(doc) = HTMLContext(doc, Documents.getplugin(doc, HTML), "", [], "", "", IOBuffer(), "", Documents.NavNode("search", "Search", nothing), [])
 
 """
 Returns a page (as a [`Documents.Page`](@ref) object) using the [`HTMLContext`](@ref).

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -116,7 +116,6 @@ examples_html_local_doc = makedocs(
     debug = true,
     root  = examples_root,
     build = "builds/html-local",
-    html_prettyurls = false,
     doctestfilters = [r"Ptr{0x[0-9]+}"],
     assets = ["assets/custom.css"],
     sitename = "Documenter example",
@@ -124,8 +123,10 @@ examples_html_local_doc = makedocs(
 
     linkcheck = true,
     linkcheck_ignore = [r"(x|y).md", "z.md", r":func:.*"],
-
-    html_edit_branch = nothing,
+    Documenter.HTML(
+        prettyurls = false,
+        edit_branch = nothing,
+    ),
 )
 
 # Build with pretty URLs and canonical links
@@ -134,8 +135,6 @@ examples_html_deploy_doc = makedocs(
     debug = true,
     root  = examples_root,
     build = "builds/html-deploy",
-    html_prettyurls = true,
-    html_canonical = "https://example.com/stable",
     doctestfilters = [r"Ptr{0x[0-9]+}"],
     assets = [
         "assets/favicon.ico",
@@ -144,4 +143,8 @@ examples_html_deploy_doc = makedocs(
     sitename = "Documenter example",
     pages = htmlbuild_pages,
     doctest = false,
+    Documenter.HTML(
+        prettyurls = true,
+        canonical = "https://example.com/stable",
+    )
 )


### PR DESCRIPTION
This PR is the start of an attempt to make `Documenter` support passing arbitrary arguments from `makedocs` through to a `Writer`. So far, I have just removed a few of the HTML specific variables from `User`, but, if people this that this is a reasonable approach, I will continue to strip away the special case variables.

One downside to this approach as it is currently implemented is that it scatters the default values for variables throughout the code. But this could be resolved with a few `get!`s at the start of the `render` function in each writer.

Another potential downside is the performance hit resulting from the untyped dictionary. I haven't done any benchmarking to see if this is significant.