### PR TITLE
Add support for FTP in linkcheck, disable other protocols

### DIFF
--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -184,7 +184,8 @@ function linkcheck(link::Markdown.Link, doc::Documents.Document)
     if !haskey(doc.internal.locallinks, link)
         local result
         try
-            result = read(`curl -sI --proto =http,https,ftp,ftps $(link.url) --max-time 10`, String)
+            # interpolating into backticks escapes spaces so constructing a Cmd is necessary
+            result = read(Cmd(String[split(CURL_CMD)..., link.url, "--max-time", "10"]), String)
         catch err
             push!(doc.internal.errors, :linkcheck)
             @warn "`$CURL_CMD $(link.url)` failed:" exception = err

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -146,7 +146,7 @@ footnote(other, orphans::Dict) = true
 
 hascurl() = (try; success(`curl --version`); catch err; false; end)
 
-const CURL_OPTS = "-sI --proto =http,https,ftp,ftps"
+const CURL_CMD = "curl -sI --proto =http,https,ftp,ftps"
 
 """
 $(SIGNATURES)
@@ -184,10 +184,10 @@ function linkcheck(link::Markdown.Link, doc::Documents.Document)
     if !haskey(doc.internal.locallinks, link)
         local result
         try
-            result = read(`curl -sI $(link.url) --max-time 10`, String)
+            result = read(`curl -sI --proto =http,https,ftp,ftps $(link.url) --max-time 10`, String)
         catch err
             push!(doc.internal.errors, :linkcheck)
-            @warn "`curl -sI $(link.url)` failed:" exception = err
+            @warn "`$CURL_CMD $(link.url)` failed:" exception = err
             return false
         end
         HTTP_STATUS_REGEX   = r"^HTTP/(1.1|2) (\d+) (.+)$"m
@@ -213,7 +213,7 @@ function linkcheck(link::Markdown.Link, doc::Documents.Document)
             @debug "linkcheck '$(link.url)': FTP success"
         else
             push!(doc.internal.errors, :linkcheck)
-            @warn "invalid result returned by `curl -sI $(link.url)`:" result
+            @warn "invalid result returned by `$CURL_CMD $(link.url)`:" result
         end
     end
     return false

--- a/test/docchecks.jl
+++ b/test/docchecks.jl
@@ -1,0 +1,28 @@
+module DocCheckTests
+
+using Test
+
+using Markdown
+using Documenter.DocChecks: linkcheck
+using Documenter.Documents
+
+@testset "DocChecks" begin
+    @testset "linkcheck" begin
+        src = md"""
+            [HTTP (HTTP/1.1) success](http://www.google.com)
+            [HTTPS (HTTP/2) success](https://www.google.com)
+            [FTP success](ftp://ftp.iana.org/tz/data/etcetera)
+            [FTP (no proto) success](ftp.iana.org/tz/data/etcetera)
+            [Redirect success](google.com)
+            """
+
+        Documents.walk(Dict{Symbol, Any}(), src) do block
+            doc = Documents.Document(; linkcheck=true)
+            result = linkcheck(block, doc)
+            @test doc.internal.errors == Set{Symbol}()
+            result
+        end
+    end
+end
+
+end

--- a/test/docchecks.jl
+++ b/test/docchecks.jl
@@ -22,6 +22,13 @@ using Documenter.Documents
             @test doc.internal.errors == Set{Symbol}()
             result
         end
+
+        src = Markdown.parse("[FILE failure](file://$(@__FILE__))")
+        doc = Documents.Document(; linkcheck=true)
+        Documents.walk(Dict{Symbol, Any}(), src) do block
+            linkcheck(block, doc)
+        end
+        @test doc.internal.errors == Set{Symbol}([:linkcheck])
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,9 @@ println("="^50)
     # Unit tests for module internals.
     include("utilities.jl")
 
+    # DocChecks tests
+    include("docchecks.jl")
+
     # NavNode tests.
     include("navnode.jl")
 


### PR DESCRIPTION
Fixes #873 ?

This adds support for FTP as well as some tests, and causes unsupported protocols to fail when running curl vs at parse time.