### PR TITLE
Handle DOCUMENTER_KEY errors better in deploydocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@
 
 * ![Enhancement][badge-enhancement] The default `documenter.sty` LaTeX preamble now include `\usepackage{graphicx}` ([#898][github-898]).
 
+* ![Enhancement][badge-enhancement] `deploydocs` is now more helpful when it fails to interpret `DOCUMENTER_KEY`. It now also uses the `BatchMode` SSH option and throws an error instead of asking for a passphrase and timing out the Travis build when `DOCUMENTER_KEY` is broken. ([#697][github-697], [#907][github-907])
+
 ## Version `v0.20.0`
 
 * Documenter v0.20 requires at least Julia v0.7. ([#795][github-795])
@@ -136,6 +138,7 @@
 
 * ![Bugfix][badge-bugfix] At-docs blocks no longer give an error when containing empty lines. ([#823][github-823], [#824][github-824])
 
+[github-697]: https://github.com/JuliaDocs/Documenter.jl/pull/697
 [github-706]: https://github.com/JuliaDocs/Documenter.jl/pull/706
 [github-764]: https://github.com/JuliaDocs/Documenter.jl/pull/764
 [github-789]: https://github.com/JuliaDocs/Documenter.jl/pull/789
@@ -161,6 +164,7 @@
 [github-885]: https://github.com/JuliaDocs/Documenter.jl/pull/885
 [github-891]: https://github.com/JuliaDocs/Documenter.jl/pull/891
 [github-898]: https://github.com/JuliaDocs/Documenter.jl/pull/898
+[github-907]: https://github.com/JuliaDocs/Documenter.jl/pull/907
 
 
 [badge-breaking]: https://img.shields.io/badge/BREAKING-red.svg


### PR DESCRIPTION
Print a more helpful error if `base64decode` fails for the provided key, or `git fetch`  throws an error, most likely due to a key misconfiguration. Also, use SSH batch mode, which means that SSH won't ask for passphrase and time out the Travis build if the SSH key is problematic.

* To see the first error in action: https://travis-ci.org/JuliaDocs/Documenter.jl/jobs/465881411#L484-L487
* To see the second error in action: https://travis-ci.org/JuliaDocs/Documenter.jl/jobs/465884830#L492-L496


Closes #697