### PR TITLE
Don't deploy documentation on cron jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Documenter.jl changelog
 
+## Version `v0.22.0`
+
+* ![Enhancement][badge-enhancement] Documentation is no longer deployed on Travis CI cron jobs. ([#917][github-917])
+
 ## Version `v0.21.0`
 
 * ![Deprecation][badge-deprecation] ![Enhancement][badge-enhancement] The symbol values to the `format` argument of `makedocs` (`:html`, `:markdown`, `:latex`) have been deprecated in favor of the `Documenter.HTML`, `Markdown` and `LaTeX`

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -463,6 +463,7 @@ function deploydocs(;
     travis_pull_request = get(ENV, "TRAVIS_PULL_REQUEST",  "")
     travis_repo_slug    = get(ENV, "TRAVIS_REPO_SLUG",     "")
     travis_tag          = get(ENV, "TRAVIS_TAG",           "")
+    travis_event_type   = get(ENV, "TRAVIS_EVENT_TYPE",    "")
 
 
     # Other variables.
@@ -492,7 +493,9 @@ function deploydocs(;
     branch_ok = !isempty(travis_tag) || travis_branch == devbranch
     ## DOCUMENTER_KEY should exist
     key_ok = !isempty(documenter_key)
-    should_deploy = repo_ok && pr_ok && tag_ok && branch_ok && key_ok
+    ## Cron jobs should not deploy
+    type_ok = travis_event_type != "cron"
+    should_deploy = repo_ok && pr_ok && tag_ok && branch_ok && key_ok && type_ok
 
     marker(x) = x ? "✔" : "✘"
     @info """Deployment criteria:
@@ -501,6 +504,7 @@ function deploydocs(;
     - $(marker(tag_ok)) ENV["TRAVIS_TAG"]="$(travis_tag)" is (i) empty or (ii) a valid VersionNumber
     - $(marker(branch_ok)) ENV["TRAVIS_BRANCH"]="$(travis_branch)" matches devbranch="$(devbranch) (if tag is empty)
     - $(marker(key_ok)) ENV["DOCUMENTER_KEY"] exists
+    - $(marker(type_ok)) ENV["TRAVIS_EVENT_TYPE"]="$(travis_event_type)" is not "cron"
     Deploying: $(marker(should_deploy))
     """
 


### PR DESCRIPTION
It's not really useful to deploy the same commit repeatedly. 
Docs on the env variable can be found [here](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables) (`TRAVIS_EVENT_TYPE`).