### PR TITLE
Add note about @meta placement while splicing docstrings

### DIFF
--- a/docs/src/man/doctests.md
+++ b/docs/src/man/doctests.md
@@ -221,6 +221,10 @@ julia> foo(2)
     and no state is shared between any code blocks.
     To preserve definitions see [Preserving Definitions Between Blocks](@ref).
 
+!!! note
+
+    If you rely on setup-code for doctests inside docstrings, included in the document with `@docs` or `@autodocs`, the `@meta` block must be in the markdown file that calls these macros and not within the docstrings themselves, otherwise they will be ignored.
+
 ## Filtering Doctests
 
 A part of the output of a doctest might be non-deterministic, e.g. pointer addresses and timings.


### PR DESCRIPTION
The example from `docs/src/man/doctests.md` gives the impression, that the `@meta` block can be next to the actual doctest. This is not true when doctests are spliced together using `@(auto)docs` as I've been informed on Slack (thanks!).

Not sure if this is the best location to put this information, but it is certainly where I looked for it before resorting to asking.