### PR TITLE
Skip keyword parsing for code-block parsing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * ![Bugfix][badge-bugfix] `@repl` blocks now work correctly together with quoted
   expressions. ([#923][github-923], [#926][github-926])
 
+* ![Bugfix][badge-bugfix] `@example`, `@repl` and `@eval` blocks now handle reserved words,
+  e.g. `try`/`catch`, correctly. ([#886][github-886], [#927][github-927])
+
 ## Version `v0.21.0`
 
 * ![Deprecation][badge-deprecation] ![Enhancement][badge-enhancement] The symbol values to the `format` argument of `makedocs` (`:html`, `:markdown`, `:latex`) have been deprecated in favor of the `Documenter.HTML`, `Markdown` and `LaTeX`
@@ -180,6 +183,7 @@
 [github-876]: https://github.com/JuliaDocs/Documenter.jl/pull/876
 [github-879]: https://github.com/JuliaDocs/Documenter.jl/pull/879
 [github-885]: https://github.com/JuliaDocs/Documenter.jl/pull/885
+[github-886]: https://github.com/JuliaDocs/Documenter.jl/pull/886
 [github-891]: https://github.com/JuliaDocs/Documenter.jl/pull/891
 [github-898]: https://github.com/JuliaDocs/Documenter.jl/pull/898
 [github-905]: https://github.com/JuliaDocs/Documenter.jl/pull/905
@@ -187,6 +191,7 @@
 [github-917]: https://github.com/JuliaDocs/Documenter.jl/pull/917
 [github-923]: https://github.com/JuliaDocs/Documenter.jl/pull/923
 [github-926]: https://github.com/JuliaDocs/Documenter.jl/pull/926
+[github-927]: https://github.com/JuliaDocs/Documenter.jl/pull/927
 [github-929]: https://github.com/JuliaDocs/Documenter.jl/pull/929
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -477,7 +477,7 @@ function Selectors.runner(::Type{EvalBlocks}, x, page, doc)
     lines = Utilities.find_block_in_file(x.code, page.source)
     cd(dirname(page.build)) do
         result = nothing
-        for (ex, str) in Utilities.parseblock(x.code, doc, page)
+        for (ex, str) in Utilities.parseblock(x.code, doc, page; keywords = false)
             try
                 result = Core.eval(sandbox, ex)
             catch err
@@ -535,7 +535,7 @@ function Selectors.runner(::Type{ExampleBlocks}, x, page, doc)
         else
             code = x.code
         end
-        for (ex, str) in Utilities.parseblock(code, doc, page)
+        for (ex, str) in Utilities.parseblock(code, doc, page; keywords = false)
             (value, success, backtrace, text) = Utilities.withoutput() do
                 cd(dirname(page.build)) do
                     Core.eval(mod, Expr(:(=), :ans, ex))
@@ -598,7 +598,7 @@ function Selectors.runner(::Type{REPLBlocks}, x, page, doc)
     mod  = get!(() -> get_new_sandbox(sym), page.globals.meta, sym)
     code = split(x.code, '\n'; limit = 2)[end]
     result, out = nothing, IOBuffer()
-    for (ex, str) in Utilities.parseblock(x.code, doc, page)
+    for (ex, str) in Utilities.parseblock(x.code, doc, page; keywords = false)
         buffer = IOBuffer()
         input  = droplines(str)
         (value, success, backtrace, text) = Utilities.withoutput() do


### PR DESCRIPTION
Fix #886