### PR TITLE
Better log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * ![Enhancement][badge-enhancement] Documentation is no longer deployed on Travis CI cron jobs. ([#917][github-917])
 
+* ![Enhancement][badge-enhancement] Log messages from failed `@meta`, `@docs`, `@autodocs`,
+  `@eval`, `@example` and `@setup` blocks now include information about the source location
+  of the block. ([#929][github-929])
+
 * ![Bugfix][badge-bugfix] `@repl` blocks now work correctly together with quoted
   expressions. ([#923][github-923], [#926][github-926])
 
@@ -180,8 +184,10 @@
 [github-898]: https://github.com/JuliaDocs/Documenter.jl/pull/898
 [github-905]: https://github.com/JuliaDocs/Documenter.jl/pull/905
 [github-907]: https://github.com/JuliaDocs/Documenter.jl/pull/907
+[github-917]: https://github.com/JuliaDocs/Documenter.jl/pull/917
 [github-923]: https://github.com/JuliaDocs/Documenter.jl/pull/923
 [github-926]: https://github.com/JuliaDocs/Documenter.jl/pull/926
+[github-929]: https://github.com/JuliaDocs/Documenter.jl/pull/929
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -9,10 +9,29 @@ using DocStringExtensions
 import Markdown, LibGit2
 import Base64: stringmime
 
+# escape characters that has a meaning in regex
+regex_escape(str) = sprint(escape_string, str, "\\^\$.|?*+()[{")
+
+# helper to display linerange for error printing
+function find_block_in_file(code, file)
+    content = read(Base.find_source_file(file), String)
+    content = replace(content, "\r\n" => "\n")
+    # make a regex of the code that matches leading whitespace
+    rcode = "\\h*" * replace(regex_escape(code), "\\n" => "\\n\\h*")
+    blockidx = findfirst(Regex(rcode), content)
+    if blockidx !== nothing
+        startline = countlines(IOBuffer(content[1:prevind(content, first(blockidx))]))
+        endline = startline + countlines(IOBuffer(code)) + 1 # +1 to include the closing ```
+        return ":$(startline)-$(endline)"
+    else
+        return ""
+    end
+end
+
 # Pretty-printing locations
 function locrepr(file, line=nothing)
     str = Base.contractuser(file) # TODO: Maybe print this relative the doc-root??
-    line !== nothing && (str = str * ":$(line)")
+    line !== nothing && (str = str * "$(line)")
     return "`$(str)`"
 end
 


### PR DESCRIPTION
Better log messages for failed at-meta, at-docs, at-autodocs, at-eval, at-example and at-setup blocks.