### PR TITLE
Fix non-text/plain output for Markdown and LaTeX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * ![Enhancement][badge-enhancement] Docstrings from `@docs`-blocks are now included in the
   rendered docs even if some part(s) of the block failed. ([#928][github-928], [#935][github-935])
 
+* ![Enhancement][badge-enhancement] The Markdown and LaTeX output writers can now handle multimedia
+  output, such as images, from `@example` blocks. ([#938][github-938])
+
 ## Version `v0.21.2`
 
 * ![Bugfix][badge-bugfix] `linkcheck` now handles servers that do not support `HEAD` requests
@@ -206,6 +209,7 @@
 [github-929]: https://github.com/JuliaDocs/Documenter.jl/pull/929
 [github-934]: https://github.com/JuliaDocs/Documenter.jl/pull/934
 [github-935]: https://github.com/JuliaDocs/Documenter.jl/pull/935
+[github-938]: https://github.com/JuliaDocs/Documenter.jl/pull/938
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -138,6 +138,10 @@ struct RawNode
     text::String
 end
 
+struct MultiOutput
+    content::Vector
+end
+
 # Navigation
 # ----------------------
 

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -562,28 +562,14 @@ function Selectors.runner(::Type{ExampleBlocks}, x, page, doc)
     content = []
     input   = droplines(x.code)
 
-    # Special-case support for displaying SVG and PNG graphics. TODO: make this more general.
-    output = if showable(MIME"text/html"(), result)
-        Documents.RawHTML(Base.invokelatest(stringmime, MIME"text/html"(), result))
-    elseif showable(MIME"image/svg+xml"(), result)
-        Documents.RawHTML(Base.invokelatest(stringmime, MIME"image/svg+xml"(), result))
-    elseif showable(MIME"image/png"(), result)
-        Documents.RawHTML(string("<img src=\"data:image/png;base64,", Base.invokelatest(stringmime, MIME"image/png"(), result), "\" />"))
-    elseif showable(MIME"image/webp"(), result)
-        Documents.RawHTML(string("<img src=\"data:image/webp;base64,", Base.invokelatest(stringmime, MIME"image/webp"(), result), "\" />"))
-    elseif showable(MIME"image/gif"(), result)
-        Documents.RawHTML(string("<img src=\"data:image/gif;base64,", Base.invokelatest(stringmime, MIME"image/gif"(), result), "\" />"))
-    elseif showable(MIME"image/jpeg"(), result)
-        Documents.RawHTML(string("<img src=\"data:image/jpeg;base64,", Base.invokelatest(stringmime, MIME"image/jpeg"(), result), "\" />"))
-    else
-        Markdown.Code(Documenter.DocTests.result_to_string(buffer, result))
-    end
+    # Generate different  in different formats and let each writer select
+    output = Base.invokelatest(Utilities.display_dict, result)
 
     # Only add content when there's actually something to add.
     isempty(input)  || push!(content, Markdown.Code("julia", input))
-    isempty(output.code) || push!(content, output)
+    isempty(output) || push!(content, output)
     # ... and finally map the original code block to the newly generated ones.
-    page.mapping[x] = Markdown.MD(content)
+    page.mapping[x] = Documents.MultiOutput(content)
 end
 
 # @repl

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -635,6 +635,20 @@ function mdparse(s::AbstractString; mode=:single)
     end
 end
 
+# Capturing output in different representations similar to IJulia.jl
+import Base64: stringmime
+function display_dict(x)
+    out = Dict{MIME,Any}()
+    # Always generate text/plain
+    out[MIME"text/plain"()] = stringmime(MIME"text/plain"(), x)
+    for m in [MIME"text/html"(), MIME"image/svg+xml"(), MIME"image/png"(),
+              MIME"image/webp"(), MIME"image/gif"(), MIME"image/jpeg"(),
+              MIME"text/latex"()]
+        showable(m, x) && (out[m] = stringmime(m, x))
+    end
+    return out
+end
+
 include("DOM.jl")
 include("MDFlatten.jl")
 include("TextDiff.jl")

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -316,6 +316,39 @@ function latex(io::IO, node::Documents.EvalNode, page, doc)
     node.result === nothing ? nothing : latex(io, node.result, page, doc)
 end
 
+# Select the "best" representation for LaTeX output.
+using Base64: base64decode
+function latex(io::IO, mo::Documents.MultiOutput)
+    foreach(x->Base.invokelatest(latex, io, x), mo.content)
+end
+function latex(io::IO, d::Dict{MIME,Any})
+    filename = String(rand('a':'z', 7))
+    if haskey(d, MIME"image/png"())
+        write("$(filename).png", base64decode(d[MIME"image/png"()]))
+        _println(io, """
+        \\begin{figure}[H]
+        \\centering
+        \\includegraphics{$(filename)}
+        \\end{figure}
+        """)
+    elseif haskey(d, MIME"image/jpeg"())
+        write("$(filename).jpeg", base64decode(d[MIME"image/jpeg"()]))
+        _println(io, """
+        \\begin{figure}[H]
+        \\centering
+        \\includegraphics{$(filename)}
+        \\end{figure}
+        """)
+    elseif haskey(d, MIME"text/latex"())
+        latex(io, Utilities.mdparse(d[MIME"text/latex"()]; mode = :single))
+    elseif haskey(d, MIME"text/plain"())
+        latex(io, Markdown.Code(d[MIME"text/plain"()]))
+    else
+        error("this should never happen.")
+    end
+    return nothing
+end
+
 
 ## Basic Nodes. AKA: any other content that hasn't been handled yet.
 


### PR DESCRIPTION
Fix non-text/plain output for Markdown
and LaTeX output by capturing several
output representations and let each writer
choose which one to render,
fixes  #916, fixes fredrikekre/Literate.jl#49.