### PR TITLE
Render text/markdown in MarkdownWriter

### DIFF
--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -643,7 +643,7 @@ function display_dict(x)
     out[MIME"text/plain"()] = stringmime(MIME"text/plain"(), x)
     for m in [MIME"text/html"(), MIME"image/svg+xml"(), MIME"image/png"(),
               MIME"image/webp"(), MIME"image/gif"(), MIME"image/jpeg"(),
-              MIME"text/latex"()]
+              MIME"text/latex"(), MIME"text/markdown"()]
         showable(m, x) && (out[m] = stringmime(m, x))
     end
     return out

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1123,6 +1123,8 @@ function mdconvert(d::Dict{MIME,Any}, parent; kwargs...)
         out = Documents.RawHTML(string("<img src=\"data:image/jpeg;base64,", d[MIME"image/jpeg"()], "\" />"))
     elseif haskey(d, MIME"text/latex"())
         out = Utilities.mdparse(d[MIME"text/latex"()]; mode = :single)
+    elseif haskey(d, MIME"text/markdown"())
+        out = Markdown.parse(d[MIME"text/markdown"()])
     elseif haskey(d, MIME"text/plain"())
         out = Markdown.Code(d[MIME"text/plain"()])
     else

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -341,6 +341,8 @@ function latex(io::IO, d::Dict{MIME,Any})
         """)
     elseif haskey(d, MIME"text/latex"())
         latex(io, Utilities.mdparse(d[MIME"text/latex"()]; mode = :single))
+    elseif haskey(d, MIME"text/markdown"())
+        latex(io, Markdown.parse(d[MIME"text/markdown"()]))
     elseif haskey(d, MIME"text/plain"())
         latex(io, Markdown.Code(d[MIME"text/plain"()]))
     else

--- a/src/Writers/MarkdownWriter.jl
+++ b/src/Writers/MarkdownWriter.jl
@@ -145,7 +145,9 @@ function render(io::IO, mime::MIME"text/plain", d::Documents.MultiOutput, page, 
 end
 function render(io::IO, mime::MIME"text/plain", d::Dict{MIME,Any}, page, doc)
     filename = String(rand('a':'z', 7))
-    if haskey(d, MIME"text/html"())
+    if haskey(d, MIME"text/markdown"())
+        println(io, d[MIME"text/markdown"()])
+    elseif haskey(d, MIME"text/html"())
         println(io, d[MIME"text/html"()])
     elseif haskey(d, MIME"image/svg+xml"())
         # NOTE: It seems that we can't simply save the SVG images as a file and include them

--- a/test/examples/src/index.md
+++ b/test/examples/src/index.md
@@ -450,3 +450,16 @@ r = :a
 * [Colons not allowed on Windows -- `some:path`](some:path)
 * [No "drive" -- `:path`](:path)
 * [Absolute Windows paths -- `X:\some\path`](X:\some\path)
+
+# Rendering text/markdown
+
+```@example
+struct MarkdownOnly
+    value::String
+end
+Base.show(io::IO, ::MIME"text/markdown", mo::MarkdownOnly) = print(io, mo.value)
+
+MarkdownOnly("""
+**bold** output from MarkdownOnly
+""")
+```

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -81,6 +81,12 @@ end
         @test isa(doc, Documenter.Documents.Document)
 
         # TODO: test the HTML build
+
+        let build_dir = joinpath(examples_root, "builds", "html-local")
+
+            index_html = read(joinpath(build_dir, "index.html"), String)
+            @test occursin("<strong>bold</strong> output from MarkdownOnly", index_html)
+        end
     end
 
     @testset "HTML: deploy" begin


### PR DESCRIPTION
This PR lets you render `Markdown.MD` when the build format is markdown.  Previously (as of #938), it was rendered as an HTML.

Before:

``````
shell> cat make.jl
import DocumenterMarkdown
using Documenter
makedocs(format=DocumenterMarkdown.Markdown())

shell> cat src/index.md
# Example

```@example
using Markdown
Markdown.parse("""
![](https://raw.githubusercontent.com/JuliaGraphics/julia-logo-graphics/master/images/julia-logo-325-by-225.png)
""")
```

julia> include("make.jl")
[ Info: SetupBuildDirectory: setting up build directory.
[ Info: ExpandTemplates: expanding markdown templates.
[ Info: CrossReferences: building cross-references.
[ Info: CheckDocument: running document checks.
[ Info: Populate: populating indices.
[ Info: RenderDocument: rendering document.

shell> cat build/index.md

<a id='Example-1'></a>

# Example


```julia
using Markdown
Markdown.parse("""
![](https://raw.githubusercontent.com/JuliaGraphics/julia-logo-graphics/master/images/julia-logo-325-by-225.png)
""")
```

<div class="markdown"><p><img src="https://raw.githubusercontent.com/JuliaGraphics/julia-logo-graphics/master/images/julia-logo-325-by-225.png" alt="" /></p>
</div>
``````


After:

``````
shell> cat build/index.md

<a id='Example-1'></a>

# Example


```julia
using Markdown
Markdown.parse("""
![](https://raw.githubusercontent.com/JuliaGraphics/julia-logo-graphics/master/images/julia-logo-325-by-225.png)
""")
```

![](https://raw.githubusercontent.com/JuliaGraphics/julia-logo-graphics/master/images/julia-logo-325-by-225.png)
``````
