### PR TITLE
Small changes for GitLab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,6 +266,7 @@
 [github-959]: https://github.com/JuliaDocs/Documenter.jl/pull/959
 [github-960]: https://github.com/JuliaDocs/Documenter.jl/pull/960
 [github-967]: https://github.com/JuliaDocs/Documenter.jl/pull/967
+[github-971]: https://github.com/JuliaDocs/Documenter.jl/pull/971
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
   blocks are now interpreted to be relative `pwd`, which is set to the output directory of the
   resulting file. ([#941][github-941])
 
+* ![Bugfix][badge-bugfix] `deploydocs` and `git_push` now support non-github repos correctly and work when the `.ssh` directory does not already exist or the working directory contains spaces. ([#971][github-971])
+
 ## Version `v0.21.5`
 
 * ![Bugfix][badge-bugfix] Deprecation warnings for `format` now get printed correctly when multiple formats are passed as a `Vector`. ([#967][github-967])

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -606,8 +606,11 @@ function git_push(
 
     target_dir = abspath(target)
 
+    # Extract host from repo as everything up to first ':' or '/' character
+    host = match(r"(.*?)[:\/]", repo)[1]
+
     # The upstream URL to which we push new content and the ssh decryption commands.
-    upstream = "git@$(replace(repo, "github.com/" => "github.com:"))"
+    upstream = "git@$(replace(repo, "$host/" => "$host:"))"
 
     keyfile = abspath(joinpath(root, ".documenter"))
     try
@@ -626,9 +629,9 @@ function git_push(
         # Use a custom SSH config file to avoid overwriting the default user config.
         withfile(joinpath(homedir(), ".ssh", "config"),
             """
-            Host github.com
+            Host $host
                 StrictHostKeyChecking no
-                HostName github.com
+                HostName $host
                 IdentityFile $keyfile
                 BatchMode yes
             """

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -632,7 +632,7 @@ function git_push(
             Host $host
                 StrictHostKeyChecking no
                 HostName $host
-                IdentityFile $keyfile
+                IdentityFile "$keyfile"
                 BatchMode yes
             """
         ) do

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -750,6 +750,10 @@ function gitrm_copy(src, dst)
 end
 
 function withfile(func, file::AbstractString, contents::AbstractString)
+    dir = dirname(file)
+    hasdir = isdir(dir)
+    hasdir || mkpath(dir)
+
     hasfile = isfile(file)
     original = hasfile ? read(file, String) : ""
     open(file, "w") do stream
@@ -765,6 +769,11 @@ function withfile(func, file::AbstractString, contents::AbstractString)
             end
         else
             rm(file)
+        end
+
+        if !hasdir
+            # dir should be empty now as the only file inside was deleted
+            rm(dir, recursive=true)
         end
     end
 end


### PR DESCRIPTION
I have been experimenting with getting docs to build on GitLab and found a few things to fix up.

For reference and to help anyone else, I've been using the following hacked together script  that calls `git_push` to skip all of the travis-specific processing in `deploydocs`:

```julia
if haskey(ENV, "CI")
  tag = get(ENV, "CI_COMMIT_TAG", "")
  tag_ok = isempty(tag) || occursin(Base.VERSION_REGEX, tag)

  if tag_ok
    root = pwd()
    build_dir = "docs/build"
    target_repo = "gitlab.com/xxx/yyy"

    mktempdir() do temp
      devurl = "dev"
      Documenter.git_push(root, temp, target_repo;
          target=build_dir,
          tag=tag,
          host="gitlab.com",
          key=ENV["DOCUMENTER_KEY"],
          # Defaults from Documenter.deploydocs
          sha=readchomp(`git rev-parse --short HEAD`),
          devurl=devurl,
          versions=["stable" => "v^", "v#.#", devurl => devurl],
          forcepush=false,
      )
    end
  end
end
```

There are three commits each with a minor change:

1. Add a `host` option to `git_push` so that the url rewriting and temp ssh config file work for gitlab.com urls as well
2. Makes the .ssh directory if it doesn't already exist to avoid crashing
3. Wraps the identity file path in quotes in case of spaces in the filename

Happy to rework anything as required