### PR TITLE
Reinstante limit=true for text/plain output.

### DIFF
--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -636,12 +636,16 @@ function mdparse(s::AbstractString; mode=:single)
 end
 
 # Capturing output in different representations similar to IJulia.jl
-import Base64: stringmime
+function limitstringmime(m::MIME"text/plain", x)
+    io = IOBuffer()
+    show(IOContext(io, :limit=> true), m, x)
+    return String(take!(io))
+end
 function display_dict(x)
     out = Dict{MIME,Any}()
     x === nothing && return out
     # Always generate text/plain
-    out[MIME"text/plain"()] = stringmime(MIME"text/plain"(), x)
+    out[MIME"text/plain"()] = limitstringmime(MIME"text/plain"(), x)
     for m in [MIME"text/html"(), MIME"image/svg+xml"(), MIME"image/png"(),
               MIME"image/webp"(), MIME"image/gif"(), MIME"image/jpeg"(),
               MIME"text/latex"(), MIME"text/markdown"()]


### PR DESCRIPTION
This only sets `limit` to `true` for `text/plain`, but maybe we should just do https://github.com/JuliaLang/IJulia.jl/blob/fda9fe50950fd433d39f7bc7294e0de9376dd4cc/src/inline.jl#L31-L49 ? I think this is fine for now. I am not aware of any other mime output that cares about `limit`.

fixes #970 