### PR TITLE
add option to upload search index to Algolia

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [extras]

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1221,7 +1221,8 @@ fixlinks!(ctx, navnode, md) = nothing
 # ------------------------------------------------------------------------------
 
 # TODO create better settings, now all defaults
-"""Customized Algolia settings for optimal results
+"""
+Customized Algolia settings for optimal results
 
 https://www.algolia.com/doc/api-reference/settings-api-parameters/
 """
@@ -1238,7 +1239,8 @@ const ALGOLIA_SETTINGS = Dict{String, Any}(
                           c == '_' ||
                           (isascii(c) && (isletter(c) || isnumeric(c)))
 
-"""Create an index name based on sitename and version
+"""
+Create an index name based on sitename and version
 
 It is assumed that the
 
@@ -1257,7 +1259,8 @@ function indexname(sitename::AbstractString; temp::Bool=false)
     temp ? string(simplesite, "_temp_", randstr) : simplesite
 end
 
-"""Delete old temporary indexes
+"""
+Delete old temporary indexes
 
 This should normally speaking never find any, but in case a previous upload
 failed halfway we don't want to accumulate temporary indexes.
@@ -1290,7 +1293,8 @@ function checkstatus(d::AbstractDict)
     return d
 end
 
-"""Do a request to the Algolia REST API
+"""
+Do a request to the Algolia REST API
 
 For this to work two environment variables need to be set;
 `ALGOLIA_APPLICATION_ID` and `ALGOLIA_API_KEY`. Both can be found on the
@@ -1346,7 +1350,8 @@ function batch_write(index_temp::AbstractString, records::AbstractVector)
     end
 end
 
-"""Use the Algolia REST API to upload the search index
+"""
+Use the Algolia REST API to upload the search index
 
 This creates a temporary index which at the end is moved over the one used in
 the generated documentation website. This approach will not give any downtime,

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -286,7 +286,13 @@ end
 
 function add_search_algolia(ctx::HTMLContext, doc::Documents.Document, settings::HTML)
     render_search(ctx, settings.search)
-    upload_index(doc.user.sitename, ctx.search_index)
+    ctx.search_index_js = "search_index.json"
+    # store a JSON that has all information needed by deploydocs(), which will
+    # upload the search index to Algolia
+    d = Dict("sitename" => doc.user.sitename, "records" => ctx.search_index)
+    open(joinpath(doc.user.root, ctx.search_index_js), "w") do io
+        JSON.print(io, d)
+    end
 end
 
 """

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -448,25 +448,20 @@ function render_search(ctx::HTMLContext, search::String)
         ul["#search-results"]
     )
 
-    # search_index_js only set for lunr search
-    if search == "lunr"
-        htmldoc = DOM.HTMLDocument(
-            html[:lang=>"en"](
-                head,
-                body(navmenu, article),
-                script[:src => relhref(src, ctx.search_index_js)],
-                script[:src => relhref(src, ctx.search_js)],
-            )
-        )
+    # include the right JS for the used search method
+    search_scripts = if search == "lunr"
+        (script[:src => relhref(src, ctx.search_index_js)], script[:src => relhref(src, ctx.search_js)])
     else
-        htmldoc = DOM.HTMLDocument(
-            html[:lang=>"en"](
-                head,
-                body(navmenu, article),
-                script[:src => "https://cdn.jsdelivr.net/algoliasearch/3/algoliasearchLite.min.js"],
-            )
-        )
+        (script[:src => "https://cdn.jsdelivr.net/algoliasearch/3/algoliasearchLite.min.js"],)
     end
+
+    htmldoc = DOM.HTMLDocument(
+        html[:lang=>"en"](
+            head,
+            body(navmenu, article),
+            search_scripts...,
+        )
+    )
     open_output(ctx, ctx.search_navnode) do io
         print(io, htmldoc)
     end


### PR DESCRIPTION
Still a work in progress, though opening here as a draft PR for visibility and discussion.

Continues after the refactoring in #966, by adding an option to upload the search index to Algolia. The uploading part should work already, given (copied from docstring):

> For this to work two environment variables need to be set;
`ALGOLIA_APPLICATION_ID` and `ALGOLIA_API_KEY`. Both can be found on the
"API Keys" page of your application on the Algolia website. `ALGOLIA_API_KEY`
refers to the Admin API Key, which is needed to create new indexes.

## User interface

However uploading the index and not using it is not very helpful, so I still plan to add this to the HTML & JS in this PR. I want to do this as simple as possible based on the example provided [here](https://github.com/algolia/algoliasearch-client-javascript/blob/27fa15a86d8ebe6854bac8c42acee091b1d07c12/examples/jquery.html). Leaving the UI as-is as much as possible, so we can leave that for a possible future PR (e.g. switching to using [InstantSearch.js](https://community.algolia.com/instantsearch.js/)  or @haampie's https://github.com/haampie/julia-docs-search-ui).

## Free plans and quotas

I  am slightly worried about this approach creating too many operations for the free plan (copied from docstring):

> Note that this approach is simple since it generates the full index from scratch,
and is therefore not reliant on updating a pre-existing index. However since
most search records are unlikely to change between each time this is run,
it would be more efficient to somehow hash the records and corresponding
Algolia object ID and only upload changes. Indexing operations count equally
as search operations towards the number of operations per month.

See also the discussion about this here: https://discourse.julialang.org/t/rfc-improved-search-for-documentation/8079/. The free [community plan](https://www.algolia.com/pricing/) will likely be too small for the largest projects, in which case they can also apply for the  [Algolia for Open Source (AOS) plan](https://www.algolia.com/for-open-source/). The records quota we can easily estimate and likely won't be the bottleneck, but the amount of operations is hard to estimate (not the number of upload operations, but the number of search operations). Though from the AOS page it seems that this limit can be discussed with Algolia (for base docs for instance).

##  Doc and search index versions

I don't know yet how to handle the different versions that are hosted simultaneously, but I also don't fully understand how versions work now. Is it true that `makedocs` always just makes one version, which is the latest master, which is deployed (`deploydocs`) to `dev`, `stable` or `vx.x` depending on what it is? So a new deploy will never touch old versions, is that right? At first I assumed it always builds all versions, in which case we could have a separate index per version, but now I'm not sure. The `versions` keyword is only available in `deploydocs` and not in `makedocs`, but `deploydocs` misses other data about the site name and `Vector{SearchRecord}` itself that I need. Not sure where I should upload the index, and how to handle versions. Ideas very welcome!