### PR TITLE
Fix example for `makedocs(root=...)`

### DIFF
--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -95,7 +95,7 @@ The folder structure that [`makedocs`](@ref) expects looks like:
 this keyword does not need to be set. It is, for the most part, needed when repeatedly
 running `makedocs` from the Julia REPL like so:
 
-    julia> makedocs(root = joinpath(pathof(MyModule), "..", "..", "docs"))
+    julia> makedocs(root = joinpath(dirname(pathof(MyModule)), "..", "docs"))
 
 **`source`** is the directory, relative to `root`, where the markdown source files are read
 from. By convention this folder is called `src`. Note that any non-markdown files stored


### PR DESCRIPTION
`pathof` returns a file name, therefore we must use `dirname` to jump to the containing directory. Simply using `/..` will result in a file-not-found error.