### PR TITLE
Display stdout if nothing result in at-example

### DIFF
--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -573,7 +573,8 @@ function Selectors.runner(::Type{ExampleBlocks}, x, page, doc)
     # Only add content when there's actually something to add.
     isempty(input)  || push!(content, Markdown.Code("julia", input))
     if result === nothing
-        push!(content, Markdown.Code(Documenter.DocTests.sanitise(buffer)))
+        code = Documenter.DocTests.sanitise(buffer)
+        isempty(code) || push!(content, Markdown.Code(code))
     elseif !isempty(output)
         push!(content, output)
     end

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -572,7 +572,11 @@ function Selectors.runner(::Type{ExampleBlocks}, x, page, doc)
 
     # Only add content when there's actually something to add.
     isempty(input)  || push!(content, Markdown.Code("julia", input))
-    isempty(output) || push!(content, output)
+    if result === nothing
+        push!(content, Markdown.Code(Documenter.DocTests.sanitise(buffer)))
+    elseif !isempty(output)
+        push!(content, output)
+    end
     # ... and finally map the original code block to the newly generated ones.
     page.mapping[x] = Documents.MultiOutput(content)
 end


### PR DESCRIPTION
Should restore the old behavior of at-example blocks with stdout/stderr output.

Fix #986 