### PR TITLE
Enable table column alignment in HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
 
 * ![Bugfix][badge-bugfix] `deploydocs` and `git_push` now support non-github repos correctly and work when the `.ssh` directory does not already exist or the working directory contains spaces. ([#971][github-971])
 
-* ![Bugfix][badge-bugfix] Tables now honor colunm alignment in the HTML output. If a column does not explicitly specify its alignment it defaults to being right-aligned, whereas previously all cells were left-aligned. ([#511][github-511], [#989][github-989])
+* ![Bugfix][badge-bugfix] Tables now honor column alignment in the HTML output. If a column does not explicitly specify its alignment, the parser defaults to it being right-aligned, whereas previously all cells were left-aligned. ([#511][github-511], [#989][github-989])
 
 ## Version `v0.21.5`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@
 
 * ![Bugfix][badge-bugfix] `deploydocs` and `git_push` now support non-github repos correctly and work when the `.ssh` directory does not already exist or the working directory contains spaces. ([#971][github-971])
 
+* ![Bugfix][badge-bugfix] Tables now honor colunm alignment in the HTML output. If a column does not explicitly specify its alignment it defaults to being right-aligned, whereas previously all cells were left-aligned. ([#511][github-511], [#989][github-989])
+
 ## Version `v0.21.5`
 
 * ![Bugfix][badge-bugfix] Deprecation warnings for `format` now get printed correctly when multiple formats are passed as a `Vector`. ([#967][github-967])
@@ -225,6 +227,7 @@
 
 * ![Bugfix][badge-bugfix] At-docs blocks no longer give an error when containing empty lines. ([#823][github-823], [#824][github-824])
 
+[github-511]: https://github.com/JuliaDocs/Documenter.jl/pull/511
 [github-697]: https://github.com/JuliaDocs/Documenter.jl/pull/697
 [github-706]: https://github.com/JuliaDocs/Documenter.jl/pull/706
 [github-764]: https://github.com/JuliaDocs/Documenter.jl/pull/764
@@ -274,6 +277,7 @@
 [github-967]: https://github.com/JuliaDocs/Documenter.jl/pull/967
 [github-971]: https://github.com/JuliaDocs/Documenter.jl/pull/971
 [github-980]: https://github.com/JuliaDocs/Documenter.jl/pull/980
+[github-989]: https://github.com/JuliaDocs/Documenter.jl/pull/989
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1053,10 +1053,28 @@ function mdconvert(paragraph::Markdown.Paragraph, parent::Markdown.List; kwargs.
     return (list_has_loose_field && !parent.loose) ? content : Tag(:p)(content)
 end
 
-mdconvert(t::Markdown.Table, parent; kwargs...) = Tag(:table)(
-    Tag(:tr)(map(x -> Tag(:th)(mdconvert(x, t; kwargs...)), t.rows[1])),
-    map(x -> Tag(:tr)(map(y -> Tag(:td)(mdconvert(y, x; kwargs...)), x)), t.rows[2:end])
-)
+function mdconvert(t::Markdown.Table, parent; kwargs...)
+    @tags table tr th td
+    alignment_style = map(t.align) do align
+        if align == :r
+            "text-align: right"
+        elseif align == :c
+            "text-align: center"
+        else
+            "text-align: left"
+        end
+    end
+    table(
+        tr(map(enumerate(t.rows[1])) do (i, x)
+            th[:style => alignment_style[i]](mdconvert(x, t; kwargs...))
+        end),
+        map(t.rows[2:end]) do x
+            tr(map(enumerate(x)) do (i, y) # each cell in a row
+                td[:style => alignment_style[i]](mdconvert(y, x; kwargs...))
+            end)
+        end
+    )
+end
 
 mdconvert(expr::Union{Expr,Symbol}, parent; kwargs...) = string(expr)
 

--- a/test/examples/src/man/tutorial.md
+++ b/test/examples/src/man/tutorial.md
@@ -336,3 +336,17 @@ Below is a nicely rendered version of `^D`:
 ```@raw html
 <kbd>Ctrl</kbd> + <kbd>D</kbd>
 ```
+
+## Tables
+
+| object | implemented |      value |
+|--------|-------------|------------|
+| `A`    |      ✓      |      10.00 |
+| `BB`   |      ✓      | 1000000.00 |
+
+With explicit alignment.
+
+| object | implemented |      value |
+| :---   |    :---:    |       ---: |
+| `A`    |      ✓      |      10.00 |
+| `BB`   |      ✓      | 1000000.00 |


### PR DESCRIPTION
Note that tables that do not explicitly define alignment default to be right-aligned. Fix #511.