### PR TITLE
Consider CRLF when splitting code lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@
 
 * ![Bugfix][badge-bugfix] Tables now honor column alignment in the HTML output. If a column does not explicitly specify its alignment, the parser defaults to it being right-aligned, whereas previously all cells were left-aligned. ([#511][github-511], [#989][github-989])
 
+* ![Bugfix][badge-bugfix] Code lines ending with `# hide` are now properly hidden for CRLF inputs. ([#991][github-991])
+
 ## Version `v0.21.5`
 
 * ![Bugfix][badge-bugfix] Deprecation warnings for `format` now get printed correctly when multiple formats are passed as a `Vector`. ([#967][github-967])
@@ -278,6 +280,7 @@
 [github-971]: https://github.com/JuliaDocs/Documenter.jl/pull/971
 [github-980]: https://github.com/JuliaDocs/Documenter.jl/pull/980
 [github-989]: https://github.com/JuliaDocs/Documenter.jl/pull/989
+[github-991]: https://github.com/JuliaDocs/Documenter.jl/pull/991
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -677,7 +677,7 @@ end
 # Remove any `# hide` lines, leading/trailing blank lines, and trailing whitespace.
 function droplines(code; skip = 0)
     buffer = IOBuffer()
-    for line in split(code, '\n')[(skip + 1):end]
+    for line in split(code, r"\r?\n")[(skip + 1):end]
         occursin(r"^(.*)#\s*hide$", line) && continue
         println(buffer, rstrip(line))
     end


### PR DESCRIPTION
I noticed that code lines ending with `# hide` were not getting hidden in the output. 
The problem went away if I switched from CRLF to LF line endings.
This might be related to issue #613

I think the issue is caused by `split(code, '\n')` (line 680 in expanders.jl) which assumes LF line ending. 
For CRLF input, code containing `... # hide` gets split to `... # hide\r` and this causes the regex on line 681 to not match---this is because `$` does not match `\r` [[ref](https://discourse.julialang.org/t/regex-doesnt-match-end-of-line-with-both-carriage-return-and-line-feed/5795)]

This PR fixes that by splitting code with `r"\r?\n"`.

---

Minimum working example:

- make.jl
```
using Documenter
makedocs(sitename="Example")
```
- src/index.md (using CRLF)
```
# Example

```@example
import Random # hide
Random.seed!(1) # hide
A = rand(3, 3)
b = [1, 2, 3]
A \ b
Random.seed!(2); nothing # hide
```

- Ouput using master (note that last line still gets hidden correctly):
![image](https://user-images.githubusercontent.com/9019681/54955058-a3607200-4f22-11e9-9b15-fb0e92d772d5.png)

- Output using PR
![image](https://user-images.githubusercontent.com/9019681/54955129-d99df180-4f22-11e9-8eb8-85a29ef4d3d8.png)

- If LF is used, then both master and PR have the same output where code is hidden correctly