### PR TITLE
Fix error when source-file can not be found.

### DIFF
--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -14,18 +14,17 @@ regex_escape(str) = sprint(escape_string, str, "\\^\$.|?*+()[{")
 
 # helper to display linerange for error printing
 function find_block_in_file(code, file)
-    content = read(Base.find_source_file(file), String)
+    source_file = Base.find_source_file(file)
+    source_file === nothing && return nothing
+    content = read(source_file, String)
     content = replace(content, "\r\n" => "\n")
     # make a regex of the code that matches leading whitespace
     rcode = "\\h*" * replace(regex_escape(code), "\\n" => "\\n\\h*")
     blockidx = findfirst(Regex(rcode), content)
-    if blockidx !== nothing
-        startline = countlines(IOBuffer(content[1:prevind(content, first(blockidx))]))
-        endline = startline + countlines(IOBuffer(code)) + 1 # +1 to include the closing ```
-        return ":$(startline)-$(endline)"
-    else
-        return ""
-    end
+    blockidx === nothing && return nothing
+    startline = countlines(IOBuffer(content[1:prevind(content, first(blockidx))]))
+    endline = startline + countlines(IOBuffer(code)) + 1 # +1 to include the closing ```
+    return ":$(startline)-$(endline)"
 end
 
 # Pretty-printing locations


### PR DESCRIPTION
Ref #929, #958. This broke e.g. Literate.jl docs since I removed a file after parsing it in an `@eval` block.