### PR TITLE
Fix filepath in tex file on Windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Documenter.jl changelog
 
+## Version `v0.22.3`
+
+* ![Bugfix][badge-bugfix] Fixed filepaths for images included in the .tex file for PDF output on Windows. ([#999][github-999])
+
 ## Version `v0.22.2`
 
 * ![Bugfix][badge-bugfix] Error reporting for meta-blocks now handles missing files gracefully instead of throwing. ([#996][github-996])
@@ -294,6 +298,7 @@
 [github-994]: https://github.com/JuliaDocs/Documenter.jl/pull/994
 [github-995]: https://github.com/JuliaDocs/Documenter.jl/pull/995
 [github-996]: https://github.com/JuliaDocs/Documenter.jl/pull/996
+[github-999]: https://github.com/JuliaDocs/Documenter.jl/pull/999
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Documenter"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.22.2"
+version = "0.22.3"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -535,6 +535,7 @@ function latexinline(io::IO, md::Markdown.Image)
         else
             normpath(joinpath(dirname(io.filename), md.url))
         end
+        url = replace(url, "\\" => "/") # use / on Windows too.
         wrapinline(io, "includegraphics") do
             _print(io, url)
         end


### PR DESCRIPTION
See https://discourse.julialang.org/t/issue-with-documenters-pdf-output-pictures-not-found/23023/