### PR TITLE
Handle non-existing files in find_block_in_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Documenter.jl changelog
 
+## Version `v0.22.4`
+
+* ![Bugfix][badge-bugfix] Documenter no longer crashes if the build includes doctests from docstrings that are defined in files that do not exist on the file system (e.g. if a Julia Base docstring is included when running a non-source Julia build). ([#1002][github-1002])
+
 ## Version `v0.22.3`
 
 * ![Bugfix][badge-bugfix] Fixed filepaths for images included in the .tex file for PDF output on Windows. ([#999][github-999])
@@ -299,6 +303,7 @@
 [github-995]: https://github.com/JuliaDocs/Documenter.jl/pull/995
 [github-996]: https://github.com/JuliaDocs/Documenter.jl/pull/996
 [github-999]: https://github.com/JuliaDocs/Documenter.jl/pull/999
+[github-1002]: https://github.com/JuliaDocs/Documenter.jl/pull/1002
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -16,6 +16,20 @@ regex_escape(str) = sprint(escape_string, str, "\\^\$.|?*+()[{")
 function find_block_in_file(code, file)
     source_file = Base.find_source_file(file)
     source_file === nothing && return nothing
+    if !isfile(source_file)
+        # TODO: but why is this happening sometimes in the first place?
+        @warn """Trying to find codeblock in $(source_file)
+        But the file does not exist. This may indicate that you are unintentionally including
+        a docstring from Julia standard libraries.
+
+        Code block:
+
+        ```
+        $(code)
+        ```
+        """ file
+        return nothing
+    end
     content = read(source_file, String)
     content = replace(content, "\r\n" => "\n")
     # make a regex of the code that matches leading whitespace

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -16,20 +16,7 @@ regex_escape(str) = sprint(escape_string, str, "\\^\$.|?*+()[{")
 function find_block_in_file(code, file)
     source_file = Base.find_source_file(file)
     source_file === nothing && return nothing
-    if !isfile(source_file)
-        # TODO: but why is this happening sometimes in the first place?
-        @warn """Trying to find codeblock in $(source_file)
-        But the file does not exist. This may indicate that you are unintentionally including
-        a docstring from Julia standard libraries.
-
-        Code block:
-
-        ```
-        $(code)
-        ```
-        """ file
-        return nothing
-    end
+    isfile(source_file) || return nothing
     content = read(source_file, String)
     content = replace(content, "\r\n" => "\n")
     # make a regex of the code that matches leading whitespace


### PR DESCRIPTION
Work around the issue reported [on Discourse](https://discourse.julialang.org/t/documenter-systemerror-while-trying-to-read-statistics-jl/23363/3). Still WIP.