### PR TITLE
Fix Utilities.url if in a submodule

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,6 +35,3 @@ build_script:
 test_script:
   - echo "%JL_TEST_SCRIPT%"
   - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
-
-on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,3 +35,6 @@ build_script:
 test_script:
   - echo "%JL_TEST_SCRIPT%"
   - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+on_finish:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * ![Bugfix][badge-bugfix] Documenter no longer crashes if the build includes doctests from docstrings that are defined in files that do not exist on the file system (e.g. if a Julia Base docstring is included when running a non-source Julia build). ([#1002][github-1002])
 
+* ![Bugfix][badge-bugfix] URLs for files in the repository are now generated correctly when the repository is used as a Git submodule in another repository. ([#1000][github-1000], [#1004][github-1004])
+
 ## Version `v0.22.3`
 
 * ![Bugfix][badge-bugfix] Fixed filepaths for images included in the .tex file for PDF output on Windows. ([#999][github-999])
@@ -303,7 +305,9 @@
 [github-995]: https://github.com/JuliaDocs/Documenter.jl/pull/995
 [github-996]: https://github.com/JuliaDocs/Documenter.jl/pull/996
 [github-999]: https://github.com/JuliaDocs/Documenter.jl/pull/999
+[github-1000]: https://github.com/JuliaDocs/Documenter.jl/issues/1000
 [github-1002]: https://github.com/JuliaDocs/Documenter.jl/pull/1002
+[github-1004]: https://github.com/JuliaDocs/Documenter.jl/pull/1004
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -317,7 +317,7 @@ not in a repository, the function returns `nothing`.
 
 The `dbdir` keyword argument specifies the name of the directory we are searching for to
 determine if this is a repostory or not. If there is a file called `dbdir`, then it's
-contents is checked under the assumption that it is a Git worktree.
+contents is checked under the assumption that it is a Git worktree or a submodule.
 """
 function repo_root(file; dbdir=".git")
     parent_dir, parent_dir_last = dirname(abspath(file)), ""
@@ -328,7 +328,7 @@ function repo_root(file; dbdir=".git")
         if isfile(dbdir_path)
             contents = chomp(read(dbdir_path, String))
             if startswith(contents, "gitdir: ")
-                if isdir(contents[9:end])
+                if isdir(joinpath(parent_dir, contents[9:end]))
                     return parent_dir
                 end
             end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -135,7 +135,9 @@ end
     end
 
     mktempdir() do path
-        cd(path) do
+        path_repo = joinpath(path, "repository")
+        mkpath(path_repo)
+        cd(path_repo) do
             # Create a simple mock repo in a temporary directory with a single file.
             @test success(`git init`)
             @test success(`git config user.email "tester@example.com"`)
@@ -149,6 +151,60 @@ end
 
             # Run tests
             commit = Documenter.Utilities.repo_commit(filepath)
+
+            @test Documenter.Utilities.url("//blob/{commit}{path}#{line}", filepath) == "//blob/$(commit)/src/SourceFile.jl#"
+            @test Documenter.Utilities.url(nothing, "//blob/{commit}{path}#{line}", Documenter.Utilities, filepath, 10:20) == "//blob/$(commit)/src/SourceFile.jl#L10-L20"
+
+            # repo_root & relpath_from_repo_root
+            @test Documenter.Utilities.repo_root(filepath) == dirname(abspath(joinpath(dirname(filepath), ".."))) # abspath() keeps trailing /, hence dirname()
+            @test Documenter.Utilities.repo_root(filepath; dbdir=".svn") == nothing
+            @test Documenter.Utilities.relpath_from_repo_root(filepath) == joinpath("src", "SourceFile.jl")
+            # We assume that a temporary file is not in a repo
+            @test Documenter.Utilities.repo_root(tempname()) == nothing
+            @test Documenter.Utilities.relpath_from_repo_root(tempname()) == nothing
+        end
+
+        # Test worktree
+        path_worktree = joinpath(path, "worktree")
+        cd("$(path_repo)") do
+            @test success(`git worktree add $(path_worktree)`)
+        end
+        cd("$(path_worktree)") do
+            filepath = abspath(joinpath("src", "SourceFile.jl"))
+            # Run tests
+            commit = Documenter.Utilities.repo_commit(filepath)
+
+            @test Documenter.Utilities.url("//blob/{commit}{path}#{line}", filepath) == "//blob/$(commit)/src/SourceFile.jl#"
+            @test Documenter.Utilities.url(nothing, "//blob/{commit}{path}#{line}", Documenter.Utilities, filepath, 10:20) == "//blob/$(commit)/src/SourceFile.jl#L10-L20"
+
+            # repo_root & relpath_from_repo_root
+            @test Documenter.Utilities.repo_root(filepath) == dirname(abspath(joinpath(dirname(filepath), ".."))) # abspath() keeps trailing /, hence dirname()
+            @test Documenter.Utilities.repo_root(filepath; dbdir=".svn") == nothing
+            @test Documenter.Utilities.relpath_from_repo_root(filepath) == joinpath("src", "SourceFile.jl")
+            # We assume that a temporary file is not in a repo
+            @test Documenter.Utilities.repo_root(tempname()) == nothing
+            @test Documenter.Utilities.relpath_from_repo_root(tempname()) == nothing
+        end
+
+        # Test submodule
+        path_submodule = joinpath(path, "submodule")
+        mkpath(path_submodule)
+        cd(path_submodule) do
+            @test success(`git init`)
+            @test success(`git config user.email "tester@example.com"`)
+            @test success(`git config user.name "Test Committer"`)
+            @test success(`git submodule add $(path_repo)`)
+            @test success(`git add -A`)
+            @test success(`git commit -m"Initial commit."`)
+        end
+        path_submodule_repo = joinpath(path, "submodule", "repository")
+        @test isdir(path_submodule_repo)
+        cd(path_submodule_repo) do
+            filepath = abspath(joinpath("src", "SourceFile.jl"))
+            # Run tests
+            commit = Documenter.Utilities.repo_commit(filepath)
+
+            @test isfile(filepath)
 
             @test Documenter.Utilities.url("//blob/{commit}{path}#{line}", filepath) == "//blob/$(commit)/src/SourceFile.jl#"
             @test Documenter.Utilities.url(nothing, "//blob/{commit}{path}#{line}", Documenter.Utilities, filepath, 10:20) == "//blob/$(commit)/src/SourceFile.jl#L10-L20"

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -194,9 +194,11 @@ end
             @test success(`git config user.name "Test Committer"`)
             @info "path_repo=$(path_repo)"
             #@test success(`git submodule add $(path_repo)`)
+            run(`git check-ignore $(path_repo)`)
             run(`git submodule add $(path_repo)`)
             @test success(`git add -A`)
             @test success(`git commit -m"Initial commit."`)
+            exit(1)
         end
         path_submodule_repo = joinpath(path, "submodule", "repository")
         @test isdir(path_submodule_repo)

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -196,10 +196,12 @@ end
             #@test success(`git submodule add $(path_repo)`)
             run(Cmd(`git check-ignore $(path_repo)`, ignorestatus=true))
             run(Cmd(`git check-ignore repository`, ignorestatus=true))
-            run(Cmd(`git submodule add $(path_repo)`, ignorestatus=true))
+            # NOTE: the target path in the `git submodule add` command is necessary for
+            # Windows builds, since otherwise Git claims that the path is in a .gitignore
+            # file.
+            run(Cmd(`git submodule add $(path_repo) repository`, ignorestatus=true))
             @test success(`git add -A`)
             @test success(`git commit -m"Initial commit."`)
-            exit(1)
         end
         path_submodule_repo = joinpath(path, "submodule", "repository")
         @test isdir(path_submodule_repo)

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -193,7 +193,7 @@ end
             @test success(`git config user.email "tester@example.com"`)
             @test success(`git config user.name "Test Committer"`)
             @info "path_repo=$(path_repo)"
-            @eval @test success(`git submodule add $(path_repo)`)
+            #@test success(`git submodule add $(path_repo)`)
             run(`git submodule add $(path_repo)`)
             @test success(`git add -A`)
             @test success(`git commit -m"Initial commit."`)

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -194,8 +194,9 @@ end
             @test success(`git config user.name "Test Committer"`)
             @info "path_repo=$(path_repo)"
             #@test success(`git submodule add $(path_repo)`)
-            run(`git check-ignore $(path_repo)`)
-            run(`git submodule add $(path_repo)`)
+            run(Cmd(`git check-ignore $(path_repo)`, ignorestatus=true))
+            run(Cmd(`git check-ignore repository`, ignorestatus=true))
+            run(Cmd(`git submodule add $(path_repo)`, ignorestatus=true))
             @test success(`git add -A`)
             @test success(`git commit -m"Initial commit."`)
             exit(1)

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -192,14 +192,10 @@ end
             @test success(`git init`)
             @test success(`git config user.email "tester@example.com"`)
             @test success(`git config user.name "Test Committer"`)
-            @info "path_repo=$(path_repo)"
-            #@test success(`git submodule add $(path_repo)`)
-            run(Cmd(`git check-ignore $(path_repo)`, ignorestatus=true))
-            run(Cmd(`git check-ignore repository`, ignorestatus=true))
             # NOTE: the target path in the `git submodule add` command is necessary for
             # Windows builds, since otherwise Git claims that the path is in a .gitignore
             # file.
-            run(Cmd(`git submodule add $(path_repo) repository`, ignorestatus=true))
+            @test success(`git submodule add $(path_repo) repository`)
             @test success(`git add -A`)
             @test success(`git commit -m"Initial commit."`)
         end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -131,7 +131,6 @@ end
     let expected_filepath = "/src/Utilities/Utilities.jl"
         Sys.iswindows() && (expected_filepath = replace(expected_filepath, "/" => "\\"))
         @test endswith(filepath, expected_filepath)
-        @show filepath expected_filepath
     end
 
     mktempdir() do path

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -192,7 +192,9 @@ end
             @test success(`git init`)
             @test success(`git config user.email "tester@example.com"`)
             @test success(`git config user.name "Test Committer"`)
-            @test success(`git submodule add $(path_repo)`)
+            @info "path_repo=$(path_repo)"
+            @eval @test success(`git submodule add $(path_repo)`)
+            run(`git submodule add $(path_repo)`)
             @test success(`git add -A`)
             @test success(`git commit -m"Initial commit."`)
         end


### PR DESCRIPTION
repo_root fails if gitdir: in the .git file is a relative path, which may be the case for submodules. Also add tests for the worktree case, which so far was untested. Fix #1000

@pmagwene, could you by any chance test this branch to make sure it fixes your problem as well?