### PR TITLE
Fix spurious "Package.Package missing" warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * ![Bugfix][badge-bugfix] URLs for files in the repository are now generated correctly when the repository is used as a Git submodule in another repository. ([#1000][github-1000], [#1004][github-1004])
 
+* ![Bugfix][badge-bugfix] When checking for omitted docstrings, Documenter no longer gives "`Package.Package` missing" type false positives. ([#1009][github-1009])
+
 ## Version `v0.22.3`
 
 * ![Bugfix][badge-bugfix] Fixed filepaths for images included in the .tex file for PDF output on Windows. ([#999][github-999])
@@ -308,6 +310,7 @@
 [github-1000]: https://github.com/JuliaDocs/Documenter.jl/issues/1000
 [github-1002]: https://github.com/JuliaDocs/Documenter.jl/pull/1002
 [github-1004]: https://github.com/JuliaDocs/Documenter.jl/pull/1004
+[github-1009]: https://github.com/JuliaDocs/Documenter.jl/pull/1009
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -33,8 +33,12 @@ function missingdocs(doc::Documents.Document)
         # module bindings that come from Docs.meta() always appear to be of the form
         # Docs.Binding(Mod.SubMod, :SubMod) (since Julia 0.7). We therefore "normalize"
         # module bindings before we search in the list returned by allbindings().
-        binding = let b = object.binding, m = Docs.resolve(b)
-            isa(m, Module) && nameof(b.mod) != b.var ? Docs.Binding(m, nameof(m)) : b
+        binding = if Documenter.DocSystem.defined(object.binding) && !Documenter.DocSystem.iskeyword(object.binding)
+            m = Documenter.DocSystem.resolve(object.binding)
+            isa(m, Module) && nameof(object.binding.mod) != object.binding.var ?
+                Docs.Binding(m, nameof(m)) : object.binding
+        else
+            object.binding
         end
         if haskey(bindings, binding)
             signatures = bindings[binding]


### PR DESCRIPTION
It seems that going from Julia 0.6 to 0.7 the way module bindings are stored in the docs metadata changed from `Binding(Mod, :SubMod)` to `Binding(Mod.SubMod, :SubMod)`. Documenter, however, still constructs the former `Binding` objects for modules that are listed just as `SubMod` in an at-docs block.

This fixes the spurious errors that causes when checking for missing docs by explicitly normalizing the module bindings that Documenter creates before it crosschecks them against the bindings in docs metadata.