### PR TITLE
Fix strict=true not failing for doctest failures

### DIFF
--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -211,6 +211,7 @@ function checkresult(sandbox::Module, result::Result, meta::Dict, doc::Documents
                 fix_doctest(result, str, doc)
             else
                 report(result, str, doc)
+                push!(doc.internal.errors, :doctest)
             end
         end
     else
@@ -225,6 +226,7 @@ function checkresult(sandbox::Module, result::Result, meta::Dict, doc::Documents
                 fix_doctest(result, str, doc)
             else
                 report(result, str, doc)
+                push!(doc.internal.errors, :doctest)
             end
         end
     end


### PR DESCRIPTION
The issue was introduced in #958, where the `push!`, which was hidden away in the `DocTests.report` function, got accidentally removed. It is not clear from its name that the `report` function should have a side-effect like this, so it is cleaner if the `push!` calls are next to the report calls, even if it creates slight code duplication.

Fix #1003