### PR TITLE
Reference travis-ci.com instead of .org

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -84,7 +84,7 @@ INFO: add the public key below to https://github.com/USER/REPO/settings/keys
 [SSH PUBLIC KEY HERE]
 
 INFO: add a secure environment variable named 'DOCUMENTER_KEY' to
-      https://travis-ci.org/USER/REPO/settings with value:
+      https://travis-ci.com/USER/REPO/settings with value:
 
 [LONG BASE64 ENCODED PRIVATE KEY]
 ```

--- a/docs/src/man/hosting/walkthrough.md
+++ b/docs/src/man/hosting/walkthrough.md
@@ -138,7 +138,7 @@ julia> read("path/to/private/key", String) |> Documenter.base64encode |> println
 
 Copy the resulting output.
 
-Next, go to `https://travis-ci.org/[YOUR_USER_NAME]/[YOUR_REPO_NAME]/settings`. Scroll down
+Next, go to `https://travis-ci.com/[YOUR_USER_NAME]/[YOUR_REPO_NAME]/settings`. Scroll down
 to the "Environment Variables" section. It should look like this:
 
 ![](travis-variables.png)


### PR DESCRIPTION
Since Travis CI [recommends activating new repositories with travis-ci.com](https://blog.travis-ci.com/2018-05-02-open-source-projects-on-travis-ci-com-with-github-apps) it seems like this documentation should also reference travis-ci.com instead of travis-ci.org.