### PR TITLE
Fix doctest output labelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * ![Enhancement][badge-enhancement] The logo image in the HTML output will now always point to the first page in the navigation menu (as opposed to `index.html`, which may or may not exist). When using pretty URLs, the `index.html` part now omitted from the logo link URL. ([#1005][github-1005])
 
+* ![Enhancement][badge-enhancement] Minor changes to how doctesting errors are printed. ([#1028][github-1028])
+
 ## Version `v0.22.4`
 
 * ![Bugfix][badge-bugfix] Documenter no longer crashes if the build includes doctests from docstrings that are defined in files that do not exist on the file system (e.g. if a Julia Base docstring is included when running a non-source Julia build). ([#1002][github-1002])
@@ -323,6 +325,7 @@
 [github-1009]: https://github.com/JuliaDocs/Documenter.jl/pull/1009
 [github-1014]: https://github.com/JuliaDocs/Documenter.jl/pull/1014
 [github-1015]: https://github.com/JuliaDocs/Documenter.jl/pull/1015
+[github-1028]: https://github.com/JuliaDocs/Documenter.jl/pull/1028
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -274,13 +274,13 @@ function report(result::Result, str, doc::Documents.Document)
 
         $(result.input)
 
-        Output:
+        Evaluated output:
 
-        $(result.output)
+        $(rstrip(str))
 
         Expected output:
 
-        $(rstrip(str))
+        $(result.output)
 
         """, diff)
 end


### PR DESCRIPTION
I find the current labeling of the outputs when printing a bit confusing. Currently it looks like:

```
┌ Error: doctest failure in src/showcase.md:17-20
│ 
│ ```jldoctest
│ julia> 2 + 2
│ 5
│ ```
│ 
│ Subexpression:
│ 
│ 2 + 2
│ 
│ Output:
│ 
│ 5
│ 
│ Expected output:
│ 
│ 4
```

I think "Expected output" should refer to the original doctest, since we expect the doctested code to match the docs. So this PR swaps them around and instead says:

```
┌ Error: doctest failure in src/showcase.md:17-20
│ 
│ ```jldoctest
│ julia> 2 + 2
│ 5
│ ```
│ 
│ Subexpression:
│ 
│ 2 + 2
│ 
│ Evaluated output:
│ 
│ 4
│ 
│ Expected output:
│ 
│ 5
```
