### PR TITLE
Insert video HTML tag for images ending with ".webm"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 * ![Enhancement][badge-enhancement] Minor changes to how doctesting errors are printed. ([#1028][github-1028])
 
+* ![Enhancement][badge-enhancement] Videos can now be included in the HTML output using the image syntax (`![]()`) if the file extension matches a known format (`.webm`, `.mp4`, `.ogg`, `.ogm`, `.ogv`, `.avi`). ([#1034][github-1034])
+
 ## Version `v0.22.4`
 
 * ![Bugfix][badge-bugfix] Documenter no longer crashes if the build includes doctests from docstrings that are defined in files that do not exist on the file system (e.g. if a Julia Base docstring is included when running a non-source Julia build). ([#1002][github-1002])
@@ -332,6 +334,7 @@
 [github-1027]: https://github.com/JuliaDocs/Documenter.jl/issues/1027
 [github-1028]: https://github.com/JuliaDocs/Documenter.jl/pull/1028
 [github-1029]: https://github.com/JuliaDocs/Documenter.jl/pull/1029
+[github-1034]: https://github.com/JuliaDocs/Documenter.jl/pull/1034
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/assets/html/documenter.css
+++ b/assets/html/documenter.css
@@ -83,6 +83,10 @@ img {
     max-width: 100%;
 }
 
+video {
+    max-width: 100%;
+}
+
 table {
     border-collapse: collapse;
     margin: 1em 0;

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1030,7 +1030,17 @@ mdconvert(h::Markdown.Header{N}, parent; kwargs...) where {N} = DOM.Tag(Symbol("
 
 mdconvert(::Markdown.HorizontalRule, parent; kwargs...) = Tag(:hr)()
 
-mdconvert(i::Markdown.Image, parent; kwargs...) = Tag(:img)[:src => i.url, :alt => i.alt]
+function mdconvert(i::Markdown.Image, parent; kwargs...)
+    @tags video img a
+
+    if occursin(r"(.webm|.mp4|.ogg|.ogm|.ogv|.avi)$", i.url)
+        video[:src => i.url, :controls => "true", :title => i.alt](
+            a[:href => i.url](i.alt)
+        )
+    else
+        img[:src => i.url, :alt => i.alt]
+    end
+end
 
 mdconvert(i::Markdown.Italic, parent; kwargs...) = Tag(:em)(mdconvert(i.text, i; kwargs...))
 

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1033,7 +1033,7 @@ mdconvert(::Markdown.HorizontalRule, parent; kwargs...) = Tag(:hr)()
 function mdconvert(i::Markdown.Image, parent; kwargs...)
     @tags video img a
 
-    if occursin(r"(.webm|.mp4|.ogg|.ogm|.ogv|.avi)$", i.url)
+    if occursin(r"\.(webm|mp4|ogg|ogm|ogv|avi)$", i.url)
         video[:src => i.url, :controls => "true", :title => i.alt](
             a[:href => i.url](i.alt)
         )


### PR DESCRIPTION
Markdown elements like `![Alt video text](dir/video.webm)` will be inserted
with a video HTML element in a similar way to Gitlab markdown.