### PR TITLE
Remove deprecations from test/examples/make.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ JSON = "0.19, 0.20"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+DocumenterMarkdown = "997ab1e6-3595-5248-9280-8efb232c3433"
 
 [targets]
-test = ["Test"]
+test = ["Test", "DocumenterMarkdown"]

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -97,13 +97,15 @@ module AutoDocs
 end
 
 # Build example docs
-using Documenter
+using Documenter, DocumenterMarkdown
 
-const examples_root = dirname(@__FILE__)
+const examples_root = @__DIR__
+const builds_directory = joinpath(examples_root, "builds")
+ispath(builds_directory) && rm(builds_directory, recursive=true)
 
 @info("Building mock package docs: MarkdownWriter")
 examples_markdown_doc = makedocs(
-    format = :markdown,
+    format = Markdown(),
     debug = true,
     root  = examples_root,
     build = "builds/markdown",
@@ -134,13 +136,13 @@ examples_html_local_doc = makedocs(
     root  = examples_root,
     build = "builds/html-local",
     doctestfilters = [r"Ptr{0x[0-9]+}"],
-    assets = ["assets/custom.css"],
     sitename = "Documenter example",
     pages = htmlbuild_pages,
 
     linkcheck = true,
     linkcheck_ignore = [r"(x|y).md", "z.md", r":func:.*"],
     Documenter.HTML(
+        assets = ["assets/custom.css"],
         prettyurls = false,
         edit_branch = nothing,
     ),
@@ -176,14 +178,14 @@ examples_html_deploy_doc = withassets("images/logo.png", "images/logo.jpg", "ima
         root  = examples_root,
         build = "builds/html-deploy",
         doctestfilters = [r"Ptr{0x[0-9]+}"],
-        assets = [
-            "assets/favicon.ico",
-            "assets/custom.css"
-        ],
         sitename = "Documenter example",
         pages = htmlbuild_pages,
         doctest = false,
         Documenter.HTML(
+            assets = [
+                "assets/favicon.ico",
+                "assets/custom.css"
+            ],
             prettyurls = true,
             canonical = "https://example.com/stable",
         )


### PR DESCRIPTION
Make sure it's `format=Markdown()`, not `format=:markdown` and that the `assets` keyword is passed to `HTML`, not `makedocs`. Also, remove the `builds/` directory every time `make.jl` runs to make sure we get clean builds.

@fredrikekre Just to make sure, having DocumenterMarkdown as a test dep won't affect normal `pkg> add` installations, right?