### PR TITLE
Add Random as test. dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ JSON = "0.19, 0.20"
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 DocumenterMarkdown = "997ab1e6-3595-5248-9280-8efb232c3433"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [targets]
-test = ["Test", "DocumenterMarkdown"]
+test = ["Test", "DocumenterMarkdown", "Random"]


### PR DESCRIPTION
We do `using Random` in one of the tests. It seems that Julia has become stricter on `master` with standard libraries (see e.g. [this](https://travis-ci.org/JuliaDocs/Documenter.jl/builds/544540753))?