### PR TITLE
Update analytics ID

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,7 +7,7 @@ makedocs(
         prettyurls = !("local" in ARGS),
         canonical = "https://juliadocs.github.io/Documenter.jl/stable/",
         assets = ["assets/favicon.ico"],
-        analytics = "UA-89508993-1",
+        analytics = "UA-136089579-2",
     ),
     clean = false,
     sitename = "Documenter.jl",


### PR DESCRIPTION
Reports the site traffic to a different Google Analytics account which I actually have access to.