### PR TITLE
Build non-pages pages too in HTMLWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 * ![Enhancement][badge-enhancement] Videos can now be included in the HTML output using the image syntax (`![]()`) if the file extension matches a known format (`.webm`, `.mp4`, `.ogg`, `.ogm`, `.ogv`, `.avi`). ([#1034][github-1034])
 
+* ![Bugfix][badge-bugfix] The HTML output now outputs HTML files for pages that are not referenced in the `pages` keyword too (Documenter finds them according to their extension). But they do exists outside of the standard navigation hierarchy (as defined by `pages`). This fixes a bug where these pages could still be referenced by `@ref` links and `@contents` blocks, but in the HTML output, the links ended up being broken. ([#1031][github-1031], [#1047][github-1047])
+
 * ![Experimental][badge-experimental] ![Feature][badge-feature] The current working directory when evaluating `@repl` and `@example` blocks can now be set to a fixed directory by passing the `workdir` keyword to `makedocs`. _The new keyword and its behaviour are experimental and not part of the public API._ ([#1013][github-1013], [#1025][github-1025])
 
 ## Version `v0.22.4`
@@ -338,7 +340,9 @@
 [github-1027]: https://github.com/JuliaDocs/Documenter.jl/issues/1027
 [github-1028]: https://github.com/JuliaDocs/Documenter.jl/pull/1028
 [github-1029]: https://github.com/JuliaDocs/Documenter.jl/pull/1029
+[github-1031]: https://github.com/JuliaDocs/Documenter.jl/issues/1031
 [github-1034]: https://github.com/JuliaDocs/Documenter.jl/pull/1034
+[github-1047]: https://github.com/JuliaDocs/Documenter.jl/pull/1047
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.22.4"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
@@ -14,6 +15,7 @@ REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
+Compat = "2.1"
 DocStringExtensions = "0.4, 0.5, 0.6, 0.7, 0.8"
 JSON = "0.19, 0.20"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ version = "0.22.4"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
@@ -15,7 +14,6 @@ REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
-Compat = "2.1"
 DocStringExtensions = "0.4, 0.5, 0.6, 0.7, 0.8"
 JSON = "0.19, 0.20"
 julia = "1"

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -42,7 +42,6 @@ module HTMLWriter
 
 import Markdown
 import JSON
-using Compat
 
 import ...Documenter:
     Anchors,

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -250,8 +250,11 @@ function render(doc::Documents.Document, settings::HTML=HTML())
     push!(ctx.local_assets, copy_asset("documenter.css", doc))
     append!(ctx.local_assets, settings.assets)
 
-    for navnode in doc.internal.navlist
-        render_page(ctx, navnode)
+    for page in keys(doc.internal.pages)
+        idx = findfirst(nn -> nn.page == page, doc.internal.navlist)
+        nn = isnothing(idx) ? Documents.NavNode(page, nothing, nothing) : doc.internal.navlist[idx]
+        @debug "Rendering $(page) [$(repr(idx))]"
+        render_page(ctx, nn)
     end
 
     render_search(ctx)

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -42,6 +42,7 @@ module HTMLWriter
 
 import Markdown
 import JSON
+using Compat
 
 import ...Documenter:
     Anchors,

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -252,7 +252,7 @@ function render(doc::Documents.Document, settings::HTML=HTML())
 
     for page in keys(doc.internal.pages)
         idx = findfirst(nn -> nn.page == page, doc.internal.navlist)
-        nn = isnothing(idx) ? Documents.NavNode(page, nothing, nothing) : doc.internal.navlist[idx]
+        nn = (idx === nothing) ? Documents.NavNode(page, nothing, nothing) : doc.internal.navlist[idx]
         @debug "Rendering $(page) [$(repr(idx))]"
         render_page(ctx, nn)
     end

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -150,7 +150,7 @@ examples_html_local_doc = makedocs(
 
     linkcheck = true,
     linkcheck_ignore = [r"(x|y).md", "z.md", r":func:.*"],
-    Documenter.HTML(
+    format = Documenter.HTML(
         assets = ["assets/custom.css"],
         prettyurls = false,
         edit_branch = nothing,
@@ -191,7 +191,7 @@ examples_html_deploy_doc = withassets("images/logo.png", "images/logo.jpg", "ima
         pages = htmlbuild_pages,
         expandfirst = expandfirst,
         doctest = false,
-        Documenter.HTML(
+        format = Documenter.HTML(
             assets = [
                 "assets/favicon.ico",
                 "assets/custom.css"

--- a/test/examples/src/omitted.md
+++ b/test/examples/src/omitted.md
@@ -1,0 +1,3 @@
+# Omitted
+
+This file is omitted from the navigation menu (`pages`), but will still get built.

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -50,7 +50,7 @@ end
 
         @test realpath(doc.internal.assets) == realpath(joinpath(dirname(@__FILE__), "..", "..", "assets"))
 
-        @test length(doc.internal.pages) == 13
+        @test length(doc.internal.pages) == 14
 
         let headers = doc.internal.headers
             @test Documenter.Anchors.exists(headers, "Documentation")
@@ -86,6 +86,11 @@ end
 
             index_html = read(joinpath(build_dir, "index.html"), String)
             @test occursin("<strong>bold</strong> output from MarkdownOnly", index_html)
+
+            @test isfile(joinpath(build_dir, "index.html"))
+            @test isfile(joinpath(build_dir, "omitted.html"))
+            @test isfile(joinpath(build_dir, "hidden.html"))
+            @test isfile(joinpath(build_dir, "lib", "autodocs.html"))
         end
     end
 
@@ -95,5 +100,12 @@ end
         @test isa(doc, Documenter.Documents.Document)
 
         # TODO: test the HTML build with pretty URLs
+
+        let build_dir = joinpath(examples_root, "builds", "html-deploy")
+            @test joinpath(build_dir, "index.html") |> isfile
+            @test joinpath(build_dir, "omitted", "index.html") |> isfile
+            @test joinpath(build_dir, "hidden", "index.html") |> isfile
+            @test joinpath(build_dir, "lib", "autodocs", "index.html") |> isfile
+        end
     end
 end


### PR DESCRIPTION
They can then be reached via their URL, which is determined from the filename, as for the other pages. But they will not show up in the sidebar nor in the bottom navigation.

If there is no filter applied, these pages may still show up in an at-contents block. In fact, this actually fixes a bug where, in the HTML output, an at-contents block would list such pages, even though the writer does not produce any `.html` files, leading to broken links in the output.

My use case is to have hidden draft pages (that I actually want to use for my [GSoC blog](http://mortenpi.eu/gsoc2019/)).

Close #1031.