### PR TITLE
Allow DocStringExtensions 0.8, bump version to 0.22.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Documenter.jl changelog
 
+## Version `v0.22.6`
+
+* ![Maintenance][badge-maintenance] Add DocStringExtensions 0.8 as an allowed dependency version. ([#1071][github-1071])
+
 ## Version `v0.22.5`
 
 * ![Maintenance][badge-maintenance] Fix a test dependency problem revealed by a bugfix in Julia / Pkg. ([#1037][github-1037])
@@ -320,6 +324,7 @@
 [github-1009]: https://github.com/JuliaDocs/Documenter.jl/pull/1009
 [github-1014]: https://github.com/JuliaDocs/Documenter.jl/pull/1014
 [github-1037]: https://github.com/JuliaDocs/Documenter.jl/pull/1037
+[github-1071]: https://github.com/JuliaDocs/Documenter.jl/pull/1071
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Documenter"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.22.5"
+version = "0.22.6"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -15,7 +15,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 julia = "0.7, 1"
-DocStringExtensions = "0.4, 0.5, 0.6, 0.7"
+DocStringExtensions = "0.4, 0.5, 0.6, 0.7, 0.8"
 JSON = "0.19, 0.20"
 
 [extras]


### PR DESCRIPTION
Currently I'm getting bumped down to 0.22.3 because it's the last version which didn't upper bound DocStringExtensions to 0.7.0, which means I can't use 0.22.4's fix for strict=true. This resolves that.