### PR TITLE
Add fallback Markdown -> Markdown2 convert methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Version `v0.23.1`
 
-* ![Bugfix][badge-bugfix] Documenter no longer throws an error if the provided `EditURL` argument is missing ([#1076](github-1076), [#1077](github-1077))
+* ![Bugfix][badge-bugfix] Documenter no longer throws an error if the provided `EditURL` argument is missing. ([#1076](github-1076), [#1077](github-1077))
+
+* ![Bugfix][badge-bugfix] Non-standard Markdown AST nodes no longer cause Documenter to exit with a missing method error in doctesting and HTML output. Documenter falls back to `repr()` for such nodes. ([#1073](github-1073), [#1075](github-1075))
+
+* ![Bugfix][badge-bugfix] Docstrings parsed into nested `Markdown.MD` objects are now unwrapped correctly and do not cause Documenter to crash with a missing method error anymore. The user can run into that when reusing docstrings with the `@doc @doc(foo) function bar end` pattern. ([#1075](github-1075))
 
 ## Version `v0.23.0`
 
@@ -388,6 +392,8 @@
 [github-1062]: https://github.com/JuliaDocs/Documenter.jl/pull/1062
 [github-1066]: https://github.com/JuliaDocs/Documenter.jl/pull/1066
 [github-1071]: https://github.com/JuliaDocs/Documenter.jl/pull/1071
+[github-1073]: https://github.com/JuliaDocs/Documenter.jl/issues/1073
+[github-1075]: https://github.com/JuliaDocs/Documenter.jl/pull/1075
 [github-1076]: https://github.com/JuliaDocs/Documenter.jl/issues/1076
 [github-1077]: https://github.com/JuliaDocs/Documenter.jl/pull/1077
 

--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -70,7 +70,7 @@ function doctest(docstr::Docs.DocStr, mod::Module, doc::Documents.Document)
     # Note: parsedocs / formatdoc in Base is weird. It double-wraps the docstring Markdown
     # in a Markdown.MD object..
     @assert isa(md, Markdown.MD) # relying on Julia internals here
-    if length(md.content) == 1 && isa(first(md.content), Markdown.MD)
+    while length(md.content) == 1 && isa(first(md.content), Markdown.MD)
         md = first(md.content)
     end
     md2ast = Markdown2.convert(Markdown2.MD, md)

--- a/src/Utilities/Markdown2.jl
+++ b/src/Utilities/Markdown2.jl
@@ -242,7 +242,7 @@ _convert_block(b::Markdown.Admonition) = Admonition(b.category, b.title, _conver
 
 # Fallback
 function _convert_block(x)
-    @debug "Strage inline Markdown node (typeof(x) = $(typeof(x))), falling back to repr()" x
+    @debug "Strange inline Markdown node (typeof(x) = $(typeof(x))), falling back to repr()" x
     Paragraph([Text(repr(x))])
 end
 

--- a/src/Utilities/Markdown2.jl
+++ b/src/Utilities/Markdown2.jl
@@ -273,7 +273,7 @@ end
 
 # Fallback
 function _convert_inline(x)
-    @debug "Strage inline Markdown node (typeof(x) = $(typeof(x))), falling back to repr()" x
+    @debug "Strange inline Markdown node (typeof(x) = $(typeof(x))), falling back to repr()" x
     Text(repr(x))
 end
 

--- a/src/Utilities/Markdown2.jl
+++ b/src/Utilities/Markdown2.jl
@@ -240,6 +240,11 @@ function _convert_block(b::Markdown.Table)
 end
 _convert_block(b::Markdown.Admonition) = Admonition(b.category, b.title, _convert_block(b.content))
 
+# Fallback
+function _convert_block(x)
+    @debug "Strage inline Markdown node (typeof(x) = $(typeof(x))), falling back to repr()" x
+    Paragraph([Text(repr(x))])
+end
 
 _convert_inline(xs::Vector) = MarkdownInlineNode[_convert_inline(x) for x in xs]
 _convert_inline(s::String) = Text(s)
@@ -264,6 +269,12 @@ _convert_inline(s::Markdown.LaTeX) = InlineMath(s.formula)
 function _convert_inline(s::Markdown.Footnote)
     @assert s.text === nothing # footnote references should not have any content, TODO: error
     FootnoteReference(s.id)
+end
+
+# Fallback
+function _convert_inline(x)
+    @debug "Strage inline Markdown node (typeof(x) = $(typeof(x))), falling back to repr()" x
+    Text(repr(x))
 end
 
 

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1140,6 +1140,12 @@ function mdconvert(d::Dict{MIME,Any}, parent; kwargs...)
     return mdconvert(out, parent; kwargs...)
 end
 
+# Fallback
+function mdconvert(x, parent; kwargs...)
+    @debug "Strange inline Markdown node (typeof(x) = $(typeof(x))), falling back to repr()" x
+    repr(x)
+end
+
 # fixlinks!
 # ------------------------------------------------------------------------------
 

--- a/test/doctests/doctestapi.jl
+++ b/test/doctests/doctestapi.jl
@@ -140,6 +140,15 @@ ERROR: syntax: invalid numeric constant "1.2."
 """
 module ScriptParseErrorFail end
 
+module PR1075
+    "x \$(42) y"
+    function qux end
+    "..."
+    function foo end
+    @doc @doc(foo) function bar end
+    @doc @doc(bar) function baz end
+end
+
 @testset "Documenter.doctest" begin
     # DocTest1
     run_doctest(nothing, [DocTest1]) do result, success, backtrace, output
@@ -204,6 +213,12 @@ module ScriptParseErrorFail end
     run_doctest(nothing, [ScriptParseErrorFail]) do result, success, backtrace, output
         @test !success
         @test result isa TestSetException
+    end
+
+    # PR 1075
+    run_doctest(nothing, [PR1075]) do result, success, backtrace, output
+        @test success
+        @test result isa Test.DefaultTestSet
     end
 end
 

--- a/test/markdown2.jl
+++ b/test/markdown2.jl
@@ -177,6 +177,29 @@ import Documenter.Utilities: Markdown2
 
         @test isa(md2.nodes[1], Markdown2.Table)
     end
+
+    # Issue 1073
+    let md = Markdown.parse(raw"""
+        $$
+        f
+        $$
+        """),
+        md2 = convert(Markdown2.MD, md)
+        @test isa(md2, Markdown2.MD)
+    end
+    let md = Markdown.parse(raw"""
+        X $(42) Y
+        """),
+        md2 = convert(Markdown2.MD, md)
+
+        @test isa(md2, Markdown2.MD)
+        @test length(md2) == 1
+        @test isa(md2.nodes[1], Markdown2.Paragraph)
+        let p = md2.nodes[1]
+            @test length(p.nodes) == 3
+            @test p.nodes[2] == Markdown2.Text("42")
+        end
+    end
 end
 
 end # module


### PR DESCRIPTION
It's easy to end up with `Symbol`s, `Int`s or other arbitrary Julia objects in `Markdown.MD` trees. While it usually indicates a problematic docstring or a parser bug, this makes sure that we do not just crash in those situations. Rather, we just convert them to text nodes with `repr()`.

Fix #1073.