### PR TITLE
Fix tests on nightly

### DIFF
--- a/test/doctests/doctestapi.jl
+++ b/test/doctests/doctestapi.jl
@@ -17,7 +17,14 @@ function run_doctest(f, args...; kwargs...)
         # Running inside a Task to make sure that the parent testsets do not interfere.
         t = Task(() -> doctest(args...; kwargs...))
         schedule(t)
-        fetch(t) # if an exception happens, it gets propagated
+        # if an exception happens, it gets propagated
+        try
+            fetch(t)
+        catch e
+            # Note: in Julia 1.3 fetch no longer throws the exception direction, but instead
+            # wraps it in a TaskFailedException (https://github.com/JuliaLang/julia/pull/32814).
+            rethrow(t.exception)
+        end
     end
 
     @debug """run_doctest($args;, $kwargs) -> $(success ? "success" : "fail")

--- a/test/manual.jl
+++ b/test/manual.jl
@@ -17,7 +17,13 @@ using Test
     ```
     """)
     @test isfile(tmpfile)
-    @test_throws TestSetException fetch(schedule(Task(() -> doctest(Documenter))))
+    # Note: in Julia 1.3 fetch no longer throws the exception direction, but instead
+    # wraps it in a TaskFailedException (https://github.com/JuliaLang/julia/pull/32814).
+    if isdefined(Base, :TaskFailedException)
+        @test_throws TaskFailedException fetch(schedule(Task(() -> doctest(Documenter))))
+    else
+        @test_throws TestSetException fetch(schedule(Task(() -> doctest(Documenter))))
+    end
     println("^^^ Expected error output.")
     rm(tmpfile)
     @test !isfile(tmpfile)


### PR DESCRIPTION
Julia 1.3 changes how exceptions are handled in `Task`s (JuliaLang/julia#32814).