### PR TITLE
Test Julia 1.2 & PRs only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,14 @@ os:
 julia:
   - 1.0
   - 1.1
+  - 1.2
   - nightly
+
+branches:
+  only:
+    - master
+    - /^release-.*$/
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
 
 notifications:
   email: false


### PR DESCRIPTION
Actually.. let's not run CI branches after all. On the rare occasion we want to run CI on a branch without a PR we can just comment out the `branches:` option in `.travis.yml`.