### PR TITLE
Compat caret specifier

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -165,7 +165,7 @@ Markdown.parse("""
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "~$(v.major).$(v.minor)"
+Documenter = "$(v.major).$(v.minor)"
 ```
 """)
 ````


### PR DESCRIPTION
Change documentation to use the default caret specifier à la semver rather than the tilde specifier indicating patch versions as breaking with 0 major.

Would it be possible for the dev process in Documenter to use minor releases as breaking while keeping patches for non-breaking while 0 major?