### PR TITLE
Increase search result prominence for close matches in result titles

### DIFF
--- a/assets/html/search.js
+++ b/assets/html/search.js
@@ -165,7 +165,7 @@ $(document).ready(function() {
 
   var index = lunr(function () {
     this.ref('location')
-    this.field('title')
+    this.field('title',{boost: 10})
     this.field('text')
     documenterSearchIndex['docs'].forEach(function(e) {
         this.add(e)


### PR DESCRIPTION
I tested this through Chrome's DevTools (breakpoint before the function runs, adding this change, then running the page so that the index is generated with this change)

It makes search queries that closely match the result title rank much higher.
For "Macros" and "Arrays" queries in searching the base docs it makes those sections 1st or 2nd,  whereas they're currently way down in the list.

Fixes #631 and #1110

