### PR TITLE
Improving search matching based on result title: Increase field boost to 100

### DIFF
--- a/assets/html/search.js
+++ b/assets/html/search.js
@@ -165,7 +165,7 @@ $(document).ready(function() {
 
   var index = lunr(function () {
     this.ref('location')
-    this.field('title',{boost: 10})
+    this.field('title',{boost: 100})
     this.field('text')
     documenterSearchIndex['docs'].forEach(function(e) {
         this.add(e)

--- a/assets/html/search.js
+++ b/assets/html/search.js
@@ -165,7 +165,7 @@ $(document).ready(function() {
 
   var index = lunr(function () {
     this.ref('location')
-    this.field('title')
+    this.field('title',{boost: 10})
     this.field('text')
     documenterSearchIndex['docs'].forEach(function(e) {
         this.add(e)


### PR DESCRIPTION
Previously, not `boost`ing the `title` field (compared to the `text` field) meant poor ranking performance for key search results related to terms like "arrays", "macros", "types", "methods".

A boost of 10 improved this, but some spurious rankings remained. Boost 100 seems to give something closer to expectation across a variety of terms tried

Ref: #1112 