### PR TITLE
Fix tests when `Pkg.add`ed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Documenter.jl changelog
 
+## Version `v0.23.3`
+
+* ![Bugfix][badge-bugfix] Fix file permission error when `Pkg.test`ing Documenter. ([#1115][github-1115])
+
 ## Version `v0.23.2`
 
 * ![Bugfix][badge-bugfix] Empty Markdown headings no longer cause Documenter to crash. ([#1081][github-1081], [#1082][github-1082])
@@ -402,6 +406,7 @@
 [github-1077]: https://github.com/JuliaDocs/Documenter.jl/pull/1077
 [github-1081]: https://github.com/JuliaDocs/Documenter.jl/issues/1081
 [github-1082]: https://github.com/JuliaDocs/Documenter.jl/pull/1082
+[github-1115]: https://github.com/JuliaDocs/Documenter.jl/pull/1115
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/test/doctests/fix/tests.jl
+++ b/test/doctests/fix/tests.jl
@@ -9,8 +9,11 @@ function test_doctest_fix(dir)
     srcdir = mktempdir(dir)
     builddir = mktempdir(dir)
     @debug "Testing doctest = :fix" srcdir builddir
-    cp(joinpath(@__DIR__, "broken.md"), joinpath(srcdir, "index.md"))
-    cp(joinpath(@__DIR__, "broken.jl"), joinpath(srcdir, "src.jl"))
+
+    # Pkg.add changes permission of files to read-only,
+    # so instead of copying them we read + write.
+    write(joinpath(srcdir, "index.md"), read(joinpath(@__DIR__, "broken.md")))
+    write(joinpath(srcdir, "src.jl"), read(joinpath(@__DIR__, "broken.jl")))
 
     # fix up
     include(joinpath(srcdir, "src.jl")); @eval import .Foo


### PR DESCRIPTION
Use read + write instead of copying in order to fix file permission error when Documenter is Pkg.added.