### PR TITLE
Add hash anchor tracking to google analytics

### DIFF
--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -783,7 +783,7 @@ analytics_script(tracking_id::AbstractString) =
         })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
         ga('create', '$(tracking_id)', 'auto');
-        ga('send', 'pageview');
+        ga('send', 'pageview', {'page': location.pathname + location.search + location.hash});
         """
     )
 


### PR DESCRIPTION
This will allow analysis of search result clicks that go to page anchor locations. Currently it's just the base URL.

Based on https://stackoverflow.com/questions/32378607/google-analytics-setting-up-a-pageview-on-hash-change