### PR TITLE
fix warning: remove bad import Documenter: asset

### DIFF
--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -51,8 +51,7 @@ import ...Documenter:
     Expanders,
     Documenter,
     Utilities,
-    Writers,
-    asset
+    Writers
 
 using ...Utilities.JSDependencies: JSDependencies, json_jsescape
 import ...Utilities.DOM: DOM, Tag, @tags


### PR DESCRIPTION
Fixes: `WARNING: could not import Documenter.asset into HTMLWriter`, which currently shows up on `master`.

It looks like that import was accidentally erroneously added in 5ae06778adad15d1e174a8ab9c88d13914aec5d4