### PR TITLE
Scale figures to textwidth in latex writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Documenter.jl changelog
 
+## Version `v0.24.0`
+
+* ![Enhancement][badge-enhancement] In the PDF/LaTeX output, images that are wider than the text are now being scaled down to text width automatically. The PDF builds now require the [adjustbox](https://ctan.org/pkg/adjustbox) LaTeX package to be available. ([#1137][github-1137])
+
 ## Version `v0.23.3`
 
 * ![Bugfix][badge-bugfix] Fix file permission error when `Pkg.test`ing Documenter. ([#1115][github-1115])
@@ -407,6 +411,7 @@
 [github-1081]: https://github.com/JuliaDocs/Documenter.jl/issues/1081
 [github-1082]: https://github.com/JuliaDocs/Documenter.jl/pull/1082
 [github-1115]: https://github.com/JuliaDocs/Documenter.jl/pull/1115
+[github-1137]: https://github.com/JuliaDocs/Documenter.jl/pull/1137
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/assets/latex/documenter.sty
+++ b/assets/latex/documenter.sty
@@ -83,4 +83,5 @@
 
 % images etc.
 \usepackage{graphicx}
+\usepackage[export]{adjustbox}
 %

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -345,7 +345,7 @@ function latex(io::IO, d::Dict{MIME,Any})
         _println(io, """
         \\begin{figure}[H]
         \\centering
-        \\includegraphics[width=\\textwidth]{$(filename)}
+        \\includegraphics[max width=\\linewidth]{$(filename)}
         \\end{figure}
         """)
     elseif haskey(d, MIME"image/jpeg"())
@@ -353,7 +353,7 @@ function latex(io::IO, d::Dict{MIME,Any})
         _println(io, """
         \\begin{figure}[H]
         \\centering
-        \\includegraphics[width=\\textwidth]{$(filename)}
+        \\includegraphics[max width=\\linewidth]{$(filename)}
         \\end{figure}
         """)
     elseif haskey(d, MIME"text/latex"())
@@ -567,7 +567,7 @@ function latexinline(io::IO, md::Markdown.Image)
             normpath(joinpath(dirname(io.filename), md.url))
         end
         url = replace(url, "\\" => "/") # use / on Windows too.
-        wrapinline(io, "includegraphics[width=\\textwidth]") do
+        wrapinline(io, "includegraphics[max width=\\linewidth]") do
             _print(io, url)
         end
         _println(io)

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -345,7 +345,7 @@ function latex(io::IO, d::Dict{MIME,Any})
         _println(io, """
         \\begin{figure}[H]
         \\centering
-        \\includegraphics{$(filename)}
+        \\includegraphics[width=\\textwidth]{$(filename)}
         \\end{figure}
         """)
     elseif haskey(d, MIME"image/jpeg"())
@@ -353,7 +353,7 @@ function latex(io::IO, d::Dict{MIME,Any})
         _println(io, """
         \\begin{figure}[H]
         \\centering
-        \\includegraphics{$(filename)}
+        \\includegraphics[width=\\textwidth]{$(filename)}
         \\end{figure}
         """)
     elseif haskey(d, MIME"text/latex"())
@@ -567,7 +567,7 @@ function latexinline(io::IO, md::Markdown.Image)
             normpath(joinpath(dirname(io.filename), md.url))
         end
         url = replace(url, "\\" => "/") # use / on Windows too.
-        wrapinline(io, "includegraphics") do
+        wrapinline(io, "includegraphics[width=\\textwidth]") do
             _print(io, url)
         end
         _println(io)


### PR DESCRIPTION
This isn't an ideal solution since we're also going to *upscale* small images, but fixing that [is nontrivial](https://stackoverflow.com/questions/122348/scale-image-down-but-not-up-in-latex).