### PR TITLE
DOCUMENTER_KEY in github actions

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -190,7 +190,7 @@ jobs:
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
         run: julia --project=docs/ docs/make.jl
 ```
 


### PR DESCRIPTION
I think it should be `DOCUMENTER_KEY` instead of `GITHUB_TOKEN` but maybe I'm wrong then this PR is more like a question :)

