### PR TITLE
Post a GitHub status with a link to generated documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 
 * ![Feature][badge-feature] Documenter now has builtin support for deploying from GitHub Actions. Documenter will autodetect the running system, unless explicitly specified. ([#1144][github-1144], [#1152][github-1152])
 
+* ![Feature][badge-feature] When using GitHub Actions Documenter will (try to) post a GitHub status with a link to the generated documentation. This is especially useful for pull request preview builds (see above). ([#1186][github-1186])
+
 * ![Enhancement][badge-enhancement] The handling of JS and CSS assets is now more customizable:
 
   * The `asset` function can now be used to declare remote JS and CSS assets in the `assets` keyword. ([#1108][github-1108])
@@ -478,6 +480,7 @@
 [github-1171]: https://github.com/JuliaDocs/Documenter.jl/pull/1171
 [github-1173]: https://github.com/JuliaDocs/Documenter.jl/pull/1173
 [github-1180]: https://github.com/JuliaDocs/Documenter.jl/pull/1180
+[github-1186]: https://github.com/JuliaDocs/Documenter.jl/pull/1186
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -586,8 +586,10 @@ function git_push(
             ) do
                 cd(git_commands, temp)
             end
+            post_status(deploy_config; repo=repo, type="success", subfolder=subfolder)
         catch e
             @error "Failed to push:" exception=(e, catch_backtrace())
+            post_status(deploy_config; repo=repo, type="error")
         finally
             # Remove the unencrypted private key.
             isfile(keyfile) && rm(keyfile)
@@ -597,8 +599,10 @@ function git_push(
         upstream = authenticated_repo_url(deploy_config)
         try
             cd(git_commands, temp)
+            post_status(deploy_config; repo=repo, type="success", subfolder=subfolder)
         catch e
             @error "Failed to push:" exception=(e, catch_backtrace())
+            post_status(deploy_config; repo=repo, type="error")
         end
     end
 end


### PR DESCRIPTION
This currently only works on GitHub Actions, but might be possible
to enable on Travis CI too if one adds a (user) access token.