### PR TITLE
Simplify/improve GitHub actions YAML setting example

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -177,7 +177,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
           version: 1.3

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -175,17 +175,12 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        julia-version: [1.2.0]
-        julia-arch: [x86]
-        os: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1.0.0
       - uses: julia-actions/setup-julia@latest
         with:
-          version: ${{ matrix.julia-version }}
+          version: 1.3
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -171,7 +171,12 @@ workflow configuration file:
 ```yaml
 name: Documentation
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
This PR contains three independent patches:

* Simplify the workflow YAML by not using `strategy.matrix`.  IIUC you don't need this if you are only running one combination of `julia` and OS.  Ref: https://github.com/bcbi/CompatHelper.jl/pull/171
* Update to actions/checkout v2: https://github.com/actions/checkout/releases/tag/v2.0.0. I didn't find any breaking change: https://github.com/tkf/MyPlayground.jl/pull/21
* Change `on` setting so that `push_preview = true` works out-of-the-box.
