### PR TITLE
Discourage use of matrix: in Travis conf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,19 @@ julia:
   - 1.0
   - 1.3
   - nightly
-matrix:
 
 branches:
   only:
     - master
     - /^release-.*$/
     - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
+
+after_success:
+  - if [ -f test/quietly.log ]; then cat test/quietly.log; fi
+  - if [[ $TRAVIS_JULIA_VERSION = 1.1 ]] && [[ $TRAVIS_OS_NAME = linux ]]; then
+      julia --project=coverage/ -e 'using Pkg; Pkg.instantiate();
+          using Coverage; Codecov.submit(Codecov.process_folder())';
+    fi
 
 jobs:
   allow_failures:
@@ -41,13 +47,6 @@ jobs:
       name: "PDF"
       after_success: skip
       services: docker
-
-after_success:
-  - if [ -f test/quietly.log ]; then cat test/quietly.log; fi
-  - if [[ $TRAVIS_JULIA_VERSION = 1.1 ]] && [[ $TRAVIS_OS_NAME = linux ]]; then
-      julia --project=coverage/ -e 'using Pkg; Pkg.instantiate();
-          using Coverage; Codecov.submit(Codecov.process_folder())';
-    fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ julia:
   - 1.3
   - nightly
 matrix:
-  allow_failures:
-  - julia: nightly
 
 branches:
   only:
@@ -18,17 +16,9 @@ branches:
     - /^release-.*$/
     - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
 
-notifications:
-  email: false
-
-after_success:
-  - if [ -f test/quietly.log ]; then cat test/quietly.log; fi
-  - if [[ $TRAVIS_JULIA_VERSION = 1.1 ]] && [[ $TRAVIS_OS_NAME = linux ]]; then
-      julia --project=coverage/ -e 'using Pkg; Pkg.instantiate();
-          using Coverage; Codecov.submit(Codecov.process_folder())';
-    fi
-
 jobs:
+  allow_failures:
+    - julia: nightly
   include:
     - stage: "Additional tests"
       script:
@@ -51,3 +41,13 @@ jobs:
       name: "PDF"
       after_success: skip
       services: docker
+
+after_success:
+  - if [ -f test/quietly.log ]; then cat test/quietly.log; fi
+  - if [[ $TRAVIS_JULIA_VERSION = 1.1 ]] && [[ $TRAVIS_OS_NAME = linux ]]; then
+      julia --project=coverage/ -e 'using Pkg; Pkg.instantiate();
+          using Coverage; Codecov.submit(Codecov.process_folder())';
+    fi
+
+notifications:
+  email: false

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -65,15 +65,6 @@ deployed. In the example above we will thus build and deploy the documentation f
 worker running Julia 1.0. For more information on how to setup a build stage, see the Travis
 manual for [Build Stages](https://docs.travis-ci.com/user/build-stages).
 
-!!! note "`matrix:` section in `.travis.yml`"
-
-    Travis CI used to use `matrix:` as the section to configure to build matrix in the config
-    file. This now appears to be a deprecated alias for `jobs:`. If you use both `matrix:` and
-    `jobs:` in your configuration, `matrix:` overrides the settings under `jobs:`.
-    
-    If your `.travis.yml` file still uses `matrix:`, it should be replaced merged into a single
-    `jobs:` section.
-
 The three lines in the `script:` section do the following:
 
  1. Instantiate the doc-building environment (i.e. `docs/Project.toml`, see below).
@@ -84,6 +75,15 @@ The three lines in the `script:` section do the following:
     If your package has a build script you should call
     `Pkg.build("PackageName")` after the call to `Pkg.develop` to make
     sure the package is built properly.
+
+!!! note "matrix: section in .travis.yml"
+
+    Travis CI used to use `matrix:` as the section to configure to build matrix in the config
+    file. This now appears to be a deprecated alias for `jobs:`. If you use both `matrix:` and
+    `jobs:` in your configuration, `matrix:` overrides the settings under `jobs:`.
+    
+    If your `.travis.yml` file still uses `matrix:`, it should be replaced with a a single
+    `jobs:` section.
 
 ### [Authentication: SSH Deploy Keys](@id travis-ssh)
 

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -65,6 +65,15 @@ deployed. In the example above we will thus build and deploy the documentation f
 worker running Julia 1.0. For more information on how to setup a build stage, see the Travis
 manual for [Build Stages](https://docs.travis-ci.com/user/build-stages).
 
+!!! note "`matrix:` section in `.travis.yml`"
+
+    Travis CI used to use `matrix:` as the section to configure to build matrix in the config
+    file. This now appears to be a deprecated alias for `jobs:`. If you use both `matrix:` and
+    `jobs:` in your configuration, `matrix:` overrides the settings under `jobs:`.
+    
+    If your `.travis.yml` file still uses `matrix:`, it should be replaced merged into a single
+    `jobs:` section.
+
 The three lines in the `script:` section do the following:
 
  1. Instantiate the doc-building environment (i.e. `docs/Project.toml`, see below).


### PR DESCRIPTION
(1) Don't use `matrix:` in our own config, and (2) add a note about it to the manual.

Close #1228 
