### PR TITLE
Fix outdated links in the manual

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,20 @@
+name: Linkcheck
+
+on:
+  push:
+    branches: '*'
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: 1.3
+      - name: Install dependencies
+        run: julia --color=yes --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and check documentation
+        run: julia --color=yes --project=docs/ docs/make.jl

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
     - stage: "Documentation"
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-        - julia --project=docs/ docs/make.jl
+        - julia --project=docs/ docs/make.jl skiplinks
       name: "HTML"
       after_success: skip
     - script:

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -24,6 +24,18 @@ makedocs(
     sitename = "Documenter.jl",
     authors = "Michael Hatherly, Morten Piibeleht, and contributors.",
     linkcheck = !("skiplinks" in ARGS),
+    linkcheck_ignore = [
+        # timelessrepo.com seems to 404 on any CURL request...
+        "http://timelessrepo.com/json-isnt-a-javascript-subset",
+        # We'll ignore links that point to GitHub's edit pages, as they redirect to the
+        # login screen and cause a warning:
+        r"https://github.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/edit(.*)",
+    ] ∪ (get(ENV, "GITHUB_ACTIONS", nothing)  == "true" ? [
+        # Extra ones we ignore only on CI.
+        #
+        # It seems that CTAN blocks GitHub Actions?
+        "https://ctan.org/pkg/minted",
+    ] : []),
     pages = [
         "Home" => "index.md",
         "Manual" => Any[

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -17,7 +17,7 @@ Feel free to nominate commits that should be backported by opening an issue. Req
 
 ### `release-*` branches
 
-  * Each new minor version `x.y.0` gets a branch called `release-x.y` (a [protected branch](https://help.github.com/en/articles/about-protected-branches)).
+  * Each new minor version `x.y.0` gets a branch called `release-x.y` (a [protected branch](https://help.github.com/en/github/administering-a-repository/about-protected-branches)).
   * New versions are usually tagged only from the `release-x.y` branches.
   * For patch releases, changes get backported to the `release-x.y` branch via a single PR with the standard name "Backports for x.y.z" and label ["Type: Backport"](https://github.com/JuliaDocs/Documenter.jl/pulls?q=label%3A%22Type%3A+Backport%22). The PR message links to all the PRs that are providing commits to the backport. The PR gets merged as a merge commit (i.e. not squashed).
   * The old `release-*` branches may be removed once they have outlived their usefulness.

--- a/docs/src/man/examples.md
+++ b/docs/src/man/examples.md
@@ -23,8 +23,8 @@ Packages that have tagged versions available in the general Registry:
 - [Augmentor.jl](https://evizero.github.io/Augmentor.jl/)
 - [BanditOpt.jl](https://v-i-s-h.github.io/BanditOpt.jl/stable/)
 - [BeaData.jl](https://stephenbnicar.github.io/BeaData.jl/stable/)
-- [Bio.jl](http://biojulia.net/Bio.jl/stable/)
-- [ControlSystems.jl](http://juliacontrol.github.io/ControlSystems.jl/stable/)
+- [Bio.jl](https://biojulia.net/Bio.jl/stable/)
+- [ControlSystems.jl](https://juliacontrol.github.io/ControlSystems.jl/stable/)
 - [DiscretePredictors.jl](https://github.com/v-i-s-h/DiscretePredictors.jl)
 - [Documenter.jl](https://juliadocs.github.io/Documenter.jl/stable/)
 - [DrWatson](https://juliadynamics.github.io/DrWatson.jl/stable/)
@@ -32,8 +32,8 @@ Packages that have tagged versions available in the general Registry:
 - [ExtractMacro.jl](https://carlobaldassi.github.io/ExtractMacro.jl/stable/)
 - [EzXML.jl](https://bicycle1885.github.io/EzXML.jl/stable/)
 - [FourierFlows.jl](https://FourierFlows.github.io/FourierFlows.jl/stable/)
-- [Gadfly.jl](http://gadflyjl.org/stable/)
-- [GeoStats.jl](http://juliohm.github.io/GeoStats.jl/stable/)
+- [Gadfly.jl](https://gadflyjl.org/stable/)
+- [GeoStats.jl](https://juliaearth.github.io/GeoStats.jl/stable/)
 - [Highlights.jl](https://juliadocs.github.io/Highlights.jl/stable/)
 - [IntervalConstraintProgramming.jl](https://juliaintervals.github.io/IntervalConstraintProgramming.jl/stable/)
 - [Luxor.jl](https://juliagraphics.github.io/Luxor.jl/stable/)
@@ -43,19 +43,19 @@ Packages that have tagged versions available in the general Registry:
 - [NLOptControl.jl](https://huckl3b3rry87.github.io/MPCDocs.jl/stable/)
 - [OhMyREPL.jl](https://github.com/KristofferC/OhMyREPL.jl)
 - [OnlineStats.jl](https://joshday.github.io/OnlineStats.jl/stable/)
-- [POMDPs.jl](http://juliapomdp.github.io/POMDPs.jl/stable/)
-- [PhyloNetworks.jl](http://crsl4.github.io/PhyloNetworks.jl/stable/)
+- [POMDPs.jl](https://juliapomdp.github.io/POMDPs.jl/stable/)
+- [PhyloNetworks.jl](https://crsl4.github.io/PhyloNetworks.jl/stable/)
 - [PrivateModules.jl](https://michaelhatherly.github.io/PrivateModules.jl/stable/)
-- [Query.jl](http://www.queryverse.org/Query.jl/stable/)
-- [TaylorSeries.jl](http://www.juliadiff.org/TaylorSeries.jl/stable/)
-- [Weave.jl](http://weavejl.mpastell.com/stable/)
+- [Query.jl](https://www.queryverse.org/Query.jl/stable/)
+- [TaylorSeries.jl](https://www.juliadiff.org/TaylorSeries.jl/stable/)
+- [Weave.jl](https://weavejl.mpastell.com/stable/)
 
 ## Documentation repositories
 
 Some projects or organizations maintain dedicated documentation repositories that are
 separate from specific packages.
 
-- [DifferentialEquations.jl](http://docs.juliadiffeq.org/latest/)
+- [DifferentialEquations.jl](https://docs.juliadiffeq.org/latest/)
 - [JuliaDocs landing page](https://juliadocs.github.io/dev/)
 - [JuliaMusic](https://juliamusic.github.io/JuliaMusic_documentation.jl/dev/)
 - [Plots.jl](https://docs.juliaplots.org/dev/)

--- a/docs/src/man/examples.md
+++ b/docs/src/man/examples.md
@@ -56,6 +56,6 @@ Some projects or organizations maintain dedicated documentation repositories tha
 separate from specific packages.
 
 - [DifferentialEquations.jl](https://docs.juliadiffeq.org/latest/)
-- [JuliaDocs landing page](https://juliadocsjuliadocsjuliadocs.github.io/dev/)
+- [JuliaDocs landing page](https://juliadocs.github.io/dev/)
 - [JuliaMusic](https://juliamusic.github.io/JuliaMusic_documentation.jl/dev/)
 - [Plots.jl](https://docs.juliaplots.org/dev/)

--- a/docs/src/man/examples.md
+++ b/docs/src/man/examples.md
@@ -56,6 +56,6 @@ Some projects or organizations maintain dedicated documentation repositories tha
 separate from specific packages.
 
 - [DifferentialEquations.jl](https://docs.juliadiffeq.org/latest/)
-- [JuliaDocs landing page](https://juliadocs.github.io/dev/)
+- [JuliaDocs landing page](https://juliadocsjuliadocsjuliadocs.github.io/dev/)
 - [JuliaMusic](https://juliamusic.github.io/JuliaMusic_documentation.jl/dev/)
 - [Plots.jl](https://docs.juliaplots.org/dev/)

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -81,7 +81,7 @@ The three lines in the `script:` section do the following:
     Travis CI used to use `matrix:` as the section to configure to build matrix in the config
     file. This now appears to be a deprecated alias for `jobs:`. If you use both `matrix:` and
     `jobs:` in your configuration, `matrix:` overrides the settings under `jobs:`.
-    
+
     If your `.travis.yml` file still uses `matrix:`, it should be replaced with a a single
     `jobs:` section.
 
@@ -209,7 +209,7 @@ build of the documentation. The `julia-version:`, `julia-arch:` and `os:` entrie
 the environment from which the docs are built and deployed. In the example above we will
 thus build and deploy the documentation from a ubuntu worker running Julia 1.2. For more
 information on how to setup a GitHub workflow see the manual for
-[Configuring a workflow](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow).
+[Configuring a workflow](https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow).
 
 The commands in the lines in the `run:` section do the same as for Travis,
 see the previous section.
@@ -218,7 +218,7 @@ see the previous section.
 
 When running from GitHub Actions it is possible to authenticate using
 [the GitHub Actions authentication token
-(`GITHUB_TOKEN`)](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/authenticating-with-the-github_token). This is done by adding
+(`GITHUB_TOKEN`)](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token). This is done by adding
 
 ```yaml
 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -251,7 +251,7 @@ DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
 
 to the configuration file, as showed in the [previous section](@ref GitHub-Actions).
 See GitHub's manual for
-[Creating and using encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)
+[Creating and using encrypted secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)
 for more information.
 
 

--- a/docs/src/man/other-formats.md
+++ b/docs/src/man/other-formats.md
@@ -170,7 +170,7 @@ The following is required to build the documentation:
 
 * You need `pdflatex` command to be installed and available to Documenter.
 * You need the [minted](https://ctan.org/pkg/minted) LaTeX package and its backend source
-  highlighter [Pygments](http://pygments.org/) installed.
+  highlighter [Pygments](https://pygments.org/) installed.
 * You need the [_DejaVu Sans_ and _DejaVu Sans Mono_](https://dejavu-fonts.github.io/) fonts installed.
 
 ### Compiling using docker image

--- a/src/deployconfig.jl
+++ b/src/deployconfig.jl
@@ -212,7 +212,7 @@ when using the `GitHubActions` configuration:
    see the manual section for [GitHub Actions](@ref) for more information.
 
 The `GITHUB_*` variables are set automatically on GitHub Actions, see the
-[documentation](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables#default-environment-variables).
+[documentation](https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables).
 """
 struct GitHubActions <: DeployConfig
     github_repository::String


### PR DESCRIPTION
And add a GitHub Actions workflow to check them on CI. linkchecking on Travis has been disabled for a while since it wasn't very reliable. Let's see if it is more reliable on GitHub Actions. Even if not, a single occasionally failing workflow is less of a hassle than a failing build stage.