### PR TITLE
Fix LaTeX tests for tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,13 @@ julia:
 
 branches:
   only:
+    - /.*/
     - master
     - /^release-.*$/
     - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
+
+env:
+  - TRAVIS_TAG: v1.2.3
 
 after_success:
   - if [ -f test/quietly.log ]; then cat test/quietly.log; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,9 @@ julia:
 
 branches:
   only:
-    - /.*/
     - master
     - /^release-.*$/
     - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
-
-env:
-  - TRAVIS_TAG: v1.2.3
 
 after_success:
   - if [ -f test/quietly.log ]; then cat test/quietly.log; fi

--- a/test/examples/tests_latex.jl
+++ b/test/examples/tests_latex.jl
@@ -16,12 +16,20 @@ elseif (@__MODULE__) !== Main && !isdefined(Main, :examples_root)
     error("examples/make.jl has not been loaded into Main.")
 end
 
+# This gets appended to the filename if we're building a tag (i.e. TRAVIS_TAG is set)
+tagsuffix = if occursin(Base.VERSION_REGEX, get(ENV, "TRAVIS_TAG", ""))
+    v = VersionNumber(ENV["TRAVIS_TAG"])
+    "-$(v.major).$(v.minor).$(v.patch)"
+else
+    ""
+end
+
 @testset "Examples/LaTeX" begin
     @testset "PDF/LaTeX: simple" begin
         doc = Main.examples_latex_simple_doc
         @test isa(doc, Documenter.Documents.Document)
         let build_dir = joinpath(examples_root, "builds", "latex_simple")
-            @test joinpath(build_dir, "DocumenterLaTeXSimple.pdf") |> isfile
+            @test joinpath(build_dir, "DocumenterLaTeXSimple$(tagsuffix).pdf") |> isfile
         end
     end
 
@@ -29,7 +37,7 @@ end
         doc = Main.examples_latex_doc
         @test isa(doc, Documenter.Documents.Document)
         let build_dir = joinpath(examples_root, "builds", "latex")
-            @test joinpath(build_dir, "DocumenterLaTeX.pdf") |> isfile
+            @test joinpath(build_dir, "DocumenterLaTeX$(tagsuffix).pdf") |> isfile
         end
     end
 end


### PR DESCRIPTION
On tags, the output file name is different as it also contains the version number. Fix #1246.
