### PR TITLE
remove "only" from search stop word filter

### DIFF
--- a/assets/html/search.js
+++ b/assets/html/search.js
@@ -38,7 +38,7 @@ $(document).ready(function() {
   })
 
   // list below is the lunr 2.1.3 list minus the intersect with names(Base)
-  // (all, any, get, in, is, which) and (do, else, for, let, where, while, with)
+  // (all, any, get, in, is, only, which) and (do, else, for, let, where, while, with)
   // ideally we'd just filter the original list but it's not available as a variable
   lunr.stopWordFilter = lunr.generateStopWordFilter([
     'a',
@@ -104,7 +104,6 @@ $(document).ready(function() {
     'off',
     'often',
     'on',
-    'only',
     'or',
     'other',
     'our',


### PR DESCRIPTION
This is a new base export in 1.4

Fixes https://github.com/JuliaLang/julia/issues/35173