### PR TITLE
Add note about doctests in docstrings

### DIFF
--- a/docs/src/man/doctests.md
+++ b/docs/src/man/doctests.md
@@ -237,6 +237,10 @@ DocMeta.setdocmeta!(MyPackage, :DocTestSetup, :(using MyPackage); recursive=true
 makedocs(modules=[MyPackage], ...)
 ```
 
+!!! note
+    Please make sure to include all modules that contain docstrings with doctests in the
+    `modules` argument to [`makedocs`](@ref). Otherwise these doctests will not be run.
+
 ### Block-level setup code
 
 Yet another option is to use the `setup` keyword argument to the `jldoctest` block, which is

--- a/docs/src/man/doctests.md
+++ b/docs/src/man/doctests.md
@@ -238,7 +238,7 @@ makedocs(modules=[MyPackage], ...)
 ```
 
 !!! note
-    Please make sure to include all modules that contain docstrings with doctests in the
+    Make sure to include all (top-level) modules that contain docstrings with doctests in the
     `modules` argument to [`makedocs`](@ref). Otherwise these doctests will not be run.
 
 ### Block-level setup code


### PR DESCRIPTION
Suggest to add modules with doctests in docstrings to the `modules` argument. Otherwise you get the strange situation where the doctests are not run when running `makedocs` but do run and potentially fail when running `doctest`.

CC: @fredrikekre 