### PR TITLE
Fix doctest testing on nightly

### DIFF
--- a/test/doctests/src/softscope.md
+++ b/test/doctests/src/softscope.md
@@ -16,7 +16,16 @@ julia> @isdefined(t) # global
 false
 ```
 
-```jldoctest; filter = r"Stacktrace:(\n \[[0-9]+\].*)*"
+```@meta
+DocTestFilters = [
+    # remove stacktraces
+    r"Stacktrace:(\n \[[0-9]+\].*)*",
+    # remove file paths from at-block URLs
+    r"└ @ .+:[0-9]+"
+]
+```
+
+```jldoctest
 julia> code = """
        s = 0 # global
        for i = 1:10
@@ -37,7 +46,7 @@ Stacktrace:
 [...]
 ```
 
-```jldoctest; filter = r"Stacktrace:(\n \[[0-9]+\].*)*"
+```jldoctest
 s = 0 # global
 for i = 1:10
     t = s + i # new local `t`
@@ -49,9 +58,13 @@ s, # global
 # output
 
 ┌ Warning: Assignment to `s` in soft scope is ambiguous because a global variable by the same name exists: `s` will be treated as a new local. Disambiguate by using `local s` to suppress this warning or `global s` to assign to the existing global variable.
-└ @ none:3
+└ @ doctests.jl:3
 ERROR: UndefVarError: s not defined
 Stacktrace:
- [1] top-level scope at ./none:2
+ [1] doctests.jl:3 [inlined]
 [...]
+```
+
+```@meta
+DocTestFilters = nothing
 ```


### PR DESCRIPTION
It seems that something has changed on master about printing from the logging macros. This adds another doctest filter which filters out the filesystem paths that are printed at the end of the logging macro outputs.