### PR TITLE
Pass non-standard admonition categories on in HTML output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * ![Bugfix][badge-bugfix] `Deps.pip` is again a closure and gets executed during the `deploydocs` call, not before it. ([#1240][github-1240])
 
+## Version `v0.24.8`
+
+* ![Enhancement][badge-enhancement] Non-standard admonition categories are (again) applied to the admonition `<div>` elements in HTML output (as `admonition-$category`). ([#1279][github-1279], [#1280][github-1280])
+
 ## Version `v0.24.7`
 
 * ![Bugfix][badge-bugfix] Remove `only`, a new export from `Base` on Julia 1.4, from the JS search filter. ([#1264][github-1264])
@@ -534,6 +538,8 @@
 [github-1258]: https://github.com/JuliaDocs/Documenter.jl/pull/1258
 [github-1264]: https://github.com/JuliaDocs/Documenter.jl/pull/1264
 [github-1269]: https://github.com/JuliaDocs/Documenter.jl/pull/1269
+[github-1279]: https://github.com/JuliaDocs/Documenter.jl/issues/1279
+[github-1280]: https://github.com/JuliaDocs/Documenter.jl/pull/1280
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Version `v0.24.8`
 
-* ![Enhancement][badge-enhancement] Non-standard admonition categories are (again) applied to the admonition `<div>` elements in HTML output (as `admonition-$category`). ([#1279][github-1279], [#1280][github-1280])
+* ![Enhancement][badge-enhancement] Non-standard admonition categories are (again) applied to the admonition `<div>` elements in HTML output (as `is-category-$category`). ([#1279][github-1279], [#1280][github-1280])
 
 ## Version `v0.24.7`
 

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1602,7 +1602,7 @@ function mdconvert(a::Markdown.Admonition, parent; kwargs...)
         (a.category == "tip")     ? "is-success" :
         (a.category == "compat")  ? "is-compat"  : begin
             # If the admonition category is not one of the standard ones, we just tag the
-            # admonition element with a `admonition--$(category)` class. However, we first
+            # admonition element with a `admonition-$(category)` class. However, we first
             # carefully sanitize the category name. Strictly speaking, this is not necessary
             # when were using the Markdown parser in the Julia standard library, since it
             # restricts the category to [a-z]+. But it is possible for the users to

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1602,8 +1602,12 @@ function mdconvert(a::Markdown.Admonition, parent; kwargs...)
         (a.category == "tip")     ? "is-success" :
         (a.category == "compat")  ? "is-compat"  : begin
             # If the admonition category is not one of the standard ones, we just tag the
-            # admonition element with a `is-$(category)` class. However, we first carefully
-            # sanitize the category name:
+            # admonition element with a `admonition--$(category)` class. However, we first
+            # carefully sanitize the category name. Strictly speaking, this is not necessary
+            # when were using the Markdown parser in the Julia standard library, since it
+            # restricts the category to [a-z]+. But it is possible for the users to
+            # construct their own Admonition objects with arbitrary category strings and
+            # pass them onto Documenter.
             #
             # (1) remove all characters except A-Z, a-z, 0-9 and -
             cat_sanitized = replace(a.category, r"[^A-Za-z0-9-]" => "")
@@ -1613,7 +1617,7 @@ function mdconvert(a::Markdown.Admonition, parent; kwargs...)
             # (3) reduce any duplicate dashes in the middle to single dashes
             cat_sanitized = replace(cat_sanitized, r"[-]+" => "-")
             cat_sanitized = lowercase(cat_sanitized)
-            "is-$(cat_sanitized)"
+            "admonition-$(cat_sanitized)"
         end
     div[".admonition.$(colorclass)"](
         header[".admonition-header"](a.title),

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1595,17 +1595,17 @@ end
 function mdconvert(a::Markdown.Admonition, parent; kwargs...)
     @tags header div
     colorclass =
-        (a.category == "danger")  ? "is-danger"  :
-        (a.category == "warning") ? "is-warning" :
-        (a.category == "note")    ? "is-info"    :
-        (a.category == "info")    ? "is-info"    :
-        (a.category == "tip")     ? "is-success" :
-        (a.category == "compat")  ? "is-compat"  : begin
-            # If the admonition category is not one of the standard ones, we just tag the
-            # admonition element with a `admonition-$(category)` class. However, we first
-            # carefully sanitize the category name. Strictly speaking, this is not necessary
-            # when were using the Markdown parser in the Julia standard library, since it
-            # restricts the category to [a-z]+. But it is possible for the users to
+        (a.category == "danger")  ? ".is-danger"  :
+        (a.category == "warning") ? ".is-warning" :
+        (a.category == "note")    ? ".is-info"    :
+        (a.category == "info")    ? ".is-info"    :
+        (a.category == "tip")     ? ".is-success" :
+        (a.category == "compat")  ? ".is-compat"  : begin
+            # If the admonition category is not one of the standard ones, we tag the
+            # admonition div element with a `is-category-$(category)` class. However, we
+            # first carefully sanitize the category name. Strictly speaking, this is not
+            # necessary when were using the Markdown parser in the Julia standard library,
+            # since it restricts the category to [a-z]+. But it is possible for the users to
             # construct their own Admonition objects with arbitrary category strings and
             # pass them onto Documenter.
             #
@@ -1617,9 +1617,11 @@ function mdconvert(a::Markdown.Admonition, parent; kwargs...)
             # (3) reduce any duplicate dashes in the middle to single dashes
             cat_sanitized = replace(cat_sanitized, r"[-]+" => "-")
             cat_sanitized = lowercase(cat_sanitized)
-            "admonition-$(cat_sanitized)"
+            # (4) if nothing is left (or the category was empty to begin with), we don't
+            # apply a class
+            isempty(cat_sanitized) ? "" : ".is-category-$(cat_sanitized)"
         end
-    div[".admonition.$(colorclass)"](
+    div[".admonition$(colorclass)"](
         header[".admonition-header"](a.title),
         div[".admonition-body"](mdconvert(a.content, a; kwargs...))
     )

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1600,7 +1600,21 @@ function mdconvert(a::Markdown.Admonition, parent; kwargs...)
         (a.category == "note")    ? "is-info"    :
         (a.category == "info")    ? "is-info"    :
         (a.category == "tip")     ? "is-success" :
-        (a.category == "compat")  ? "is-compat"  : ""
+        (a.category == "compat")  ? "is-compat"  : begin
+            # If the admonition category is not one of the standard ones, we just tag the
+            # admonition element with a `is-$(category)` class. However, we first carefully
+            # sanitize the category name:
+            #
+            # (1) remove all characters except A-Z, a-z, 0-9 and -
+            cat_sanitized = replace(a.category, r"[^A-Za-z0-9-]" => "")
+            # (2) remove any dashes from the beginning and end of the string
+            cat_sanitized = replace(cat_sanitized, r"^[-]+" => "")
+            cat_sanitized = replace(cat_sanitized, r"[-]+$" => "")
+            # (3) reduce any duplicate dashes in the middle to single dashes
+            cat_sanitized = replace(cat_sanitized, r"[-]+" => "-")
+            cat_sanitized = lowercase(cat_sanitized)
+            "is-$(cat_sanitized)"
+        end
     div[".admonition.$(colorclass)"](
         header[".admonition-header"](a.title),
         div[".admonition-body"](mdconvert(a.content, a; kwargs...))

--- a/test/examples/src/man/style.md
+++ b/test/examples/src/man/style.md
@@ -20,6 +20,12 @@ In an admonition it looks like this:
     * Nulla quis venenatis justo.
     * In non _sodales_ eros.
 
+Also, custom admonition classes can be used:
+
+!!! myadmonition "My Admonition Class"
+
+    In the HTML output, this admonition has `is-category-myadmonition` applied to it.
+
 But otherwise
 
 * Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -28,10 +28,11 @@ end
             @test joinpath(build_dir, "omitted", "index.html") |> isfile
             @test joinpath(build_dir, "hidden", "index.html") |> isfile
             @test joinpath(build_dir, "lib", "autodocs", "index.html") |> isfile
+            @test joinpath(build_dir, "man", "style", "index.html") |> isfile
 
             # Test existence of some HTML elements
-            indexhtml = String(read(joinpath(build_dir, "index.html")))
-            #@test occursin("", indexhtml)
+            man_style_html = String(read(joinpath(build_dir, "man", "style", "index.html")))
+            @test occursin("is-category-myadmonition", man_style_html)
 
             # Assets
             @test joinpath(build_dir, "assets", "documenter.js") |> isfile


### PR DESCRIPTION
Arguably fixing a regression, although it is an undocumented "feature". But it is a good idea to pass these on.

Compared to pre-0.24 behaviour, the class names are now prepended with ~`admonition-`~ `is-category-` (not using `is-`, since that can conflict with various Bulma classes, like `is-hidden`) and fully sanitized (the final class names match `[a-z0-9-]+`).

Fix #1279.