### PR TITLE
Add example admonition css to example build

### DIFF
--- a/test/examples/src/assets/custom.css
+++ b/test/examples/src/assets/custom.css
@@ -3,3 +3,12 @@
 center.raw-html-block {
     color: red;
 }
+
+.admonition.is-category-myadmonition > .admonition-header {
+    background-color: rgba(152,78,163,0.8);
+   }
+   
+.admonition.is-category-myadmonition > .admonition-body {
+background-color: rgba(152,78,163,0.2);
+}
+   

--- a/test/examples/src/man/style.md
+++ b/test/examples/src/man/style.md
@@ -25,6 +25,21 @@ Also, custom admonition classes can be used:
 !!! myadmonition "My Admonition Class"
 
     In the HTML output, this admonition has `is-category-myadmonition` applied to it.
+    Its style can be changed by adding styles to `.admonition-header` and `.admonition-body`
+    in a custom css file and adding it to the build with, for example:
+
+    ```julia
+    makedocs(
+        # ...
+        format=Documenter.HTML(;
+            #...
+            assets=["assets/custom.css"]
+        )
+    )
+    ```
+
+    [See here](https://github.com/JuliaDocs/Documenter.jl/blob/master/test/examples/src/assets/custom.css)
+    for an example `custom.css` file.
 
 But otherwise
 

--- a/test/examples/src/man/style.md
+++ b/test/examples/src/man/style.md
@@ -38,8 +38,8 @@ Also, custom admonition classes can be used:
     )
     ```
 
-    [See here](https://github.com/JuliaDocs/Documenter.jl/blob/master/test/examples/src/assets/custom.css)
-    for an example `custom.css` file.
+    See [`test/examples/src/assets/custom.css`](https://github.com/JuliaDocs/Documenter.jl/blob/master/test/examples/src/assets/custom.css)
+    for an example of a custom CSS file.
 
 But otherwise
 


### PR DESCRIPTION
Pseudo-document custom CSS for admonitions in example build. Re: #1280 

I wasn't sure how to test this build locally, but I'm ~92% sure it should work :-)