### PR TITLE
Make the depwarn test dependent on --depwarn value

### DIFF
--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -268,6 +268,8 @@ end
             # warnings enabled or not. To figure out whether that is the case or not, we can
             # look at the .depwarn field of the undocumented Base.JLOptions object.
             @test isdefined(Base, :JLOptions)
+            # hasfield was added in Julia 1.2. This definition borrowed from Compat.jl (MIT)
+            (VERSION < v"1.2.0-DEV.272") && (hasfield(::Type{T}, name::Symbol) where T = Base.fieldindex(T, name, false) > 0)
             @test hasfield(Base.JLOptions, :depwarn)
             if Base.JLOptions().depwarn == 0 # --depwarn=no, default on Julia >= 1.5
                 @test output == "println\n[ Info: @info\n"

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -255,6 +255,7 @@ end
         @test splitby(r"[▶]+", "Ω▶▶Y▶Z▶κ") == ["Ω▶▶", "Y▶", "Z▶", "κ"]
     end
 
+    # This test checks that deprecation warnings are captured correctly
     @static if isdefined(Base, :with_logger)
         @testset "withoutput" begin
             _, _, _, output = Documenter.Utilities.withoutput() do
@@ -263,7 +264,16 @@ end
                 f() = (Base.depwarn("depwarn", :f); nothing)
                 f()
             end
-            @test startswith(output, "println\n[ Info: @info\n┌ Warning: depwarn\n")
+            # The output is dependent on whether the user is running tests with deprecation
+            # warnings enabled or not. To figure out whether that is the case or not, we can
+            # look at the .depwarn field of the undocumented Base.JLOptions object.
+            @test isdefined(Base, :JLOptions)
+            @test hasfield(Base.JLOptions, :depwarn)
+            if Base.JLOptions().depwarn == 0 # --depwarn=no, default on Julia >= 1.5
+                @test output == "println\n[ Info: @info\n"
+            else # --depwarn=yes
+                @test startswith(output, "println\n[ Info: @info\n┌ Warning: depwarn\n")
+            end
         end
     end
 

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -47,6 +47,10 @@ module A
 end
 end
 
+# hasfield was added in Julia 1.2. This definition borrowed from Compat.jl (MIT)
+# Note: this can not be inside the testset
+(VERSION < v"1.2.0-DEV.272") && (hasfield(::Type{T}, name::Symbol) where T = Base.fieldindex(T, name, false) > 0)
+
 @testset "Utilities" begin
     let doc = @doc(length)
         a = Documenter.Utilities.filterdocs(doc, Set{Module}())
@@ -268,8 +272,6 @@ end
             # warnings enabled or not. To figure out whether that is the case or not, we can
             # look at the .depwarn field of the undocumented Base.JLOptions object.
             @test isdefined(Base, :JLOptions)
-            # hasfield was added in Julia 1.2. This definition borrowed from Compat.jl (MIT)
-            (VERSION < v"1.2.0-DEV.272") && (hasfield(::Type{T}, name::Symbol) where T = Base.fieldindex(T, name, false) > 0)
             @test hasfield(Base.JLOptions, :depwarn)
             if Base.JLOptions().depwarn == 0 # --depwarn=no, default on Julia >= 1.5
                 @test output == "println\n[ Info: @info\n"


### PR DESCRIPTION
The nightly tests have been failing since JuliaLang/julia#35362 was merged, since the test that checks whether deprecation warnings are captured correctly assumed that the deprecation warning gets printed even if `--depwarn=no` (which is now the default).

Should also be pushed to #1300 once merged.