### PR TITLE
Create a parsedoc wrapper for more helpful errors

### DIFF
--- a/src/DocSystem.jl
+++ b/src/DocSystem.jl
@@ -6,7 +6,7 @@ module DocSystem
 
 using DocStringExtensions
 import Markdown
-import Base.Docs: MultiDoc, parsedoc, formatdoc, DocStr
+import Base.Docs: MultiDoc, formatdoc, DocStr
 
 ## Bindings ##
 
@@ -266,5 +266,23 @@ category(::DataType) = :type
 category(x::UnionAll) = category(Base.unwrap_unionall(x))
 category(::Module) = :module
 category(::Any) = :constant
+
+"""
+    DocSystem.parsedoc(docstr::DocStr)
+
+Thin internal wrapper around `Base.Docs.parsedoc` which prints additional debug information
+in case `Base.Docs.parsedoc` fails with an exception.
+"""
+function parsedoc(docstr::DocStr)
+    try
+        Base.Docs.parsedoc(docstr)
+    catch exception
+        @error """
+        parsedoc failed to parse a docstring into Markdown.
+        This indicates a problem with the docstring.
+        """ exception docstr.data docstr.text docstr.object
+        rethrow(exception)
+    end
+end
 
 end

--- a/src/DocSystem.jl
+++ b/src/DocSystem.jl
@@ -278,9 +278,9 @@ function parsedoc(docstr::DocStr)
         Base.Docs.parsedoc(docstr)
     catch exception
         @error """
-        parsedoc failed to parse a docstring into Markdown.
-        This indicates a problem with the docstring.
-        """ exception docstr.data docstr.text docstr.object
+        parsedoc failed to parse a docstring into Markdown. This indicates a problem with the docstring.
+        """ exception docstr.data collect(docstr.text) docstr.object
+        # Note: collect is there because svec does not print as nicely as a vector
         rethrow(exception)
     end
 end


### PR DESCRIPTION
With this the error message in #1296 allows the offending docstring to be identified more easily.

```
[ Info: SetupBuildDirectory: setting up build directory.
[ Info: Doctest: running doctests.
┌ Error: parsedoc failed to parse a docstring into Markdown. This indicates a problem with the docstring.
│   exception = type UnionAll has no field a
│   docstr.data =
│    Dict{Symbol,Any} with 5 entries:
│      :typesig    => Union{Tuple{T}, Tuple{Type{T},System}, Tuple{Type{T},System,Union{Nothing, Function}}} where T<:Component
│      :module     => PowerSystems
│      :linenumber => 486
│      :binding    => PowerSystems.get_components
│      :path       => "/home/mortenpi/Julia/test/PowerSystems.jl/src/base.jl"
│   collect(docstr.text) =
│    4-element Array{Any,1}:
│     DocStringExtensions.TypedMethodSignatures()
│     "\n"
│     "Returns an iterator of components. T can be concrete or abstract.\nCall collect on the result if an array is desired.\n\n# Examples\n```julia\niter = PowerSystems.get_components(ThermalStandard, sys)\niter
= PowerSystems.get_components(Generator, sys)\niter = PowerSystems.get_components(Generator, sys, x->(PowerSystems.get_available(x)))\ngenerators = collect(PowerSystems.get_components(Generator, sys))\n```\n\nSee
also: [`iterate_components`](@ref)\n"
│     "\n"
│   docstr.object = nothing
└ @ Documenter.DocSystem ~/Julia/JuliaDocs/Documenter/src/DocSystem.jl:280
ERROR: LoadError: type UnionAll has no field a
Stacktrace:
 [1] getproperty(::Type{T} where T, ::Symbol) at ./Base.jl:28
 [2] format(::DocStringExtensions.TypedMethodSignatures, ::Base.GenericIOBuffer{Array{UInt8,1}}, ::Base.Docs.DocStr) at /home/mortenpi/.julia/packages/DocStringExtensions/BEyNH/src/abbreviations.jl:386
 [3] formatdoc(::Base.GenericIOBuffer{Array{UInt8,1}}, ::Base.Docs.DocStr, ::DocStringExtensions.TypedMethodSignatures) at /home/mortenpi/.julia/packages/DocStringExtensions/BEyNH/src/abbreviations.jl:25
 [4] formatdoc(::Base.Docs.DocStr) at /home/mortenpi/Julia/julia-1.4/usr/share/julia/stdlib/v1.4/REPL/src/docview.jl:60
 [5] parsedoc(::Base.Docs.DocStr) at /home/mortenpi/Julia/julia-1.4/usr/share/julia/stdlib/v1.4/REPL/src/docview.jl:68
 [6] parsedoc(::Base.Docs.DocStr) at /home/mortenpi/Julia/JuliaDocs/Documenter/src/DocSystem.jl:278
 [7] doctest(::Base.Docs.DocStr, ::Module, ::Documenter.Documents.Document) at /home/mortenpi/Julia/JuliaDocs/Documenter/src/DocTests.jl:69
 [8] doctest(::Documenter.Documents.DocumentBlueprint, ::Documenter.Documents.Document) at /home/mortenpi/Julia/JuliaDocs/Documenter/src/DocTests.jl:56
 [9] runner(::Type{Documenter.Builder.Doctest}, ::Documenter.Documents.Document) at /home/mortenpi/Julia/JuliaDocs/Documenter/src/Builder.jl:201
 [10] dispatch(::Type{Documenter.Builder.DocumentPipeline}, ::Documenter.Documents.Document) at /home/mortenpi/Julia/JuliaDocs/Documenter/src/Utilities/Selectors.jl:167
 [11] #2 at /home/mortenpi/Julia/JuliaDocs/Documenter/src/Documenter.jl:240 [inlined]
 [12] cd(::Documenter.var"#2#3"{Documenter.Documents.Document}, ::String) at ./file.jl:104
 [13] #makedocs#1 at /home/mortenpi/Julia/JuliaDocs/Documenter/src/Documenter.jl:239 [inlined]
 [14] top-level scope at /home/mortenpi/Julia/test/PowerSystems.jl/docs/make.jl:8
 [15] include(::String) at ./client.jl:439
 [16] top-level scope at REPL[2]:1
 [17] eval(::Module, ::Any) at ./boot.jl:331
 [18] eval_user_input(::Any, ::REPL.REPLBackend) at /home/mortenpi/Julia/julia-1.4/usr/share/julia/stdlib/v1.4/REPL/src/REPL.jl:86
 [19] run_backend(::REPL.REPLBackend) at /home/mortenpi/.julia/dev/Revise/src/Revise.jl:1073
 [20] top-level scope at REPL[1]:0
in expression starting at /home/mortenpi/Julia/test/PowerSystems.jl/docs/make.jl:8
```

Close #1296.