### PR TITLE
always use pipeline in search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 * ![Bugfix][badge-bugfix] `Deps.pip` is again a closure and gets executed during the `deploydocs` call, not before it. ([#1240][github-1240])
 
+## Version `v0.24.11`
+
+* ![Bugfix][badge-bugfix] Some sections and page titles that were missing from the search results in the HTML backend now show up. ([#1311][github-1311])
+
 ## Version `v0.24.10`
 
 * ![Enhancement][badge-enhancement] The `curl` timeout when checking remote links is now configurable with the `linkcheck_timeout` keyword. ([#1057][github-1057], [#1295][github-1295])
@@ -565,6 +569,7 @@
 [github-1295]: https://github.com/JuliaDocs/Documenter.jl/pull/1295
 [github-1298]: https://github.com/JuliaDocs/Documenter.jl/pull/1298
 [github-1299]: https://github.com/JuliaDocs/Documenter.jl/pull/1299
+[github-1311]: https://github.com/JuliaDocs/Documenter.jl/pull/1311
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/assets/html/search.js
+++ b/assets/html/search.js
@@ -187,14 +187,14 @@ $(document).ready(function() {
           q.term(t.toString(), {
             fields: ["title"],
             boost: 100,
-            usePipeline: false,
+            usePipeline: true,
             editDistance: 0,
             wildcard: lunr.Query.wildcard.NONE
           })
           q.term(t.toString(), {
             fields: ["title"],
             boost: 10,
-            usePipeline: false,
+            usePipeline: true,
             editDistance: 2,
             wildcard: lunr.Query.wildcard.NONE
           })


### PR DESCRIPTION
I don't remember why I set it to false in 2533ae5ab25e72666c33fd581a67a089ea28340b, likely just copied it from another example.
I timed a query and this didn't seem to have an impact on performance.

Fixes https://github.com/JuliaLang/julia/issues/35724