### PR TITLE
Remove exported/unexported ordering override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 * ![Bugfix][badge-bugfix] Custom assets (CSS, JS etc.) for the HTML build are now again included as the very last elements in the `<head>` tag so that it would be possible to override default the default assets. ([#1328][github-1328])
 
+* ![Bugfix][badge-bugfix] Docstrings from `@autodocs` blocks are no longer sorted according to an undocumented rule where exported names should come before unexported names. Should this behavior be necessary, the `@autodocs` can be replaced by two separate blocks that use the `Public` and `Private` options to filter out the unexported or exported docstrings in the first or the second block, respectively. ([#964][github-964], [#1323][github-1323])
+
 ## Version `v0.24.11`
 
 * ![Bugfix][badge-bugfix] Some sections and page titles that were missing from the search results in the HTML backend now show up. ([#1311][github-1311])
@@ -486,6 +488,7 @@
 [github-958]: https://github.com/JuliaDocs/Documenter.jl/pull/958
 [github-959]: https://github.com/JuliaDocs/Documenter.jl/pull/959
 [github-960]: https://github.com/JuliaDocs/Documenter.jl/pull/960
+[github-964]: https://github.com/JuliaDocs/Documenter.jl/issues/964
 [github-966]: https://github.com/JuliaDocs/Documenter.jl/pull/966
 [github-967]: https://github.com/JuliaDocs/Documenter.jl/pull/967
 [github-971]: https://github.com/JuliaDocs/Documenter.jl/pull/971
@@ -575,6 +578,7 @@
 [github-1307]: https://github.com/JuliaDocs/Documenter.jl/pull/1307
 [github-1310]: https://github.com/JuliaDocs/Documenter.jl/pull/1310
 [github-1315]: https://github.com/JuliaDocs/Documenter.jl/pull/1315
+[github-1323]: https://github.com/JuliaDocs/Documenter.jl/pull/1323
 [github-1328]: https://github.com/JuliaDocs/Documenter.jl/pull/1328
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -438,7 +438,6 @@ function Selectors.runner(::Type{AutoDocsBlocks}, x, page, doc)
         comparison = function (a, b)
             local t
             (t = Documents._compare(modulemap, 1, a, b)) == 0 || return t < 0 # module
-            a[5] == b[5] || return a[5] > b[5] # exported bindings before unexported ones.
             (t = Documents._compare(pagesmap,  2, a, b)) == 0 || return t < 0 # page
             (t = Documents._compare(ordermap,  3, a, b)) == 0 || return t < 0 # category
             string(a[4]) < string(b[4])                                       # name


### PR DESCRIPTION
Three reasons I think this should be removed:

__1)__ The documentation for `@index` states: 
> Order and Modules behave the same way as in @autodocs blocks and filter out docstrings that do not match one of the modules or categories specified.

which is not true due to the split introduced into exported/unexported bindings only in `@autodocs`.

__2)__ The documentation contains an example which shows how to use the `Private` and `Public` field with `@autodocs` to create the currently implemented behaviour.

__3)__ Offering the possibility to define an `Order`, but overridden it by something that is not documented is quite surprising and results in bug reports. 

Fixes: https://github.com/JuliaDocs/Documenter.jl/issues/964 