### PR TITLE
Fix linerange for empty svec

### DIFF
--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -490,6 +490,12 @@ end
 linerange(doc) = linerange(doc.text, doc.data[:linenumber])
 
 function linerange(text, from)
+    # text is assumed to be a Core.SimpleVector (svec) from the .text field of a Docs.DocStr object.
+    # Hence, we need to be careful when summing over an empty svec below.
+    #
+    # Also, the isodd logic _appears_ to be there to handle variable interpolation into docstrings. In that case,
+    # the .text field seems to become longer than just 1 element and every even element is the interpolated object,
+    # and only the odd ones actually contain the docstring text as a string.
     lines = sum(Int[isodd(n) ? newlines(s) : 0 for (n, s) in enumerate(text)])
     return lines > 0 ? (from:(from + lines + 1)) : (from:from)
 end

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -490,7 +490,7 @@ end
 linerange(doc) = linerange(doc.text, doc.data[:linenumber])
 
 function linerange(text, from)
-    lines = sum([isodd(n) ? newlines(s) : 0 for (n, s) in enumerate(text)])
+    lines = sum(Int[isodd(n) ? newlines(s) : 0 for (n, s) in enumerate(text)])
     return lines > 0 ? (from:(from + lines + 1)) : (from:from)
 end
 

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -129,6 +129,8 @@ end
         @test Documenter.Utilities.format_line(100:9999, formatting) == "100:9999"
     end
 
+    @test Documenter.Utilities.linerange(Core.svec(), 0) === 0:0
+
     # URL building
     filepath = string(first(methods(Documenter.Utilities.url)).file)
     Sys.iswindows() && (filepath = replace(filepath, "/" => "\\")) # work around JuliaLang/julia#26424


### PR DESCRIPTION
I have a package that fails to generate documentation because `Documenter.Utilities.linerange` receives an empty `svec()` as the first argument.  I can upload this setup somewhere if it's unreasonable that the first argument is an empty `svec()`.  But I think it's nice to always handle the empty case cleanly.  So maybe this patch makes sense as-is?
