### PR TITLE
Added link to main repo site

### DIFF
--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -319,6 +319,7 @@ struct HTML <: Documenter.Writer
     disable_git   :: Bool
     edit_link     :: Union{String, Symbol, Nothing}
     canonical     :: Union{String, Nothing}
+    siteurl       :: String
     assets        :: Vector{HTMLAsset}
     analytics     :: String
     collapselevel :: Int
@@ -332,6 +333,7 @@ struct HTML <: Documenter.Writer
             disable_git   :: Bool = false,
             edit_link     :: Union{String, Symbol, Nothing, Default} = Default("master"),
             canonical     :: Union{String, Nothing} = nothing,
+            siteurl       :: String = "",
             assets        :: Vector = String[],
             analytics     :: String = "",
             collapselevel :: Integer = 2,
@@ -361,7 +363,7 @@ struct HTML <: Documenter.Writer
             throw(ArgumentError("Invalid symbol (:$edit_link) passed to edit_link."))
         end
         isa(edit_link, Default) && (edit_link = edit_link[])
-        new(prettyurls, disable_git, edit_link, canonical, assets, analytics,
+        new(prettyurls, disable_git, edit_link, canonical, siteurl, assets, analytics,
             collapselevel, sidebar_sitename, highlights, mathengine, lang)
     end
 end
@@ -857,7 +859,9 @@ function render_sidebar(ctx, navnode)
     # Sitename
     if ctx.settings.sidebar_sitename
         push!(navmenu.nodes, div[".docs-package-name"](
-            span[".docs-autofit"](ctx.doc.user.sitename)
+           span[".docs-autofit"](isempty(ctx.settings.siteurl) ?
+                                    ctx.doc.user.sitename :
+                                    a[:href => ctx.settings.siteurl](ctx.doc.user.sitename))
         ))
     end
 


### PR DESCRIPTION
This is a small change which makes site name in navbar clickable. You can see how it looks like in [https://arkoniak.github.io/PCloud.jl/dev/](https://arkoniak.github.io/PCloud.jl/dev/)

I am missing this feature in current implementation of `Documenter.jl` and as far as I remember there was a discussion regarding it some time ago on discourse.

PR in current state can be considered as proof of concept: if everything is ok, I can add necessary docstrings and may be tests (if I would be able to figure out how to test such a thing). If this implementation is not good, I am open to suggestion how it can be made better.