### PR TITLE
added simple ssh deploy config

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -282,7 +282,6 @@ See GitHub's manual for
 [Creating and using encrypted secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)
 for more information.
 
-
 ## `docs/Project.toml`
 
 The doc-build environment `docs/Project.toml` includes Documenter and other doc-build
@@ -339,6 +338,18 @@ or `git@`.
 
 See the [`deploydocs`](@ref) function documentation for more details.
 
+
+## Using Simple SSH
+If you do not have access to either Travis or Github for automated documentation updates,
+or you are working in a private git hosting service where using these is impractical, it
+may be desirable to push objects more simply via SSH.  For such cases, simply call, e.g.
+```julia
+deploydocs(
+    repo = "github.com/USER_NAME/PACKAGE_NAME.jl.git",
+    deploy_config = Documenter.SimpleSSHConfig("/path/to/ssh-key")
+)
+```
+If no path to the SSH key is provided, the `DOCUMENTER_KEY` environment variable will be used.
 
 
 ## `.gitignore`
@@ -457,4 +468,5 @@ Documenter.documenter_key
 Documenter.documenter_key_previews
 Documenter.Travis
 Documenter.GitHubActions
+Documenter.SimpleSSHConfig
 ```

--- a/src/deployconfig.jl
+++ b/src/deployconfig.jl
@@ -484,6 +484,35 @@ function post_github_status(type::S, deploydocs_repo::S, sha::S, subfolder=nothi
 end
 
 
+"""
+    SimpleSSHConfig <: DeployConfig
+
+Implementation of deploy config for deploying directly via SSH.  This is particularly useful in cases
+where there is a private repository and it's impractical or impossible to set up github actions or
+travis for fully automated deployment.
+
+The constructor optionally accepts a key location, so that it is possible to use multiple distinct keys.
+If the key location is not passed or is an empty string, the `DOCUMENTER_KEY` environment variable will
+be used.
+"""
+struct SimpleSSHConfig <: DeployConfig
+    ssh_key_location::String
+end
+
+SimpleSSHConfig() = SimpleSSHConfig("")
+
+deploy_folder(::SimpleSSHConfig; repo, devbranch, push_preview, devurl, kwargs...) = devurl
+authentication_method(::SimpleSSHConfig) = SSH
+function documenter_key(cfg.::SimpleSSHConfig)
+    k = cfg.ssh_key_location
+    if isempty(k)
+        ENV["DOCUMENTER_KEY"]
+    else
+        Base64.base64encode(open(read, k))
+    end
+end
+
+
 ##################
 # Auto-detection #
 ##################


### PR DESCRIPTION
When using Documenter.jl for projects at my job, I have to use our private company github and very often wind up having to do just the sort of thing that I did here.  I think this would be useful to anyone who may not have the ability to, or not want to use either of travis or github actions for deploying documentation for any reason.

Obviously I have added no testing here at all, and it's not at all clear to me how we'd test this.  I was hoping you guys would give me some guidance on what it might take to get this merged, thanks.