### PR TITLE
Don't warn on 302 redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 * ![Enhancement][badge-enhancement] You can now optionally choose to push pull request preview builds to a different branch and/or different repository than the main docs builds, by setting the optional `branch_previews` and/or `repo_previews` keyword arguments to the `deploydocs` function. Also, you can now optionally choose to use a different SSH key for preview builds, by setting the optional `DOCUMENTER_KEY_PREVIEWS` environment variable; if the `DOCUMENTER_KEY_PREVIEWS` environment variable is not set, then the regular `DOCUMENTER_KEY` environment variable will be used. ([#1307][github-1307], [#1310][github-1310], [#1315][github-1315])
 
+* ![Enhancement][badge-enhancement] Linkcheck no longer prints a warning when enountering a `302 Found` temporary redirect. ([#1344][github-1344], [#1345][github-1345])
+
 * ![Bugfix][badge-bugfix] `Deps.pip` is again a closure and gets executed during the `deploydocs` call, not before it. ([#1240][github-1240])
 
 * ![Bugfix][badge-bugfix] Custom assets (CSS, JS etc.) for the HTML build are now again included as the very last elements in the `<head>` tag so that it would be possible to override default the default assets. ([#1328][github-1328])
@@ -580,6 +582,8 @@
 [github-1315]: https://github.com/JuliaDocs/Documenter.jl/pull/1315
 [github-1323]: https://github.com/JuliaDocs/Documenter.jl/pull/1323
 [github-1328]: https://github.com/JuliaDocs/Documenter.jl/pull/1328
+[github-1344]: https://github.com/JuliaDocs/Documenter.jl/issues/1344
+[github-1345]: https://github.com/JuliaDocs/Documenter.jl/pull/1345
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -215,9 +215,13 @@ function linkcheck(link::Markdown.Link, doc::Documents.Document; method::Symbol=
             protocol = startswith(scheme, "HTTP") ? :HTTP :
                 startswith(scheme, "FTP") ? :FTP : :UNKNOWN
 
-            if (protocol === :HTTP && status < 300) ||
+            if (protocol === :HTTP && (status < 300 || status == 302)) ||
                 (protocol === :FTP && (200 <= status < 300 || status == 350))
-                @debug "linkcheck '$(link.url)' status: $(status)."
+                if location !== nothing
+                    @debug "linkcheck '$(link.url)' status: $(status), redirects to $(location)."
+                else
+                    @debug "linkcheck '$(link.url)' status: $(status)."
+                end
             elseif protocol === :HTTP && status < 400
                 if location !== nothing
                     @warn "linkcheck '$(link.url)' status: $(status), redirects to $(location)."


### PR DESCRIPTION
302s are meant to be temporary redirects, so we shouldn't warn. Fixes #1344.