### PR TITLE
Log `@error` for any DocCheck which triggers a failure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * ![Enhancement][badge-enhancement] When automatically determining the page list (i.e. `pages` is not passed to `makedocs`), Documenter now lists `index.md` before other pages. ([#1355][github-1355])
 
+* ![Enhancement][badge-enhancement] Warnings that cause `makedocs` to error when `strict=true` are now printed as errors when `strict` is set to `true`. ([#1088][github-1088], [#1349][github-1349])
+
 ## Version `v0.25.0`
 
 * ![Enhancement][badge-enhancement] When deploying with `deploydocs`, any SSH username can now be used (not just `git`), by prepending `username@` to the repository URL in the `repo` argument. ([#1285][github-1285])
@@ -538,6 +540,7 @@
 [github-1077]: https://github.com/JuliaDocs/Documenter.jl/pull/1077
 [github-1081]: https://github.com/JuliaDocs/Documenter.jl/issues/1081
 [github-1082]: https://github.com/JuliaDocs/Documenter.jl/pull/1082
+[github-1088]: https://github.com/JuliaDocs/Documenter.jl/issues/1088
 [github-1089]: https://github.com/JuliaDocs/Documenter.jl/pull/1089
 [github-1094]: https://github.com/JuliaDocs/Documenter.jl/pull/1094
 [github-1097]: https://github.com/JuliaDocs/Documenter.jl/pull/1097
@@ -592,6 +595,7 @@
 [github-1339]: https://github.com/JuliaDocs/Documenter.jl/pull/1339
 [github-1344]: https://github.com/JuliaDocs/Documenter.jl/issues/1344
 [github-1345]: https://github.com/JuliaDocs/Documenter.jl/pull/1345
+[github-1349]: https://github.com/JuliaDocs/Documenter.jl/pull/1349
 [github-1355]: https://github.com/JuliaDocs/Documenter.jl/pull/1355
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl


### PR DESCRIPTION
This makes it easier to distinguish other warnings (e.g. redirects) from those which actually trigger a DocCheck failure.

Fixes #1088.

_Edit by @mortenpi: changed the issue number that this will close._