### PR TITLE
Add .gitattributes to fix language report

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-/assets/html/themes/*.css linguist-generated
 /assets/html/scss/bulma/** linguist-vendored
 /assets/html/scss/darkly/** linguist-vendored
 /assets/html/scss/highlightjs/** linguist-vendored
+/assets/html/themes/*.css linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+/assets/html/themes/*.css linguist-generated
+/assets/html/scss/bulma/** linguist-vendored
+/assets/html/scss/darkly/** linguist-vendored
+/assets/html/scss/highlightjs/** linguist-vendored


### PR DESCRIPTION
Add `.gitattributes` that should make GitHub ignore the vendored/generated CSS & SCSS files when generating the "Languages" widget for the repo. Seems to work on my fork: https://github.com/mortenpi/Documenter.jl