### PR TITLE
Add specific HTML class to example output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * ![Enhancement][badge-enhancement] When automatically determining the page list (i.e. `pages` is not passed to `makedocs`), Documenter now lists `index.md` before other pages. ([#1355][github-1355])
 
+* ![Enhancement][badge-enhancement] The output text boxes of `@example` blocks are now style differently from the code blocks, to make it easier to visually distinguish between the input and output. ([#1026][github-1026], [#1357][github-1357])
+
 ## Version `v0.25.0`
 
 * ![Enhancement][badge-enhancement] When deploying with `deploydocs`, any SSH username can now be used (not just `git`), by prepending `username@` to the repository URL in the `repo` argument. ([#1285][github-1285])
@@ -517,6 +519,7 @@
 [github-1014]: https://github.com/JuliaDocs/Documenter.jl/pull/1014
 [github-1015]: https://github.com/JuliaDocs/Documenter.jl/pull/1015
 [github-1025]: https://github.com/JuliaDocs/Documenter.jl/pull/1025
+[github-1026]: https://github.com/JuliaDocs/Documenter.jl/issues/1026
 [github-1027]: https://github.com/JuliaDocs/Documenter.jl/issues/1027
 [github-1028]: https://github.com/JuliaDocs/Documenter.jl/pull/1028
 [github-1029]: https://github.com/JuliaDocs/Documenter.jl/pull/1029
@@ -593,6 +596,8 @@
 [github-1344]: https://github.com/JuliaDocs/Documenter.jl/issues/1344
 [github-1345]: https://github.com/JuliaDocs/Documenter.jl/pull/1345
 [github-1355]: https://github.com/JuliaDocs/Documenter.jl/pull/1355
+[github-1357]: https://github.com/JuliaDocs/Documenter.jl/pull/1357
+
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -598,7 +598,6 @@
 [github-1355]: https://github.com/JuliaDocs/Documenter.jl/pull/1355
 [github-1357]: https://github.com/JuliaDocs/Documenter.jl/pull/1357
 
-
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl
 [json-jl]: https://github.com/JuliaIO/JSON.jl

--- a/assets/html/scss/documenter/components/_all.scss
+++ b/assets/html/scss/documenter/components/_all.scss
@@ -1,2 +1,3 @@
 @import "admonition";
 @import "docstring";
+@import "example";

--- a/assets/html/scss/documenter/components/_example.scss
+++ b/assets/html/scss/documenter/components/_example.scss
@@ -1,0 +1,3 @@
+.documenter-example-output {
+  background-color: $body-background-color;
+}

--- a/assets/html/themes/documenter-dark.css
+++ b/assets/html/themes/documenter-dark.css
@@ -7277,6 +7277,8 @@ html.theme--documenter-dark {
       opacity: 0.2; }
     html.theme--documenter-dark .docstring > section:hover a.docs-sourcelink {
       opacity: 1; }
+  html.theme--documenter-dark .documenter-example-output {
+    background-color: #1f2424; }
   html.theme--documenter-dark .content pre {
     border: 1px solid #5e6d6f; }
   html.theme--documenter-dark .content code {

--- a/assets/html/themes/documenter-light.css
+++ b/assets/html/themes/documenter-light.css
@@ -7239,6 +7239,9 @@ h1:hover .docs-heading-anchor-permalink, h2:hover .docs-heading-anchor-permalink
   .docstring > section:hover a.docs-sourcelink {
     opacity: 1; }
 
+.documenter-example-output {
+  background-color: white; }
+
 .content pre {
   border: 1px solid #dbdbdb; }
 

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1651,7 +1651,8 @@ function mdconvert(d::Dict{MIME,Any}, parent; kwargs...)
     elseif haskey(d, MIME"text/markdown"())
         out = Markdown.parse(d[MIME"text/markdown"()])
     elseif haskey(d, MIME"text/plain"())
-        out = Markdown.Code(d[MIME"text/plain"()])
+        @tags pre
+        return pre[".documenter-example-output"](d[MIME"text/plain"()])
     else
         error("this should never happen.")
     end

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -34,6 +34,9 @@ end
             man_style_html = String(read(joinpath(build_dir, "man", "style", "index.html")))
             @test occursin("is-category-myadmonition", man_style_html)
 
+            index_html = read(joinpath(build_dir, "index.html"), String)
+            @test occursin("documenter-example-output", index_html)
+
             # Assets
             @test joinpath(build_dir, "assets", "documenter.js") |> isfile
 
@@ -55,6 +58,7 @@ end
 
             index_html = read(joinpath(build_dir, "index.html"), String)
             @test occursin("<strong>bold</strong> output from MarkdownOnly", index_html)
+            @test occursin("documenter-example-output", index_html)
 
             @test isfile(joinpath(build_dir, "index.html"))
             @test isfile(joinpath(build_dir, "omitted.html"))


### PR DESCRIPTION
This PR tweaks DOM of the `@example` output so that it has a different class than the code blocks.  We can then apply a different CSS style to visually distinguish the input and the output.

Before:

> ![image](https://user-images.githubusercontent.com/29282/86528363-13ff7980-be5c-11ea-97a3-c240ace87ea0.png) ![image](https://user-images.githubusercontent.com/29282/86528422-75274d00-be5c-11ea-83a9-0686b408e20f.png)


After:

> ![image](https://user-images.githubusercontent.com/29282/86528379-2c6f9400-be5c-11ea-8e08-5a00d79695ed.png) ![image](https://user-images.githubusercontent.com/29282/86528412-55902480-be5c-11ea-96b3-e7370130109a.png)

Fix #1026.

_Edit by @mortenpi: added issue reference._