### PR TITLE
Use consistent HTML classs for stdout/err in example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * ![Enhancement][badge-enhancement] When automatically determining the page list (i.e. `pages` is not passed to `makedocs`), Documenter now lists `index.md` before other pages. ([#1355][github-1355])
 
-* ![Enhancement][badge-enhancement] The output text boxes of `@example` blocks are now style differently from the code blocks, to make it easier to visually distinguish between the input and output. ([#1026][github-1026], [#1357][github-1357])
+* ![Enhancement][badge-enhancement] The output text boxes of `@example` blocks are now style differently from the code blocks, to make it easier to visually distinguish between the input and output. ([#1026][github-1026], [#1357][github-1357], [#1360][github-1360])
 
 ## Version `v0.25.0`
 
@@ -597,6 +597,7 @@
 [github-1345]: https://github.com/JuliaDocs/Documenter.jl/pull/1345
 [github-1355]: https://github.com/JuliaDocs/Documenter.jl/pull/1355
 [github-1357]: https://github.com/JuliaDocs/Documenter.jl/pull/1357
+[github-1360]: https://github.com/JuliaDocs/Documenter.jl/pull/1360
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -585,7 +585,7 @@ function Selectors.runner(::Type{ExampleBlocks}, x, page, doc)
     isempty(input)  || push!(content, Markdown.Code("julia", input))
     if result === nothing
         code = Documenter.DocTests.sanitise(buffer)
-        isempty(code) || push!(content, Markdown.Code(code))
+        isempty(code) || push!(content, Dict{MIME,Any}(MIME"text/plain"() => code))
     elseif !isempty(output)
         push!(content, output)
     end

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -162,6 +162,7 @@ htmlbuild_pages = Any[
     ],
     "unicode.md",
     "latex.md",
+    "example-output.md",
 ]
 
 # Build with pretty URLs and canonical links and a PNG logo
@@ -274,7 +275,6 @@ examples_latex_doc = if "latex" in EXAMPLE_BUILDS
                 "index.md",
                 "latex.md",
                 "unicode.md",
-                "example-output.md",
                 hide("hidden.md"),
             ],
             # SVG images nor code blocks in footnotes are allowed in LaTeX

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -274,6 +274,7 @@ examples_latex_doc = if "latex" in EXAMPLE_BUILDS
                 "index.md",
                 "latex.md",
                 "unicode.md",
+                "example-output.md",
                 hide("hidden.md"),
             ],
             # SVG images nor code blocks in footnotes are allowed in LaTeX

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -276,6 +276,7 @@ examples_latex_doc = if "latex" in EXAMPLE_BUILDS
                 "latex.md",
                 "unicode.md",
                 hide("hidden.md"),
+                "example-output.md",
             ],
             # SVG images nor code blocks in footnotes are allowed in LaTeX
             # "Manual" => [
@@ -336,6 +337,7 @@ examples_latex_texonly_doc = if "latex_texonly" in EXAMPLE_BUILDS
                 "latex.md",
                 "unicode.md",
                 hide("hidden.md"),
+                "example-output.md",
             ],
             # SVG images nor code blocks in footnotes are allowed in LaTeX
             # "Manual" => [

--- a/test/examples/src/example-output.md
+++ b/test/examples/src/example-output.md
@@ -1,0 +1,9 @@
+Checking that `@example` output is contained in a specific HTML class.
+
+!!! warning
+
+    This file should contain exactly one `@example` for the test to work.
+
+```@example
+println("hello")
+```

--- a/test/examples/src/example-output.md
+++ b/test/examples/src/example-output.md
@@ -1,3 +1,5 @@
+# Example stdout
+
 Checking that `@example` output is contained in a specific HTML class.
 
 !!! warning

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -37,6 +37,9 @@ end
             index_html = read(joinpath(build_dir, "index.html"), String)
             @test occursin("documenter-example-output", index_html)
 
+            example_output_html = read(joinpath(build_dir, "example-output.html"), String)
+            @test occursin("documenter-example-output", example_output_html)
+
             # Assets
             @test joinpath(build_dir, "assets", "documenter.js") |> isfile
 

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -113,7 +113,7 @@ end
 
         @test realpath(doc.internal.assets) == realpath(joinpath(dirname(@__FILE__), "..", "..", "assets"))
 
-        @test length(doc.blueprint.pages) == 18
+        @test length(doc.blueprint.pages) == 19
 
         let headers = doc.internal.headers
             @test Documenter.Anchors.exists(headers, "Documentation")

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -37,7 +37,7 @@ end
             index_html = read(joinpath(build_dir, "index.html"), String)
             @test occursin("documenter-example-output", index_html)
 
-            example_output_html = read(joinpath(build_dir, "example-output.html"), String)
+            example_output_html = read(joinpath(build_dir, "example-output", "index.html"), String)
             @test occursin("documenter-example-output", example_output_html)
 
             # Assets


### PR DESCRIPTION
This is a follow up of #1357.  While #1357 handled evaluated output, it didn't handle the HTML class of stdout/stderr.  This PR fixes it.