### PR TITLE
Fix exception handling in test/examples/make.jl

### DIFF
--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -6,7 +6,7 @@
 # or not and should be kept unique.
 isdefined(@__MODULE__, :examples_root) && error("examples_root is already defined\n$(@__FILE__) included multiple times?")
 
-# The `Mod` and `AutoDocs` modules are assumed to exists in the Main module.
+# The `Mod` and `AutoDocs` modules are assumed to exist in the Main module.
 (@__MODULE__) === Main || error("$(@__FILE__) must be included into Main.")
 
 # DOCUMENTER_TEST_EXAMPLES environment variable can be used to control which
@@ -118,15 +118,14 @@ function withassets(f, assets...)
     for asset in assets
         cp(src(asset), dst(asset))
     end
-    rv, exception = try
-        f(), nothing
-    catch e
-        nothing, e
+    try
+        f()
+    finally
+        @debug "Cleaning up assets" assets
+        for asset in assets
+            rm(dst(asset))
+        end
     end
-    for asset in assets
-        rm(dst(asset))
-    end
-    return (exception === nothing) ? rv : throw(exception)
 end
 
 # Build example docs


### PR DESCRIPTION
Using `throw()` like this attaches the wrong backtrace to the exception. Should be `rethrow()`, but you can only have that in `catch` blocks. However, in this case, a simple `try`-`finally` actually suffices, no need to do anything more complicated.

Came up while testing #1352.