### PR TITLE
Add "Powered by ..." message to footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * ![Enhancement][badge-enhancement] The output text boxes of `@example` blocks are now style differently from the code blocks, to make it easier to visually distinguish between the input and output. ([#1026][github-1026], [#1357][github-1357], [#1360][github-1360])
 
+* ![Enhancement][badge-enhancement] The generated HTML site now displays a footer by default that mentions Julia and Documenter. This can be customized or disabled by passing the `footer` keyword to `Documeter.HTML`. ([#1184][github-1184], [#1365][github-1365])
+
 ## Version `v0.25.0`
 
 * ![Enhancement][badge-enhancement] When deploying with `deploydocs`, any SSH username can now be used (not just `git`), by prepending `username@` to the repository URL in the `repo` argument. ([#1285][github-1285])
@@ -563,6 +565,7 @@
 [github-1171]: https://github.com/JuliaDocs/Documenter.jl/pull/1171
 [github-1173]: https://github.com/JuliaDocs/Documenter.jl/pull/1173
 [github-1180]: https://github.com/JuliaDocs/Documenter.jl/pull/1180
+[github-1184]: https://github.com/JuliaDocs/Documenter.jl/issues/1184
 [github-1186]: https://github.com/JuliaDocs/Documenter.jl/pull/1186
 [github-1189]: https://github.com/JuliaDocs/Documenter.jl/pull/1189
 [github-1194]: https://github.com/JuliaDocs/Documenter.jl/pull/1194
@@ -598,6 +601,7 @@
 [github-1355]: https://github.com/JuliaDocs/Documenter.jl/pull/1355
 [github-1357]: https://github.com/JuliaDocs/Documenter.jl/pull/1357
 [github-1360]: https://github.com/JuliaDocs/Documenter.jl/pull/1360
+[github-1365]: https://github.com/JuliaDocs/Documenter.jl/pull/1365
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/assets/html/scss/documenter/layout/_main.scss
+++ b/assets/html/scss/documenter/layout/_main.scss
@@ -135,6 +135,7 @@
       .footer-message {
         font-size: 0.7em;
         margin: 0.5em auto 0 auto;
+        text-align: center;
       }
     }
   }

--- a/assets/html/scss/documenter/layout/_main.scss
+++ b/assets/html/scss/documenter/layout/_main.scss
@@ -133,7 +133,7 @@
       }
 
       .footer-message {
-        font-size: 0.9em;
+        font-size: 0.7em;
         margin: 0.5em auto 0 auto;
       }
     }

--- a/assets/html/scss/documenter/layout/_main.scss
+++ b/assets/html/scss/documenter/layout/_main.scss
@@ -133,7 +133,7 @@
       }
 
       .footer-message {
-        font-size: 0.7em;
+        font-size: 0.8em;
         margin: 0.5em auto 0 auto;
         text-align: center;
       }

--- a/assets/html/scss/documenter/layout/_main.scss
+++ b/assets/html/scss/documenter/layout/_main.scss
@@ -108,6 +108,7 @@
 
     .docs-footer {
       display: flex;
+      flex-wrap: wrap;
       margin-left: 0;
       margin-right: 0;
       border-top: 1px solid $border;
@@ -124,6 +125,16 @@
       }
       .docs-footer-nextpage {
         text-align: right;
+      }
+
+      .flexbox-break {
+        flex-basis: 100%;
+        height: 0;
+      }
+
+      .footer-message {
+        font-size: 0.9em;
+        margin: 0.5em auto 0 auto;
       }
     }
   }

--- a/assets/html/themes/documenter-dark.css
+++ b/assets/html/themes/documenter-dark.css
@@ -7381,6 +7381,7 @@ html.theme--documenter-dark {
       margin-bottom: 0.4em; }
   html.theme--documenter-dark #documenter .docs-main .docs-footer {
     display: flex;
+    flex-wrap: wrap;
     margin-left: 0;
     margin-right: 0;
     border-top: 1px solid #5e6d6f;
@@ -7394,6 +7395,12 @@ html.theme--documenter-dark {
       flex-grow: 1; }
     html.theme--documenter-dark #documenter .docs-main .docs-footer .docs-footer-nextpage {
       text-align: right; }
+    html.theme--documenter-dark #documenter .docs-main .docs-footer .flexbox-break {
+      flex-basis: 100%;
+      height: 0; }
+    html.theme--documenter-dark #documenter .docs-main .docs-footer .footer-message {
+      font-size: 0.9em;
+      margin: 0.5em auto 0 auto; }
   html.theme--documenter-dark #documenter .docs-sidebar {
     display: flex;
     flex-direction: column;

--- a/assets/html/themes/documenter-dark.css
+++ b/assets/html/themes/documenter-dark.css
@@ -7399,8 +7399,9 @@ html.theme--documenter-dark {
       flex-basis: 100%;
       height: 0; }
     html.theme--documenter-dark #documenter .docs-main .docs-footer .footer-message {
-      font-size: 0.9em;
-      margin: 0.5em auto 0 auto; }
+      font-size: 0.8em;
+      margin: 0.5em auto 0 auto;
+      text-align: center; }
   html.theme--documenter-dark #documenter .docs-sidebar {
     display: flex;
     flex-direction: column;

--- a/assets/html/themes/documenter-light.css
+++ b/assets/html/themes/documenter-light.css
@@ -7363,6 +7363,7 @@ html {
 
 #documenter .docs-main .docs-footer {
   display: flex;
+  flex-wrap: wrap;
   margin-left: 0;
   margin-right: 0;
   border-top: 1px solid #dbdbdb;
@@ -7376,6 +7377,12 @@ html {
     flex-grow: 1; }
   #documenter .docs-main .docs-footer .docs-footer-nextpage {
     text-align: right; }
+  #documenter .docs-main .docs-footer .flexbox-break {
+    flex-basis: 100%;
+    height: 0; }
+  #documenter .docs-main .docs-footer .footer-message {
+    font-size: 0.9em;
+    margin: 0.5em auto 0 auto; }
 
 #documenter .docs-sidebar {
   display: flex;

--- a/assets/html/themes/documenter-light.css
+++ b/assets/html/themes/documenter-light.css
@@ -7381,8 +7381,9 @@ html {
     flex-basis: 100%;
     height: 0; }
   #documenter .docs-main .docs-footer .footer-message {
-    font-size: 0.9em;
-    margin: 0.5em auto 0 auto; }
+    font-size: 0.8em;
+    margin: 0.5em auto 0 auto;
+    text-align: center; }
 
 #documenter .docs-sidebar {
   display: flex;

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1058,7 +1058,11 @@ function render_footer(ctx, navnode)
         link = a[".docs-footer-nextpage", :href => navhref(ctx, navnode.next, navnode)](title, " »")
         push!(navlinks, link)
     end
-    return isempty(navlinks) ? "" : nav[".docs-footer"](navlinks)
+
+    linebreak = div[".flexbox-break"]()
+    footer_message = div[".footer-message"]("Powered by ", a[:href => "https://github.com/JuliaDocs/Documenter.jl"]("Documenter.jl"), " and the ", a[:href => "https://julialang.org/"]("Julia Programming Language"), ".")
+
+    return isempty(navlinks) ? nav[".docs-footer"](footer_message) : nav[".docs-footer"](navlinks, linebreak, footer_message)
 end
 
 # Article (page contents)

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1029,7 +1029,7 @@ function render_navbar(ctx, navnode, edit_page_link::Bool)
             title = "$(edit_verb)$hoststring"
             push!(navbar_right.nodes,
                 a[".docs-edit-link", :href => url, :title => title](
-                        span[".docs-icon.fab"](logo),
+                    span[".docs-icon.fab"](logo),
                     span[".docs-label.is-hidden-touch"](title)
                 )
             )

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -7,8 +7,8 @@ A module for rendering `Document` objects to HTML.
 [`Documenter.makedocs`](@ref): `authors`, `pages`, `sitename`, `version`.
 The behavior of [`HTMLWriter`](@ref) can be further customized by setting the `format`
 keyword of [`Documenter.makedocs`](@ref) to a [`HTML`](@ref), which accepts the following
-keyword arguments: `analytics`, `assets`, `canonical`, `disable_git`, `edit_link` and
-`prettyurls`.
+keyword arguments: `analytics`, `assets`, `canonical`, `disable_git`, `edit_link`,
+`prettyurls`, `collapselevel`, `sidebar_sitename`, `highlights`, `mathengine` and `footer`.
 
 **`sitename`** is the site's title displayed in the title bar and at the top of the
 *navigation menu. This argument is mandatory for [`HTMLWriter`](@ref).
@@ -282,6 +282,10 @@ blocks. The options are either [KaTeX](https://katex.org/) (default) or
 passing options to the [`KaTeX`](@ref) or [`MathJax`](@ref) constructors.
 
 **`lang`** can be used to specify the language tag of each HTML page. Default is `"en"`.
+
+**`footer`** can be a valid single-line markdown `String` or `nothing` and is displayed below
+the page navigation. Defaults to `"Powered by [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl)
+and the [Julia Programming Language](https://julialang.org/)."`.
 
 # Default and custom assets
 

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1078,7 +1078,6 @@ function render_footer(ctx, navnode)
     if footer_content !== nothing
         footer_container = domify(ctx, navnode, footer_content)
         push!(first(footer_container).attributes, :class => "footer-message")
-
         push!(nav_children, footer_container)
     end
 

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -195,6 +195,7 @@ examples_html_doc = if "html" in EXAMPLE_BUILDS
                     ),
                 ))),
                 highlights = ["erlang", "erlang-repl"],
+                footer = "This footer has been customized.",
             )
         )
     end
@@ -221,6 +222,7 @@ examples_html_local_doc = if "html-local" in EXAMPLE_BUILDS
             assets = ["assets/custom.css"],
             prettyurls = false,
             edit_branch = nothing,
+            footer = nothing,
         ),
     )
 else

--- a/test/htmlwriter.jl
+++ b/test/htmlwriter.jl
@@ -52,6 +52,7 @@ end
     @test Documenter.HTML() isa Documenter.HTML
     @test_throws ArgumentError Documenter.HTML(collapselevel=-200)
     @test_throws Exception Documenter.HTML(assets=["foo.js", 10])
+    @test_throws ArgumentError Documenter.HTML(footer="foo\nbar")
 
     # MathEngine
     let katex = KaTeX()

--- a/test/htmlwriter.jl
+++ b/test/htmlwriter.jl
@@ -54,6 +54,7 @@ end
     @test_throws Exception Documenter.HTML(assets=["foo.js", 10])
     @test_throws ArgumentError Documenter.HTML(footer="foo\n\nbar")
     @test_throws ArgumentError Documenter.HTML(footer="# foo")
+    @test_throws ArgumentError Documenter.HTML(footer="")
     @test Documenter.HTML(footer="foo bar [baz](https://github.com)") isa Documenter.HTML
 
     # MathEngine

--- a/test/htmlwriter.jl
+++ b/test/htmlwriter.jl
@@ -52,7 +52,9 @@ end
     @test Documenter.HTML() isa Documenter.HTML
     @test_throws ArgumentError Documenter.HTML(collapselevel=-200)
     @test_throws Exception Documenter.HTML(assets=["foo.js", 10])
-    @test_throws ArgumentError Documenter.HTML(footer="foo\nbar")
+    @test_throws ArgumentError Documenter.HTML(footer="foo\n\nbar")
+    @test_throws ArgumentError Documenter.HTML(footer="# foo")
+    @test Documenter.HTML(footer="foo bar [baz](https://github.com)") isa Documenter.HTML
 
     # MathEngine
     let katex = KaTeX()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6735977/87404054-ed5ce380-c5bd-11ea-81f2-113ac6272d33.png)

This should help a bit with SEO and therefore Julia's ranking (both for Julia itself and packages). AFAIU it's not ideal to put this in the footer, but I don't know enough about how Google ranks websites to figure out something better.

Open questions:
- [ ] Is everyone happy with this?
- [x] Should there be an opt-out mechanism?
- [ ] Should this be an opt-in feature (would completely defeat the purpose though, I think)?
- [x] Is the styling ok?

cc @ViralBShah 

_Edit by @mortenpi: fixes #1184_