### PR TITLE
Doctest output starting with #

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Documenter.jl changelog
 
+## Version `v0.25.2`
+
+* ![Bugfix][badge-bugfix] REPL doctest output lines starting with `#` right after the input code part are now correctly treated as being part of the output (unless prepended with 7 spaces, in line with the standard heuristic). ([#1369][github-1369])
+
 ## Version `v0.25.1`
 
 * ![Enhancement][badge-enhancement] When automatically determining the page list (i.e. `pages` is not passed to `makedocs`), Documenter now lists `index.md` before other pages. ([#1355][github-1355])
@@ -598,6 +602,7 @@
 [github-1355]: https://github.com/JuliaDocs/Documenter.jl/pull/1355
 [github-1357]: https://github.com/JuliaDocs/Documenter.jl/pull/1357
 [github-1360]: https://github.com/JuliaDocs/Documenter.jl/pull/1360
+[github-1369]: https://github.com/JuliaDocs/Documenter.jl/pull/1369
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -445,24 +445,24 @@ function repl_splitter(code)
     lines  = split(string(code, "\n"), '\n')
     input  = String[]
     output = String[]
-    buffer = IOBuffer()
+    buffer = IOBuffer() # temporary buffer for doctest inputs and outputs
+    found_first_prompt = false
     while !isempty(lines)
         line = popfirst!(lines)
         prompt = match(PROMPT_REGEX, line)
+        # We allow comments before the first julia> prompt
+        !found_first_prompt && startswith(line, '#') && continue
         if prompt === nothing
             source = match(SOURCE_REGEX, line)
             if source === nothing
                 savebuffer!(input, buffer)
                 println(buffer, line)
                 takeuntil!(PROMPT_REGEX, buffer, lines)
-            elseif startswith(lstrip(source[1]), '#')
-                # REPL code blocks may contain leading lines with comments. Drop them.
-                # TODO: handle multiline comments?
-                continue
             else
                 println(buffer, source[1])
             end
         else
+            found_first_prompt = true
             savebuffer!(output, buffer)
             println(buffer, prompt[1])
         end

--- a/test/doctests/src/working.md
+++ b/test/doctests/src/working.md
@@ -4,3 +4,18 @@ This source file contains a working doctest:
 julia> 2 + 2
 4
 ```
+
+Test comments or comment-like lines:
+
+```jldoctest
+julia> f(x) = println("# output from f\n$x");
+
+julia> f(42)
+# output from f
+42
+
+julia> f(42)
+       # comment line
+# output from f
+42
+```

--- a/test/doctests/src/working.md
+++ b/test/doctests/src/working.md
@@ -20,6 +20,20 @@ julia> f(42)
 42
 ```
 
+```jldoctest
+julia> let x = 1
+           println("$x")
+           # comment
+           println("$x")
+       end
+1
+1
+
+julia> println("xyz")
+       # comment
+xyz
+```
+
 Original issue:
 
 ```jldoctest
@@ -29,4 +43,13 @@ f (generic function with 1 method)
 julia> methods(f)
 # 1 method for generic function "f":
 [1] f() in Main at none:1
+```
+
+Comments at the start:
+
+```jldoctest
+# Initial comments before the first julia> prompt..
+# .. should be ignored.
+julia> 2 + 2
+4
 ```

--- a/test/doctests/src/working.md
+++ b/test/doctests/src/working.md
@@ -19,3 +19,14 @@ julia> f(42)
 # output from f
 42
 ```
+
+Original issue:
+
+```jldoctest
+julia> f()=0
+f (generic function with 1 method)
+
+julia> methods(f)
+# 1 method for generic function "f":
+[1] f() in Main at none:1
+```

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -6,7 +6,7 @@
 # or not and should be kept unique.
 isdefined(@__MODULE__, :examples_root) && error("examples_root is already defined\n$(@__FILE__) included multiple times?")
 
-# The `Mod` and `AutoDocs` modules are assumed to exists in the Main module.
+# The `Mod` and `AutoDocs` modules are assumed to exist in the Main module.
 (@__MODULE__) === Main || error("$(@__FILE__) must be included into Main.")
 
 # DOCUMENTER_TEST_EXAMPLES environment variable can be used to control which
@@ -118,15 +118,14 @@ function withassets(f, assets...)
     for asset in assets
         cp(src(asset), dst(asset))
     end
-    rv, exception = try
-        f(), nothing
-    catch e
-        nothing, e
+    try
+        f()
+    finally
+        @debug "Cleaning up assets" assets
+        for asset in assets
+            rm(dst(asset))
+        end
     end
-    for asset in assets
-        rm(dst(asset))
-    end
-    return (exception === nothing) ? rv : throw(exception)
 end
 
 # Build example docs


### PR DESCRIPTION
The following doctest will fail

```jldoctest
julia> f(x) = println("# output from f\n$x");

julia> f(42)
# output from f
42
```

because we consider lines starting `#` as comments and include in the source part of the doctest, kinda: https://github.com/JuliaDocs/Documenter.jl/blob/3e2090abf8064c55ac8828c060513de7f8e6959f/src/DocTests.jl#L454-L456

Arguably, we should only consider the `#` as part of the doctest source if it is preceded by 7 spaces (our standard heuristic for determining if something is part of the source or output part):

```jldoctest
julia> f(x) = println("# output from f\n$x");

julia> f(42)
       # actual comment
# output from f
42
```

X-ref: JuliaLang/julia#36696