### PR TITLE
Add Go to repo button

### DIFF
--- a/assets/html/js/repoinfo.js
+++ b/assets/html/js/repoinfo.js
@@ -1,0 +1,21 @@
+// libraries: jquery
+// arguments: $
+
+function round(value) {
+  if (value > 999) {
+    const digits = +((value - 950) % 1000 > 99)
+    return `${((value + 1) / 1000).toFixed(digits)}k`
+  } else {
+    return value.toString()
+  }
+}
+
+$(document).ready(function(){
+  gotorepo = $('#documenter-go-to-repo')
+  $.getJSON(`https://api.github.com/repos/${repo_owner}/${repo_name}`, function( data ) {
+    li = $('<li>').append(`${round(data.stargazers_count || 0)} Stars`)
+    gotorepo.append(li)
+    li = $('<li>').append(`${round(data.forks_count || 0)} Forks`)
+    gotorepo.append(li)
+  });
+});


### PR DESCRIPTION
This is my first iteration of something that minimally works for #1332 . It still looks ugly because there is no css.

<img width="1271" alt="Captura de Tela 2020-07-27 às 23 43 07" src="https://user-images.githubusercontent.com/32756941/88613200-56833300-d063-11ea-9998-5e86a7861393.png">

I still have to:

- [ ] Add the link that points to repository. 
- [ ] Add the repository owner and repository name
- [ ] Write proper HTML to make a proper layout
- [ ] Apply some css

Potentially missing things
- [ ] Add a logo, just like they have on https://squidfunk.github.io/mkdocs-material/