### PR TITLE
Correct render code block with tag "```julia-repl XXX"

### DIFF
--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -441,7 +441,7 @@ const LEXER = Set([
 function latex(io::IO, code::Markdown.Code)
     language = isempty(code.language) ? "none" : code.language
     # the julia-repl is called "jlcon" in Pygments
-    language = (language == "julia-repl") ? "jlcon" : language
+    language = occursin(r"^julia-repl\b", language) ? "jlcon" : language
     escape = '⊻' ∈ code.code
     if language in LEXER
         _print(io, "\n\\begin{minted}")


### PR DESCRIPTION
 To correct render the code block with the following formatted tag:

````
```Julia-repl XXXX

```
````

such as [```julia-repl sayhello2](https://github.com/JuliaLang/julia/edit/master/doc/src/manual/metaprogramming.md#L521) in the `metaprogramming` manual.