### PR TITLE
Fix the nightly tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
   - julia_version: 1.0
-  - julia_version: 1.4
+  - julia_version: 1.5
   - julia_version: nightly
 
 platform:

--- a/test/doctests/doctests.jl
+++ b/test/doctests/doctests.jl
@@ -73,7 +73,7 @@ function onormalize(s)
     s = replace(s, r"(@ Documenter.DocTests )(.*)$"m => s"\1{PATH}")
 
     # Remove stacktraces
-    s = replace(s, r"(│\s+Stacktrace:)(\n(│\s+)\[[0-9]+\].*)+" => s"\1\\n\3{STACKTRACE}")
+    s = replace(s, r"(│\s+Stacktrace:)(\n(│\s+)\[[0-9]+\].*)(\n(│\s+)@.*)?+" => s"\1\\n\3{STACKTRACE}")
 
     return s
 end

--- a/test/doctests/fix/broken.jl
+++ b/test/doctests/fix/broken.jl
@@ -1,14 +1,15 @@
 module Foo
 """
 ```jldoctest
-julia> Int64[1, 2, 3, 4] * 2
-4-element Array{Int64,1}:
+julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+4×1×1 Array{Int64,3}:
+[:, :, 1] =
  1
  2
  3
  4
 
-julia> Int64[1, 2, 3, 4]
+julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
 4-element Array{Int64,1}:
  1
  2
@@ -16,14 +17,14 @@ julia> Int64[1, 2, 3, 4]
  4
 ```
 ```jldoctest
-julia> Int64[1, 2, 3, 4]
+julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
 4-element Array{Int64,1}:
  1
  2
  3
  4
 
-julia> Int64[1, 2, 3, 4] * 2
+julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
 4-element Array{Int64,1}:
  1
  2
@@ -31,14 +32,14 @@ julia> Int64[1, 2, 3, 4] * 2
  4
 ```
 ```jldoctest
-julia> Int64[1, 2, 3, 4] * 2
+julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
 4-element Array{Int64,1}:
  1
  2
  3
  4
 
-julia> Int64[1, 2, 3, 4] * 2
+julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
 4-element Array{Int64,1}:
  1
  2
@@ -47,7 +48,7 @@ julia> Int64[1, 2, 3, 4] * 2
 ```
 ```jldoctest
 julia> begin
-          Int64[1, 2, 3, 4] * 2
+           reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
        end
 4-element Array{Int64,1}:
  1
@@ -56,7 +57,7 @@ julia> begin
  4
 ```
 ```jldoctest
-Int64[1, 2, 3, 4] * 2
+reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
 
 # output
 
@@ -81,7 +82,7 @@ foo() = 1
     """
     ```jldoctest
     julia> begin
-              Int64[1, 2, 3, 4] * 2
+               reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
            end
     4-element Array{Int64,1}:
      1

--- a/test/doctests/fix/broken.md
+++ b/test/doctests/fix/broken.md
@@ -3,14 +3,15 @@ DocTestFixTest.Foo.foo
 ```
 
 ```jldoctest
-julia> Int64[1, 2, 3, 4] * 2
-4-element Array{Int64,1}:
+julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+4×1×1 Array{Int64,3}:
+[:, :, 1] =
  1
  2
  3
  4
 
-julia> Int64[1, 2, 3, 4]
+julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
 4-element Array{Int64,1}:
  1
  2
@@ -18,14 +19,14 @@ julia> Int64[1, 2, 3, 4]
  4
 ```
 ```jldoctest
-julia> Int64[1, 2, 3, 4]
+julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
 4-element Array{Int64,1}:
  1
  2
  3
  4
 
-julia> Int64[1, 2, 3, 4] * 2
+julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
 4-element Array{Int64,1}:
  1
  2
@@ -33,14 +34,14 @@ julia> Int64[1, 2, 3, 4] * 2
  4
 ```
 ```jldoctest
-julia> Int64[1, 2, 3, 4] * 2
+julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
 4-element Array{Int64,1}:
  1
  2
  3
  4
 
-julia> Int64[1, 2, 3, 4] * 2
+julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
 4-element Array{Int64,1}:
  1
  2
@@ -49,7 +50,7 @@ julia> Int64[1, 2, 3, 4] * 2
 ```
 ```jldoctest
 julia> begin
-          Int64[1, 2, 3, 4] * 2
+          reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
        end
 4-element Array{Int64,1}:
  1
@@ -58,7 +59,7 @@ julia> begin
  4
 ```
 ```jldoctest
-Int64[1, 2, 3, 4] * 2
+reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
 
 # output
 

--- a/test/doctests/fix/fixed.jl
+++ b/test/doctests/fix/fixed.jl
@@ -1,45 +1,51 @@
 module Foo
 """
 ```jldoctest
-julia> Int64[1, 2, 3, 4] * 2
-4-element Array{Int64,1}:
+julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+4×1×1 Array{Int64,3}:
+[:, :, 1] =
  2
  4
  6
  8
 
-julia> Int64[1, 2, 3, 4]
-4-element Array{Int64,1}:
+julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
+4×1×1 Array{Int64,3}:
+[:, :, 1] =
  1
  2
  3
  4
 ```
 ```jldoctest
-julia> Int64[1, 2, 3, 4]
-4-element Array{Int64,1}:
+julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
+4×1×1 Array{Int64,3}:
+[:, :, 1] =
  1
  2
  3
  4
 
-julia> Int64[1, 2, 3, 4] * 2
-4-element Array{Int64,1}:
+julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+4×1×1 Array{Int64,3}:
+[:, :, 1] =
  2
  4
  6
  8
 ```
 ```jldoctest
-julia> Int64[1, 2, 3, 4] * 2
-4-element Array{Int64,1}:
+julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+4×1×1 Array{Int64,3}:
+[:, :, 1] =
  2
  4
  6
  8
 
-julia> Int64[1, 2, 3, 4] * 2
-4-element Array{Int64,1}:
+julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+4×1×1 Array{Int64,3}:
+[:, :, 1] =
  2
  4
  6
@@ -47,20 +53,22 @@ julia> Int64[1, 2, 3, 4] * 2
 ```
 ```jldoctest
 julia> begin
-          Int64[1, 2, 3, 4] * 2
+           reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
        end
-4-element Array{Int64,1}:
+4×1×1 Array{Int64,3}:
+[:, :, 1] =
  2
  4
  6
  8
 ```
 ```jldoctest
-Int64[1, 2, 3, 4] * 2
+reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
 
 # output
 
-4-element Array{Int64,1}:
+4×1×1 Array{Int64,3}:
+[:, :, 1] =
  2
  4
  6
@@ -83,9 +91,10 @@ foo() = 1
     """
     ```jldoctest
     julia> begin
-              Int64[1, 2, 3, 4] * 2
+               reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
            end
-    4-element Array{Int64,1}:
+    4×1×1 Array{Int64,3}:
+    [:, :, 1] =
      2
      4
      6

--- a/test/doctests/fix/fixed.md
+++ b/test/doctests/fix/fixed.md
@@ -3,45 +3,51 @@ DocTestFixTest.Foo.foo
 ```
 
 ```jldoctest
-julia> Int64[1, 2, 3, 4] * 2
-4-element Array{Int64,1}:
+julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+4×1×1 Array{Int64,3}:
+[:, :, 1] =
  2
  4
  6
  8
 
-julia> Int64[1, 2, 3, 4]
-4-element Array{Int64,1}:
+julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
+4×1×1 Array{Int64,3}:
+[:, :, 1] =
  1
  2
  3
  4
 ```
 ```jldoctest
-julia> Int64[1, 2, 3, 4]
-4-element Array{Int64,1}:
+julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
+4×1×1 Array{Int64,3}:
+[:, :, 1] =
  1
  2
  3
  4
 
-julia> Int64[1, 2, 3, 4] * 2
-4-element Array{Int64,1}:
+julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+4×1×1 Array{Int64,3}:
+[:, :, 1] =
  2
  4
  6
  8
 ```
 ```jldoctest
-julia> Int64[1, 2, 3, 4] * 2
-4-element Array{Int64,1}:
+julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+4×1×1 Array{Int64,3}:
+[:, :, 1] =
  2
  4
  6
  8
 
-julia> Int64[1, 2, 3, 4] * 2
-4-element Array{Int64,1}:
+julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+4×1×1 Array{Int64,3}:
+[:, :, 1] =
  2
  4
  6
@@ -49,20 +55,22 @@ julia> Int64[1, 2, 3, 4] * 2
 ```
 ```jldoctest
 julia> begin
-          Int64[1, 2, 3, 4] * 2
+          reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
        end
-4-element Array{Int64,1}:
+4×1×1 Array{Int64,3}:
+[:, :, 1] =
  2
  4
  6
  8
 ```
 ```jldoctest
-Int64[1, 2, 3, 4] * 2
+reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
 
 # output
 
-4-element Array{Int64,1}:
+4×1×1 Array{Int64,3}:
+[:, :, 1] =
  2
  4
  6

--- a/test/doctests/fix/tests.jl
+++ b/test/doctests/fix/tests.jl
@@ -2,8 +2,10 @@
 #
 # DOCUMENTER_TEST_DEBUG= JULIA_DEBUG=all julia test/doctests/fix/tests.jl
 #
+isdefined(@__MODULE__, :TestUtilities) || (include("../../TestUtilities.jl"); using .TestUtilities)
 module DocTestFixTest
 using Documenter, Test
+using ..TestUtilities: @quietly
 
 function test_doctest_fix(dir)
     srcdir = mktempdir(dir)
@@ -30,15 +32,12 @@ function test_doctest_fix(dir)
     @test read(joinpath(srcdir, "src.jl"), String) == read(joinpath(@__DIR__, "fixed.jl"), String)
 end
 
-println("="^50)
-@info("Testing `doctest = :fix`")
+@info "Testing `doctest = :fix` in $(@__FILE__)"
 if haskey(ENV, "DOCUMENTER_TEST_DEBUG")
     # in this mode the directories remain
     test_doctest_fix(mktempdir(@__DIR__))
 else
-    mktempdir(test_doctest_fix, @__DIR__)
+    @quietly mktempdir(test_doctest_fix, @__DIR__)
 end
-@info("Done testing `doctest = :fix`")
-println("="^50)
 
 end # module

--- a/test/htmlwriter.jl
+++ b/test/htmlwriter.jl
@@ -145,7 +145,11 @@ end
         verify_version_file(versionfile, entries)
 
         versions = ["v^", "devel" => "dev", "foobar", "foo" => "bar"]
-        entries, symlinks = expand_versions(tmpdir, versions)
+        entries, symlinks = @test_logs(
+            (:warn, "no match for `versions` entry `\"foobar\"`"),
+            (:warn, "no match for `versions` entry `\"foo\" => \"bar\"`"),
+            expand_versions(tmpdir, versions)
+        )
         @test entries == ["v2.1", "devel"]
         @test ("v2.1" => "2.1.1") in symlinks
         @test ("devel" => "dev") in symlinks

--- a/test/htmlwriter.jl
+++ b/test/htmlwriter.jl
@@ -74,7 +74,7 @@ end
         @test haskey(katex.config, :foo)
     end
 
-    let mathjax = MathJax()
+    let mathjax = MathJax2()
         @test length(mathjax.config) == 5
         @test haskey(mathjax.config, :tex2jax)
         @test haskey(mathjax.config, :config)
@@ -82,7 +82,7 @@ end
         @test haskey(mathjax.config, :extensions)
         @test haskey(mathjax.config, :TeX)
     end
-    let mathjax = MathJax(Dict(:foo => 1))
+    let mathjax = MathJax2(Dict(:foo => 1))
         @test length(mathjax.config) == 6
         @test haskey(mathjax.config, :tex2jax)
         @test haskey(mathjax.config, :config)
@@ -91,7 +91,7 @@ end
         @test haskey(mathjax.config, :TeX)
         @test haskey(mathjax.config, :foo)
     end
-    let mathjax = MathJax(Dict(:tex2jax => 1, :foo => 2))
+    let mathjax = MathJax2(Dict(:tex2jax => 1, :foo => 2))
         @test length(mathjax.config) == 6
         @test haskey(mathjax.config, :tex2jax)
         @test haskey(mathjax.config, :config)


### PR DESCRIPTION
Nightly tests for docstring fixing are failing because of the `Array{1/2}` -> `Vector/Matrix` printing change in 1.6. This works around the version-dependence by reshaping the arrays into a higher-dimensional array, which still prints the same way.