### PR TITLE
Add example of code coverage to docs

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -282,6 +282,22 @@ See GitHub's manual for
 [Creating and using encrypted secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)
 for more information.
 
+### Add code coverage from your deployed docs
+
+If you want code run during the documentation deployment to be covered by codecov,
+you can edit the end of the docs part of your workflow configuration file so that 
+`docs/make.jl` is run with the `--code-coverage=user` flag and the coverage reports
+are uploaded to codecov:
+
+```yaml
+      - run: julia --project=docs/ --code-coverage=user docs/make.jl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+      - uses: julia-actions/julia-uploadcodecov@latest
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }
+```
 
 ## `docs/Project.toml`
 

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -284,7 +284,7 @@ for more information.
 
 ### Add code coverage from documentation builds
 
-If you want code run during the documentation deployment to be covered by codecov,
+If you want code run during the documentation deployment to be covered by Codecov,
 you can edit the end of the docs part of your workflow configuration file so that 
 `docs/make.jl` is run with the `--code-coverage=user` flag and the coverage reports
 are uploaded to codecov:

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -294,9 +294,8 @@ are uploaded to Codecov:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-      - uses: julia-actions/julia-uploadcodecov@latest
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
 ```
 
 ## `docs/Project.toml`

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -287,7 +287,7 @@ for more information.
 If you want code run during the documentation deployment to be covered by Codecov,
 you can edit the end of the docs part of your workflow configuration file so that 
 `docs/make.jl` is run with the `--code-coverage=user` flag and the coverage reports
-are uploaded to codecov:
+are uploaded to Codecov:
 
 ```yaml
       - run: julia --project=docs/ --code-coverage=user docs/make.jl

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -282,7 +282,7 @@ See GitHub's manual for
 [Creating and using encrypted secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)
 for more information.
 
-### Add code coverage from your deployed docs
+### Add code coverage from documentation builds
 
 If you want code run during the documentation deployment to be covered by codecov,
 you can edit the end of the docs part of your workflow configuration file so that 


### PR DESCRIPTION
Just a suggestion to add an example of how to cover the code run during the docs deployment to codecov, as per issue/question https://github.com/JuliaDocs/Documenter.jl/issues/1397#issuecomment-672277080. (This probably needs polishing and generalized to include coveralls as well?)

_Edit by @mortenpi: close #1397_