### PR TITLE
render a latex environment input as a paragraph

### DIFF
--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -498,8 +498,15 @@ function _print_code_escapes_inline(io, s::AbstractString)
 end
 
 function latex(io::IO, md::Markdown.Paragraph)
-    for md in md.content
-        latexinline(io, md)
+    if occursin(r"^\h*?\\begin{\p{Xan}*?}", md.content[begin])
+        for md in md.content
+            md = Base.replace(md, r"\\$" => "\\\\")
+            Base.print(io.io, md)
+        end
+    else
+        for md in md.content
+            latexinline(io, md)
+        end
     end
     _println(io, "\n")
 end


### PR DESCRIPTION
Sometimes, the output of a `@example` block is itself a latex environment, such as a [DataFrame](https://github.com/JuliaData/DataFrames.jl/edit/master/docs/src/man/getting_started.md#L36).

````
```@example
using DataFrames
df = DataFrame(i=1:4, y='A':'D', z=5:8);
df
```
````

In this case, some special characters, such as `&` and `\`, are not need escaped, except for the linebreak symbol `\\`.
This pr intends to do this.
This is related to issue #1346.

