### PR TITLE
simple typo fix "rather then" to "rather than"

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -405,7 +405,7 @@ By default Documenter will create a link called `stable` that points to the late
 https://USER_NAME.github.io/PACKAGE_NAME.jl/stable
 ```
 
-It is recommended to use this link, rather then the versioned links, since it will be updated
+It is recommended to use this link, rather than the versioned links, since it will be updated
 with new releases.
 
 !!! info "Fixing broken release deployments"


### PR DESCRIPTION
Fixed small typo -- "rather then" should be "rather than".