### PR TITLE
Replace Utilities.withoutput with IOCapture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,13 @@ jobs:
         - julia --project=test/themes test/themes/themes.jl
       name: "Themes"
     - script:
-      - julia --project=test/examples -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd())); Pkg.add("DocumenterMarkdown")'
+      - |
+        julia --project=test/examples -e '
+          using Pkg
+          Pkg.instantiate()
+          Pkg.develop(PackageSpec(path=pwd()))
+          Pkg.add("IOCapture")
+        '
       - julia --project=test/examples test/examples/tests_latex.jl
       name: "PDF/LaTeX backend"
     - stage: "Documentation"

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
           using Pkg
           Pkg.instantiate()
           Pkg.develop(PackageSpec(path=pwd()))
-          Pkg.add("IOCapture")
+          Pkg.add(["IOCapture", "DocumenterMarkdown"])
         '
       - julia --project=test/examples test/examples/tests_latex.jl
       name: "PDF/LaTeX backend"

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.25.2"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+IOCapture = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
@@ -17,6 +18,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 DocStringExtensions = "0.4, 0.5, 0.6, 0.7, 0.8"
+IOCapture = "0.1"
 JSON = "0.19, 0.20, 0.21"
 julia = "1"
 

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -528,13 +528,6 @@ newlines(s::AbstractString) = count(c -> c === '\n', s)
 newlines(other) = 0
 
 
-using IOCapture
-function withoutput(f)
-    c = iocapture(f, throwerrors=false)
-    return c.value, !c.error, c.backtrace, c.output
-end
-
-
 """
     issubmodule(sub, mod)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,9 +3,6 @@ import Documenter
 include("TestUtilities.jl"); using .TestUtilities
 
 @testset "Documenter" begin
-    # Test TestUtilities
-    TestUtilities.test()
-
     # Build the example docs
     @info "Building example/make.jl"
     include("examples/make.jl")

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -261,28 +261,6 @@ end
         @test splitby(r"[▶]+", "Ω▶▶Y▶Z▶κ") == ["Ω▶▶", "Y▶", "Z▶", "κ"]
     end
 
-    # This test checks that deprecation warnings are captured correctly
-    @static if isdefined(Base, :with_logger)
-        @testset "withoutput" begin
-            _, _, _, output = Documenter.Utilities.withoutput() do
-                println("println")
-                @info "@info"
-                f() = (Base.depwarn("depwarn", :f); nothing)
-                f()
-            end
-            # The output is dependent on whether the user is running tests with deprecation
-            # warnings enabled or not. To figure out whether that is the case or not, we can
-            # look at the .depwarn field of the undocumented Base.JLOptions object.
-            @test isdefined(Base, :JLOptions)
-            @test hasfield(Base.JLOptions, :depwarn)
-            if Base.JLOptions().depwarn == 0 # --depwarn=no, default on Julia >= 1.5
-                @test output == "println\n[ Info: @info\n"
-            else # --depwarn=yes
-                @test startswith(output, "println\n[ Info: @info\n┌ Warning: depwarn\n")
-            end
-        end
-    end
-
     @testset "issues #749, #790, #823" begin
         let parse(x) = Documenter.Utilities.parseblock(x, nothing, nothing)
             for LE in ("\r\n", "\n")


### PR DESCRIPTION
I moved the stdout/err capturing functionality into a [separate package](https://github.com/JuliaDocs/IOCapture.jl), since it's slightly non-trivial and has been copy-pasted into several packages (e.g. Literate, Publish). So it seems like a good candidate for a small, well-defined package.