### PR TITLE
Add a showcase example for multiple uses of the same symbol.

### DIFF
--- a/docs/DocumenterShowcase.jl
+++ b/docs/DocumenterShowcase.jl
@@ -73,4 +73,13 @@ function Base.show(io, ::MIME"image/svg+xml", c::SVGCircle)
     """)
 end
 
+"The type definition."
+struct Foo{T,S} end
+
+"Constructor `Foo()` with no arguments."
+Foo() = Foo{Nothing,Nothing}()
+
+"Constructor `Foo{T}()` with one parametric argument."
+Foo{T}() where T = Foo{T,Nothing}()
+
 end # module

--- a/docs/src/showcase.md
+++ b/docs/src/showcase.md
@@ -274,7 +274,7 @@ The [`@index` block](@ref) can be used to generate a list of all the docstrings 
 Pages = ["showcase.md"]
 ```
 
-## Multiple uses of the same symbol
+### Multiple uses of the same symbol
 
 Sometimes a symbol has multiple docstrings, for example a type definition, inner and outer constructors. The example
 below shows how to use specific ones in the documentation.

--- a/docs/src/showcase.md
+++ b/docs/src/showcase.md
@@ -274,6 +274,17 @@ The [`@index` block](@ref) can be used to generate a list of all the docstrings 
 Pages = ["showcase.md"]
 ```
 
+## Multiple uses of the same symbol
+
+Sometimes a symbol has multiple docstrings, for example a type definition, inner and outer constructors. The example
+below shows how to use specific ones in the documentation.
+
+```@docs
+DocumenterShowcase.Foo
+DocumenterShowcase.Foo()
+DocumenterShowcase.Foo{T}()
+```
+
 ## Doctesting example
 
 Often you want to write code example such as this:


### PR DESCRIPTION
Fixes #1361.