### PR TITLE
Strip out $$ as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * ![Enhancement][badge-enhancement] The URL to the MathJax JS module can now be customized by passing the `url` keyword argument to the constructors (`MathJax2`, `MathJax3`). ([#1428][github-1428], [#1430][github-1430])
 
 * ![Bugfix][badge-bugfix] `Documenter.doctest` now correctly accepts the `doctestfilters` keyword, similar to `Documenter.makedocs`. ([#1364][github-1364], [#1435][github-1435])
+
 ## Version `v0.25.2`
 
 * ![Deprecation][badge-deprecation] The `Documenter.MathJax` type, used to specify the mathematics rendering engine in the HTML output, is now deprecated in favor of `Documenter.MathJax2`. ([#1362][github-1362], [#1367][github-1367])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -661,14 +661,11 @@
 [github-1389]: https://github.com/JuliaDocs/Documenter.jl/pull/1389
 [github-1392]: https://github.com/JuliaDocs/Documenter.jl/pull/1392
 [github-1400]: https://github.com/JuliaDocs/Documenter.jl/pull/1400
-<<<<<<< HEAD
 [github-1428]: https://github.com/JuliaDocs/Documenter.jl/issues/1428
 [github-1430]: https://github.com/JuliaDocs/Documenter.jl/pull/1430
 [github-1364]: https://github.com/JuliaDocs/Documenter.jl/issues/1364
 [github-1435]: https://github.com/JuliaDocs/Documenter.jl/pull/1435
-=======
 [github-1426]: https://github.com/JuliaDocs/Documenter.jl/pull/1426
->>>>>>> 5eca1784... Add CHANGELOG
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Documenter.jl changelog
 
+## Version `v0.26.0`
+
+* ![Enhancement][badge-enhancement] Objects that render as equations and whose `text/latex` representations are wrapped in display equation delimiters `\[ ... \]` or `$$ ... $$` are now handled correctly in the HTML output. ([#1278][github-1278], [#1283][github-1283], [#1426][github-1426])
+
 ## Version `v0.25.3`
 
 * ![Enhancement][badge-enhancement] The URL to the MathJax JS module can now be customized by passing the `url` keyword argument to the constructors (`MathJax2`, `MathJax3`). ([#1428][github-1428], [#1430][github-1430])
 
 * ![Bugfix][badge-bugfix] `Documenter.doctest` now correctly accepts the `doctestfilters` keyword, similar to `Documenter.makedocs`. ([#1364][github-1364], [#1435][github-1435])
-
 ## Version `v0.25.2`
 
 * ![Deprecation][badge-deprecation] The `Documenter.MathJax` type, used to specify the mathematics rendering engine in the HTML output, is now deprecated in favor of `Documenter.MathJax2`. ([#1362][github-1362], [#1367][github-1367])
@@ -623,8 +626,10 @@
 [github-1258]: https://github.com/JuliaDocs/Documenter.jl/pull/1258
 [github-1264]: https://github.com/JuliaDocs/Documenter.jl/pull/1264
 [github-1269]: https://github.com/JuliaDocs/Documenter.jl/pull/1269
+[github-1278]: https://github.com/JuliaDocs/Documenter.jl/issues/1278
 [github-1279]: https://github.com/JuliaDocs/Documenter.jl/issues/1279
 [github-1280]: https://github.com/JuliaDocs/Documenter.jl/pull/1280
+[github-1283]: https://github.com/JuliaDocs/Documenter.jl/pull/1283
 [github-1285]: https://github.com/JuliaDocs/Documenter.jl/pull/1285
 [github-1292]: https://github.com/JuliaDocs/Documenter.jl/pull/1292
 [github-1293]: https://github.com/JuliaDocs/Documenter.jl/pull/1293
@@ -656,10 +661,14 @@
 [github-1389]: https://github.com/JuliaDocs/Documenter.jl/pull/1389
 [github-1392]: https://github.com/JuliaDocs/Documenter.jl/pull/1392
 [github-1400]: https://github.com/JuliaDocs/Documenter.jl/pull/1400
+<<<<<<< HEAD
 [github-1428]: https://github.com/JuliaDocs/Documenter.jl/issues/1428
 [github-1430]: https://github.com/JuliaDocs/Documenter.jl/pull/1430
 [github-1364]: https://github.com/JuliaDocs/Documenter.jl/issues/1364
 [github-1435]: https://github.com/JuliaDocs/Documenter.jl/pull/1435
+=======
+[github-1426]: https://github.com/JuliaDocs/Documenter.jl/pull/1426
+>>>>>>> 5eca1784... Add CHANGELOG
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1749,7 +1749,7 @@ function mdconvert(d::Dict{MIME,Any}, parent; kwargs...)
         latex = d[MIME"text/latex"()]
         equation = false
         m_bracket = match(r"\s*\\\[(.*)\\\]\s*", latex)
-        m_dollars = match(r"\s*\\\[(.*)\\\]\s*", latex)
+        m_dollars = match(r"\s*\\$$(.*)\\$$\s*", latex)
         if m_bracket === nothing && m_dollars === nothing
             out = Utilities.mdparse(latex; mode = :single)
         else

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1743,7 +1743,11 @@ function mdconvert(d::Dict{MIME,Any}, parent; kwargs...)
     elseif haskey(d, MIME"image/jpeg"())
         out = Documents.RawHTML(string("<img src=\"data:image/jpeg;base64,", d[MIME"image/jpeg"()], "\" />"))
     elseif haskey(d, MIME"text/latex"())
-        out = Utilities.mdparse(d[MIME"text/latex"()]; mode = :single)
+        # If the show(io, ::MIME"text/latex", x) output is already wrapped in \[ ... \], we
+        # unwrap it first, since when we output Markdown.LaTeX objects we put the correct
+        # delimiters around it anyway.
+        m = match(r"\s*\\\[(.*)\\\]\s*", d[MIME"text/latex"()])
+        out = Markdown.LaTeX(m === nothing ? d[MIME"text/latex"()] : m[1])
     elseif haskey(d, MIME"text/markdown"())
         out = Markdown.parse(d[MIME"text/markdown"()])
     elseif haskey(d, MIME"text/plain"())

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1749,7 +1749,7 @@ function mdconvert(d::Dict{MIME,Any}, parent; kwargs...)
         latex = d[MIME"text/latex"()]
         equation = false
         m_bracket = match(r"\s*\\\[(.*)\\\]\s*", latex)
-        m_dollars = match(r"\s*\\$$(.*)\\$$\s*", latex)
+        m_dollars = match(r"\s*\$\$(.*)\$\$\s*", latex)
         if m_bracket === nothing && m_dollars === nothing
             out = Utilities.mdparse(latex; mode = :single)
         else

--- a/test/examples/src/man/tutorial.md
+++ b/test/examples/src/man/tutorial.md
@@ -416,7 +416,7 @@ Base.show(io, ::MIME"text/latex", latex::LaTeXEquation) = write(io, latex.code)
 nothing # hide
 ```
 
-In an `@example` or `@eval`block, it renders as an equation:
+In an `@example` or `@eval` block, it renders as an equation:
 
 ```@example showablelatex
 LaTeXEquation("x^2")

--- a/test/examples/src/man/tutorial.md
+++ b/test/examples/src/man/tutorial.md
@@ -422,8 +422,14 @@ In an `@example` or `@eval`block, it renders as an equation:
 LaTeXEquation("x^2")
 ```
 
-Documenter also supports having the LaTeX text being already wrapped in `\[ ... \]`.
+Documenter also supports having the LaTeX text being already wrapped in `\[ ... \]`:
 
 ```@example showablelatex
 LaTeXEquation("\\[\\left[ \\begin{array}{rr}x&2 x\\end{array}\\right]\\]")
+```
+
+or wrapped in `$$ ... $$`:
+
+```@example showablelatex
+LaTeXEquation("$$\\begin{bmatrix} 1 & 2\\ 3 & 4 \\end{bmatrix}$$")
 ```

--- a/test/examples/src/man/tutorial.md
+++ b/test/examples/src/man/tutorial.md
@@ -425,7 +425,7 @@ LaTeXEquation(raw"Foo $x^2$ bar.")
 Documenter also supports having the LaTeX text being already wrapped in `\[ ... \]`:
 
 ```@example showablelatex
-LaTeXEquation("\\[\\left[ \\begin{array}{rr}x&2 x\\end{array}\\right]\\]")
+LaTeXEquation(raw"\[\left[ \begin{array}{rr}x&2 x\end{array}\right]\]")
 ```
 
 or wrapped in `$$ ... $$`:

--- a/test/examples/src/man/tutorial.md
+++ b/test/examples/src/man/tutorial.md
@@ -419,8 +419,7 @@ nothing # hide
 In an `@example` or `@eval` block, it renders as an equation:
 
 ```@example showablelatex
-LaTeXEquation("x^2")
-```
+LaTeXEquation("Foo $x^2$ bar.")
 
 Documenter also supports having the LaTeX text being already wrapped in `\[ ... \]`:
 

--- a/test/examples/src/man/tutorial.md
+++ b/test/examples/src/man/tutorial.md
@@ -431,5 +431,5 @@ LaTeXEquation(raw"\[\left[ \begin{array}{rr}x&2 x\end{array}\right]\]")
 or wrapped in `$$ ... $$`:
 
 ```@example showablelatex
-LaTeXEquation("$$\\begin{bmatrix} 1 & 2\\ 3 & 4 \\end{bmatrix}$$")
+LaTeXEquation(raw"$$\begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix}$$")
 ```

--- a/test/examples/src/man/tutorial.md
+++ b/test/examples/src/man/tutorial.md
@@ -403,3 +403,27 @@ Hello World!
 Written in <a href="https://fonts.google.com/specimen/Nanum+Brush+Script">Nanum Brush Script.</a>
 </div>
 ```
+
+## Handling of `text/latex`
+
+You can define a type that has a `Base.show` method for the `text/latex` MIME:
+
+```@example showablelatex
+struct LaTeXEquation
+    code :: String
+end
+Base.show(io, ::MIME"text/latex", latex::LaTeXEquation) = write(io, latex.code)
+nothing # hide
+```
+
+In an `@example` or `@eval`block, it renders as an equation:
+
+```@example showablelatex
+LaTeXEquation("x^2")
+```
+
+Documenter also supports having the LaTeX text being already wrapped in `\[ ... \]`.
+
+```@example showablelatex
+LaTeXEquation("\\[\\left[ \\begin{array}{rr}x&2 x\\end{array}\\right]\\]")
+```

--- a/test/examples/src/man/tutorial.md
+++ b/test/examples/src/man/tutorial.md
@@ -419,7 +419,8 @@ nothing # hide
 In an `@example` or `@eval` block, it renders as an equation:
 
 ```@example showablelatex
-LaTeXEquation("Foo $x^2$ bar.")
+LaTeXEquation(raw"Foo $x^2$ bar.")
+```
 
 Documenter also supports having the LaTeX text being already wrapped in `\[ ... \]`:
 


### PR DESCRIPTION
Rebases https://github.com/JuliaDocs/Documenter.jl/pull/1283 and strips `$$` as well

_Edit by @mortenpi: close #1283, fix #1278_