### PR TITLE
Allow specifying URLs for LaTeX engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version `v0.25.3`
 
-* ![Enhancement][badge-enhancement] The URL of the MathJax module can now be customized by passing the `url` keyword argument to the constructors (`MathJax2`, `MathJax3`). ([#1428][github-1428], [#1430][github-1430])
+* ![Enhancement][badge-enhancement] The URL to the MathJax JS module can now be customized by passing the `url` keyword argument to the constructors (`MathJax2`, `MathJax3`). ([#1428][github-1428], [#1430][github-1430])
 
 ## Version `v0.25.2`
 

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -188,8 +188,9 @@ setting your own `tex2jax` value will override the default). This can be overrid
 setting `override` to `true`, in which case the default values are ignored and only the
 user-provided dictionary is used.
 
-user can specify a Content Delivery Network (CDN) link via the optional argument of `url` to
-access a particular minor version of [MathJax v2 rendering engine](https://www.mathjax.org/).
+The URL of the MathJax JS file can be overridden using the `url` keyword argument (e.g. to
+use a particular minor version). The URL should just refer to the file and not contain any
+query parameters (e.g. `?config=TeX-AMS-MML_CHTML` must be removed).
 """
 struct MathJax2 <: MathEngine
     config :: Dict{Symbol,Any}
@@ -243,8 +244,9 @@ setting your own `tex` value will override the default). This can be overridden 
 setting `override` to `true`, in which case the default values are ignored and only the
 user-provided dictionary is used.
 
-user can specify a Content Delivery Network (CDN) link via the optional argument of `url` to
-access a particular minor version of [MathJax v3 rendering engine](https://www.mathjax.org/).
+The URL of the MathJax JS file can be overridden using the `url` keyword argument (e.g. to
+use a particular minor version). The URL should just refer to the file and not contain any
+query parameters (e.g. `?config=TeX-AMS-MML_CHTML` must be removed).
 """
 struct MathJax3 <: MathEngine
     config :: Dict{Symbol,Any}

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -189,8 +189,7 @@ setting `override` to `true`, in which case the default values are ignored and o
 user-provided dictionary is used.
 
 The URL of the MathJax JS file can be overridden using the `url` keyword argument (e.g. to
-use a particular minor version). The URL should just refer to the file and not contain any
-query parameters (e.g. `?config=TeX-AMS-MML_CHTML` must be removed).
+use a particular minor version).
 """
 struct MathJax2 <: MathEngine
     config :: Dict{Symbol,Any}
@@ -245,8 +244,7 @@ setting `override` to `true`, in which case the default values are ignored and o
 user-provided dictionary is used.
 
 The URL of the MathJax JS file can be overridden using the `url` keyword argument (e.g. to
-use a particular minor version). The URL should just refer to the file and not contain any
-query parameters (e.g. `?config=TeX-AMS-MML_CHTML` must be removed).
+use a particular minor version).
 """
 struct MathJax3 <: MathEngine
     config :: Dict{Symbol,Any}

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -187,6 +187,9 @@ resulting configuration dictionary will contain the values from both dictionarie
 setting your own `tex2jax` value will override the default). This can be overridden by
 setting `override` to `true`, in which case the default values are ignored and only the
 user-provided dictionary is used.
+
+user can specify a Content Delivery Network (CDN) link via the optional argument of `url` to
+access a particular minor version of [MathJax v2 rendering engine](https://www.mathjax.org/).
 """
 struct MathJax2 <: MathEngine
     config :: Dict{Symbol,Any}
@@ -239,6 +242,9 @@ resulting configuration dictionary will contain the values from both dictionarie
 setting your own `tex` value will override the default). This can be overridden by
 setting `override` to `true`, in which case the default values are ignored and only the
 user-provided dictionary is used.
+
+user can specify a Content Delivery Network (CDN) link via the optional argument of `url` to
+access a particular minor version of [MathJax v3 rendering engine](https://www.mathjax.org/).
 """
 struct MathJax3 <: MathEngine
     config :: Dict{Symbol,Any}
@@ -531,7 +537,7 @@ module RD
 
             (function () {
                 var script = document.createElement('script');
-                script.src = $url;
+                script.src = '$url';
                 script.async = true;
                 document.head.appendChild(script);
             })();

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -230,7 +230,7 @@ examples_html_mathjax2_custom_doc = if "html-mathjax2-custom" in EXAMPLE_BUILDS
                     ),
                 ),
             ),
-            url = "https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js",
+            url = "https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS-MML_HTMLorMML",
         ),
     )
 else

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -206,7 +206,9 @@ examples_html_doc = if "html" in EXAMPLE_BUILDS
                     :pdv => ["\\frac{\\partial^{#1} #2}{\\partial #3^{#1}}", 3, ""],
                 ),
             ),
-        )),
+        ); 
+            url = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-AMS_HTML"
+        ),
     )
 else
     @info "Skipping build: HTML/deploy" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
@@ -224,7 +226,9 @@ examples_html_mathjax3_doc = if "html-mathjax3" in EXAMPLE_BUILDS
                 "tags" => "ams",
                 "packages" => ["base", "ams", "autoload", "physics"],
             ),
-        )),
+        ); 
+            url = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.0.5/es5/tex-svg.js"
+        ),
     )
 else
     @info "Skipping build: HTML/deploy MathJax v3" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -53,8 +53,7 @@ end
             elseif name == "html-mathjax2-custom"
                 @test occursin("https://cdn.jsdelivr.net/npm/mathjax@2/MathJax", documenter_js)
             elseif name == "html-mathjax3-custom"
-                @test occursin("script.src = https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js;", documenter_js)
-                @test_broken occursin("script.src = 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js';", documenter_js)
+                @test occursin("script.src = 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js';", documenter_js)
             else # name == "html", uses MathJax2
                 @test occursin("https://cdnjs.cloudflare.com/ajax/libs/mathjax/2", documenter_js)
             end


### PR DESCRIPTION
add a field for MathJax CDN that user can input by calling Documenter.HTML

_Edit by @mortenpi: fix #1428_