### PR TITLE
Correctly accept doctestfilters kwarg in Documenter.doctest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * ![Enhancement][badge-enhancement] The URL to the MathJax JS module can now be customized by passing the `url` keyword argument to the constructors (`MathJax2`, `MathJax3`). ([#1428][github-1428], [#1430][github-1430])
 
+* ![Bugfix][badge-bugfix] `Documenter.doctest` now correctly accepts the `doctestfilters` keyword, similar to `Documenter.makedocs`. ([#1364][github-1364], [#1435][github-1435])
+
 ## Version `v0.25.2`
 
 * ![Deprecation][badge-deprecation] The `Documenter.MathJax` type, used to specify the mathematics rendering engine in the HTML output, is now deprecated in favor of `Documenter.MathJax2`. ([#1362][github-1362], [#1367][github-1367])
@@ -656,6 +658,8 @@
 [github-1400]: https://github.com/JuliaDocs/Documenter.jl/pull/1400
 [github-1428]: https://github.com/JuliaDocs/Documenter.jl/issues/1428
 [github-1430]: https://github.com/JuliaDocs/Documenter.jl/pull/1430
+[github-1364]: https://github.com/JuliaDocs/Documenter.jl/issues/1364
+[github-1435]: https://github.com/JuliaDocs/Documenter.jl/pull/1435
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -775,6 +775,8 @@ manual pages can be disabled if `source` is set to `nothing`.
 
 **`testset`** specifies the name of test testset (default `Doctests`).
 
+**`doctestfilters`** vector of regex to filter tests (see the manual on [Filtering Doctests](@ref))
+
 **`fix`**, if set to `true`, updates all the doctests that fail with the correct output
 (default `false`).
 
@@ -790,6 +792,7 @@ function doctest(
         modules::AbstractVector{Module};
         fix = false,
         testset = "Doctests",
+        doctestfilters = Regex[],
     )
     function all_doctests()
         dir = mktempdir()
@@ -805,6 +808,7 @@ function doctest(
                 sitename = "",
                 doctest = fix ? :fix : :only,
                 modules = modules,
+                doctestfilters = doctestfilters,
             )
             true
         catch err

--- a/test/doctests/doctestapi.jl
+++ b/test/doctests/doctestapi.jl
@@ -108,6 +108,19 @@ end
 
 """
 ```jldoctest
+julia> println("global filter")
+global FILTER
+```
+
+```jldoctest; filter = r"local (filter|FILTER)"
+julia> println("local filter")
+local FILTER
+```
+"""
+module DoctestFilters end
+
+"""
+```jldoctest
 julia> map(tuple, 1/(i+j) for i=1:2, j=1:2, [1:4;])
 ERROR: syntax: invalid iteration specification
 ```
@@ -208,6 +221,12 @@ end
     run_doctest(nothing, [DocTest5]) do result, success, backtrace, output
         @test success
         @test result isa Test.DefaultTestSet
+    end
+
+    # DoctestFilters
+    df = [r"global (filter|FILTER)"]
+    run_doctest(nothing, [DoctestFilters], doctestfilters=df) do result, success, backtrace, output
+        @test success
     end
 
     # Parse errors in doctests (https://github.com/JuliaDocs/Documenter.jl/issues/1046)


### PR DESCRIPTION
Fixes #1364