### PR TITLE
Add support for ANSI colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Documenter.jl changelog
 
+
+## Version `v0.27.4`
+
+* ![Feature][badge-feature] `@example`- and `@repl`-blocks now support colored output by mapping ANSI escape sequences to HTML. This requires Julia >= 1.6 and passing `ansicolor=true` to `Documenter.HTML` (e.g. `makedocs(format=Documenter.HTML(ansicolor=true, ...), ...)`). In Documenter 0.28.0 this will be the default so to (preemptively) opt-out pass `ansicolor=false`. ([#1441][github-1441])
+
 ## Version `v0.27.3`
 
 * ![Feature][badge-feature] Documenter can now deploy documentation directly to the "root" instead of versioned folders. ([#1615][github-1615], [#1616][github-1616])
@@ -784,6 +789,7 @@
 [github-1430]: https://github.com/JuliaDocs/Documenter.jl/pull/1430
 [github-1435]: https://github.com/JuliaDocs/Documenter.jl/pull/1435
 [github-1438]: https://github.com/JuliaDocs/Documenter.jl/issues/1438
+[github-1441]: https://github.com/JuliaDocs/Documenter.jl/pull/1441
 [github-1448]: https://github.com/JuliaDocs/Documenter.jl/pull/1448
 [github-1440]: https://github.com/JuliaDocs/Documenter.jl/pull/1440
 [github-1449]: https://github.com/JuliaDocs/Documenter.jl/issues/1449

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 version = "0.27.3"
 
 [deps]
+ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
@@ -17,6 +18,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
+ANSIColoredPrinters = "0.0.1"
 DocStringExtensions = "0.4, 0.5, 0.6, 0.7, 0.8"
 IOCapture = "0.2"
 JSON = "0.19, 0.20, 0.21"

--- a/assets/html/scss/documenter-dark.scss
+++ b/assets/html/scss/documenter-dark.scss
@@ -91,6 +91,8 @@ html.theme--#{$themename} {
   //   }
   // }
 
+  @import "documenter/ansicolors";
+
   // FIXME: Hack to get a proper theme for highlight.js in the Darkly theme
   @import "highlightjs/a11y-dark";
   // Also, a11y-dark does not highlight string interpolation properly.

--- a/assets/html/scss/documenter-light.scss
+++ b/assets/html/scss/documenter-light.scss
@@ -19,6 +19,8 @@
 @import "documenter/patches";
 @import "documenter/layout/all";
 
+@import "documenter/ansicolors";
+
 // Workaround to compile in highlightjs theme, so that we could have different
 // themes for both
 @import "highlightjs/default"

--- a/assets/html/scss/documenter/_ansicolors.scss
+++ b/assets/html/scss/documenter/_ansicolors.scss
@@ -1,0 +1,216 @@
+$ansi-black: $black-ter !default;
+$ansi-red: null !default;
+$ansi-green: null !default;
+$ansi-yellow: null !default;
+$ansi-blue: null !default;
+$ansi-magenta: null !default;
+$ansi-cyan: null !default;
+$ansi-white: $grey-lighter !default;
+
+$ansi-light-black: null !default;
+$ansi-light-red: null !default;
+$ansi-light-green: null !default;
+$ansi-light-yellow: null !default;
+$ansi-light-blue: null !default;
+$ansi-light-magenta: null !default;
+$ansi-light-cyan: null !default;
+$ansi-light-white: $white-ter !default;
+
+@if $documenter-is-dark-theme {
+  $ansi-red: $red !default;
+  $ansi-green: $green !default;
+  $ansi-yellow: $yellow !default;
+  $ansi-blue: $blue !default;
+  $ansi-magenta: $purple !default;
+  $ansi-cyan: $turquoise !default;
+
+  $ansi-light-black: $grey-light !default;
+
+  $ansi-light-red: lighten($ansi-red, 15) !default;
+  $ansi-light-green: lighten($ansi-green, 15) !default;
+  $ansi-light-yellow: lighten($ansi-yellow, 10) !default;
+  $ansi-light-blue: lighten($ansi-blue, 15) !default;
+  $ansi-light-magenta: lighten($ansi-magenta, 10) !default;
+  $ansi-light-cyan: lighten($ansi-cyan, 15) !default;
+}
+
+@else {
+  $ansi-light-red: $red !default;
+  $ansi-light-green: $green !default;
+  $ansi-light-yellow: $yellow !default;
+  $ansi-light-blue: $blue !default;
+  $ansi-light-magenta: $purple !default;
+  $ansi-light-cyan: $turquoise !default;
+
+  $ansi-light-black: $grey !default;
+
+  $ansi-red: darken($ansi-light-red, 10) !default;
+  $ansi-green: darken($ansi-light-green, 10) !default;
+  $ansi-yellow: darken($ansi-light-yellow, 18) !default;
+  $ansi-blue: darken($ansi-light-blue, 10) !default;
+  $ansi-magenta: darken($ansi-light-magenta, 15) !default;
+  $ansi-cyan: darken($ansi-light-cyan, 10) !default;
+}
+
+.ansi span {
+  &.sgr1 {
+    font-weight: bolder;
+  }
+
+  &.sgr2 {
+    font-weight: lighter;
+  }
+
+  &.sgr3 {
+    font-style: italic;
+  }
+
+  &.sgr4 {
+    text-decoration: underline;
+  }
+
+  &.sgr7 {
+    color: $body-background-color;
+    background-color: $text;
+  }
+
+  &.sgr8 {
+    color: transparent;
+
+    span {
+      color: transparent;
+    }
+  }
+
+  &.sgr9 {
+    text-decoration: line-through;
+  }
+
+  &.sgr30 {
+    color: $ansi-black;
+  }
+
+  &.sgr31 {
+    color: $ansi-red;
+  }
+
+  &.sgr32 {
+    color: $ansi-green;
+  }
+
+  &.sgr33 {
+    color: $ansi-yellow;
+  }
+
+  &.sgr34 {
+    color: $ansi-blue;
+  }
+
+  &.sgr35 {
+    color: $ansi-magenta;
+  }
+
+  &.sgr36 {
+    color: $ansi-cyan;
+  }
+
+  &.sgr37 {
+    color: $ansi-white;
+  }
+
+  &.sgr40 {
+    background-color: $ansi-black;
+  }
+
+  &.sgr41 {
+    background-color: $ansi-red;
+  }
+
+  &.sgr42 {
+    background-color: $ansi-green;
+  }
+
+  &.sgr43 {
+    background-color: $ansi-yellow;
+  }
+
+  &.sgr44 {
+    background-color: $ansi-blue;
+  }
+
+  &.sgr45 {
+    background-color: $ansi-magenta;
+  }
+
+  &.sgr46 {
+    background-color: $ansi-cyan;
+  }
+
+  &.sgr47 {
+    background-color: $ansi-white;
+  }
+
+  &.sgr90 {
+    color: $ansi-light-black;
+  }
+
+  &.sgr91 {
+    color: $ansi-light-red;
+  }
+
+  &.sgr92 {
+    color: $ansi-light-green;
+  }
+
+  &.sgr93 {
+    color: $ansi-light-yellow;
+  }
+
+  &.sgr94 {
+    color: $ansi-light-blue;
+  }
+
+  &.sgr95 {
+    color: $ansi-light-magenta;
+  }
+
+  &.sgr96 {
+    color: $ansi-light-cyan;
+  }
+
+  &.sgr97 {
+    color: $ansi-light-white;
+  }
+
+  &.sgr100 {
+    background-color: $ansi-light-black;
+  }
+
+  &.sgr101 {
+    background-color: $ansi-light-red;
+  }
+
+  &.sgr102 {
+    background-color: $ansi-light-green;
+  }
+
+  &.sgr103 {
+    background-color: $ansi-light-yellow;
+  }
+
+  &.sgr104 {
+    background-color: $ansi-light-blue;
+  }
+
+  &.sgr105 {
+    background-color: $ansi-light-magenta;
+  }
+
+  &.sgr106 {
+    background-color: $ansi-light-cyan;
+  }
+
+  &.sgr107 {
+    background-color: $ansi-light-white;
+  }
+}

--- a/assets/html/themes/documenter-dark.css
+++ b/assets/html/themes/documenter-dark.css
@@ -7604,6 +7604,87 @@ html.theme--documenter-dark {
     overflow-y: scroll;
     text-rendering: optimizeLegibility;
     text-size-adjust: 100%; }
+  html.theme--documenter-dark .ansi span.sgr1 {
+    font-weight: bolder; }
+  html.theme--documenter-dark .ansi span.sgr2 {
+    font-weight: lighter; }
+  html.theme--documenter-dark .ansi span.sgr3 {
+    font-style: italic; }
+  html.theme--documenter-dark .ansi span.sgr4 {
+    text-decoration: underline; }
+  html.theme--documenter-dark .ansi span.sgr7 {
+    color: #1f2424;
+    background-color: #fff; }
+  html.theme--documenter-dark .ansi span.sgr8 {
+    color: transparent; }
+    html.theme--documenter-dark .ansi span.sgr8 span {
+      color: transparent; }
+  html.theme--documenter-dark .ansi span.sgr9 {
+    text-decoration: line-through; }
+  html.theme--documenter-dark .ansi span.sgr30 {
+    color: #242424; }
+  html.theme--documenter-dark .ansi span.sgr31 {
+    color: #e74c3c; }
+  html.theme--documenter-dark .ansi span.sgr32 {
+    color: #2ecc71; }
+  html.theme--documenter-dark .ansi span.sgr33 {
+    color: #f1b70e; }
+  html.theme--documenter-dark .ansi span.sgr34 {
+    color: #3498db; }
+  html.theme--documenter-dark .ansi span.sgr35 {
+    color: #8e44ad; }
+  html.theme--documenter-dark .ansi span.sgr36 {
+    color: #137886; }
+  html.theme--documenter-dark .ansi span.sgr37 {
+    color: #dbdee0; }
+  html.theme--documenter-dark .ansi span.sgr40 {
+    background-color: #242424; }
+  html.theme--documenter-dark .ansi span.sgr41 {
+    background-color: #e74c3c; }
+  html.theme--documenter-dark .ansi span.sgr42 {
+    background-color: #2ecc71; }
+  html.theme--documenter-dark .ansi span.sgr43 {
+    background-color: #f1b70e; }
+  html.theme--documenter-dark .ansi span.sgr44 {
+    background-color: #3498db; }
+  html.theme--documenter-dark .ansi span.sgr45 {
+    background-color: #8e44ad; }
+  html.theme--documenter-dark .ansi span.sgr46 {
+    background-color: #137886; }
+  html.theme--documenter-dark .ansi span.sgr47 {
+    background-color: #dbdee0; }
+  html.theme--documenter-dark .ansi span.sgr90 {
+    color: #8c9b9d; }
+  html.theme--documenter-dark .ansi span.sgr91 {
+    color: #ef8b80; }
+  html.theme--documenter-dark .ansi span.sgr92 {
+    color: #69dd9a; }
+  html.theme--documenter-dark .ansi span.sgr93 {
+    color: #f4c53e; }
+  html.theme--documenter-dark .ansi span.sgr94 {
+    color: #75b9e7; }
+  html.theme--documenter-dark .ansi span.sgr95 {
+    color: #a563c1; }
+  html.theme--documenter-dark .ansi span.sgr96 {
+    color: #1db4c9; }
+  html.theme--documenter-dark .ansi span.sgr97 {
+    color: #ecf0f1; }
+  html.theme--documenter-dark .ansi span.sgr100 {
+    background-color: #8c9b9d; }
+  html.theme--documenter-dark .ansi span.sgr101 {
+    background-color: #ef8b80; }
+  html.theme--documenter-dark .ansi span.sgr102 {
+    background-color: #69dd9a; }
+  html.theme--documenter-dark .ansi span.sgr103 {
+    background-color: #f4c53e; }
+  html.theme--documenter-dark .ansi span.sgr104 {
+    background-color: #75b9e7; }
+  html.theme--documenter-dark .ansi span.sgr105 {
+    background-color: #a563c1; }
+  html.theme--documenter-dark .ansi span.sgr106 {
+    background-color: #1db4c9; }
+  html.theme--documenter-dark .ansi span.sgr107 {
+    background-color: #ecf0f1; }
   html.theme--documenter-dark .hljs {
     background: #2b2b2b;
     color: #f8f8f2; }

--- a/assets/html/themes/documenter-light.css
+++ b/assets/html/themes/documenter-light.css
@@ -7582,6 +7582,126 @@ html {
   #documenter .docs-main #documenter-search-results .docs-highlight {
     background-color: yellow; }
 
+.ansi span.sgr1 {
+  font-weight: bolder; }
+
+.ansi span.sgr2 {
+  font-weight: lighter; }
+
+.ansi span.sgr3 {
+  font-style: italic; }
+
+.ansi span.sgr4 {
+  text-decoration: underline; }
+
+.ansi span.sgr7 {
+  color: white;
+  background-color: #222222; }
+
+.ansi span.sgr8 {
+  color: transparent; }
+  .ansi span.sgr8 span {
+    color: transparent; }
+
+.ansi span.sgr9 {
+  text-decoration: line-through; }
+
+.ansi span.sgr30 {
+  color: #242424; }
+
+.ansi span.sgr31 {
+  color: #a70800; }
+
+.ansi span.sgr32 {
+  color: #1a9847; }
+
+.ansi span.sgr33 {
+  color: #fac800; }
+
+.ansi span.sgr34 {
+  color: #244d8f; }
+
+.ansi span.sgr35 {
+  color: #931fff; }
+
+.ansi span.sgr36 {
+  color: #178d9c; }
+
+.ansi span.sgr37 {
+  color: #dbdbdb; }
+
+.ansi span.sgr40 {
+  background-color: #242424; }
+
+.ansi span.sgr41 {
+  background-color: #a70800; }
+
+.ansi span.sgr42 {
+  background-color: #1a9847; }
+
+.ansi span.sgr43 {
+  background-color: #fac800; }
+
+.ansi span.sgr44 {
+  background-color: #244d8f; }
+
+.ansi span.sgr45 {
+  background-color: #931fff; }
+
+.ansi span.sgr46 {
+  background-color: #178d9c; }
+
+.ansi span.sgr47 {
+  background-color: #dbdbdb; }
+
+.ansi span.sgr90 {
+  color: #7a7a7a; }
+
+.ansi span.sgr91 {
+  color: #da0b00; }
+
+.ansi span.sgr92 {
+  color: #22c35b; }
+
+.ansi span.sgr93 {
+  color: #ffdd57; }
+
+.ansi span.sgr94 {
+  color: #2e63b8; }
+
+.ansi span.sgr95 {
+  color: #b86bff; }
+
+.ansi span.sgr96 {
+  color: #1db5c9; }
+
+.ansi span.sgr97 {
+  color: whitesmoke; }
+
+.ansi span.sgr100 {
+  background-color: #7a7a7a; }
+
+.ansi span.sgr101 {
+  background-color: #da0b00; }
+
+.ansi span.sgr102 {
+  background-color: #22c35b; }
+
+.ansi span.sgr103 {
+  background-color: #ffdd57; }
+
+.ansi span.sgr104 {
+  background-color: #2e63b8; }
+
+.ansi span.sgr105 {
+  background-color: #b86bff; }
+
+.ansi span.sgr106 {
+  background-color: #1db5c9; }
+
+.ansi span.sgr107 {
+  background-color: whitesmoke; }
+
 /*!
   Theme: Default
   Description: Original highlight.js style

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,6 +19,7 @@ makedocs(
         assets = ["assets/favicon.ico"],
         analytics = "UA-136089579-2",
         highlights = ["yaml"],
+        ansicolor = true,
     ),
     clean = false,
     sitename = "Documenter.jl",

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -477,6 +477,42 @@ draw(SVG("plot.svg", 6inch, 4inch), ans); nothing # hide
 ![](plot.svg)
 ````
 
+**Color output**
+
+`@example` blocks support colored text output by mapping [ANSI escape codes]
+(https://en.wikipedia.org/wiki/ANSI_escape_code) to HTML. For example, this block:
+````markdown
+```@example
+printstyled("Here are some colors:\n"; color=:red, bold=true)
+for color in 0:15
+    print("\e[38;5;$(color);48;5;$(color)m  ")
+    print("\e[49m", lpad(color, 3), " ")
+    color % 8 == 7 && println()
+end
+print("\e[m")
+```
+````
+results in the following input and output blocks:
+```@example
+printstyled("Here are some colors:\n"; color=:red, bold=true)
+for color in 0:15
+    print("\e[38;5;$(color);48;5;$(color)m  ")
+    print("\e[49m", lpad(color, 3), " ")
+    color % 8 == 7 && println()
+end
+print("\e[m")
+```
+
+!!! note "Disable color output"
+    To disable color output globally, pass `ansicolor=false` to [`Documenter.HTML`](@ref),
+    and to disable locally for the block, use `ansicolor=false`, like so:
+
+    ````markdown
+    ```@example; ansicolor=false
+    printstyled("hello, world"; color=:red, bold=true)
+    ```
+    ````
+
 **Delayed Execution of `@example` Blocks**
 
 `@example` blocks accept a keyword argument `continued` which can be set to `true` or `false`
@@ -548,6 +584,26 @@ ERROR: DomainError with -1.0:
 sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
 ```
 ````
+
+`@repl` blocks support colored output, just like `@example` blocks. The following block
+````markdown
+```@repl
+printstyled("hello, world"; color=:red, bold=true)
+```
+````
+gives
+```@repl
+printstyled("hello, world"; color=:red, bold=true)
+```
+!!! note "Disable color output"
+    To disable color output globally, pass `ansicolor=false` to [`Documenter.HTML`](@ref),
+    and to disable locally for the block, use `ansicolor=false`, like so:
+
+    ````markdown
+    ```@repl; ansicolor=false
+    printstyled("hello, world"; color=:red, bold=true)
+    ```
+    ````
 
 Named `@repl <name>` blocks behave in the same way as named `@example <name>` blocks.
 

--- a/docs/src/showcase.md
+++ b/docs/src/showcase.md
@@ -67,7 +67,7 @@ Finally, admonitions for notes, warnings and such:
     #### Heading 4
     ##### Heading 5
     ###### Heading 6
-    
+
 ###### Info admonition
 !!! info "'info' admonition"
     This is a `!!! info`-type admonition. This is the same as a `!!! note`-type.
@@ -358,6 +358,66 @@ However, do note that if the block prints to standard output, but also has a fin
 ```@example
 println("Hello World")
 42
+```
+
+### Color output
+
+Output from [`@repl` block](@ref)s and [`@example` block](@ref)s support colored output,
+tranforming ANSI color codes to HTML.
+
+!!! compat "Julia 1.6"
+    Color output requires Julia 1.6 or higher.
+    To enable color output pass `ansicolor=true` to [`Documenter.HTML`](@ref).
+
+#### Colored `@example` block output
+
+**Input:**
+````markdown
+```@example
+code_typed(sqrt, (Float64,))
+```
+````
+
+**Output:**
+```@example
+code_typed(sqrt, (Float64,))
+```
+
+#### Colored `@repl` block output
+
+**Input:**
+````markdown
+```@repl
+printstyled("This should be in bold light cyan.", color=:light_cyan, bold=true)
+```
+````
+
+**Output:**
+```@repl
+printstyled("This should be in bold cyan.", color=:cyan, bold=true)
+```
+
+**Locally disabled color:**
+````markdown
+```@repl; ansicolor=false
+printstyled("This should be in bold light cyan.", color=:light_cyan, bold=true)
+```
+````
+```@repl; ansicolor=false
+printstyled("This should be in bold light cyan.", color=:light_cyan, bold=true)
+```
+
+#### Raw ANSI code output
+
+Regardless of the color setting, when you print the ANSI escape codes directly, coloring is
+enabled.
+```@example
+for color in 0:15
+    print("\e[38;5;$color;48;5;$(color)m  ")
+    print("\e[49m", lpad(color, 3), " ")
+    color % 8 == 7 && println()
+end
+print("\e[m")
 ```
 
 ### REPL-type

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -58,6 +58,8 @@ using ...Utilities.JSDependencies: JSDependencies, json_jsescape
 import ...Utilities.DOM: DOM, Tag, @tags
 using ...Utilities.MDFlatten
 
+import ANSIColoredPrinters
+
 export HTML
 
 "Data attribute for the script inserting a wraning for outdated docs."
@@ -315,6 +317,8 @@ Default is `nothing`, in which case no canonical link is set.
 **`assets`** can be used to include additional assets (JS, CSS, ICO etc. files). See below
 for more information.
 
+**`ansicolor`** can be used to enable/disable colored output from `@repl` and `@example` blocks globally.
+
 **`sidebar_sitename`** determines whether the site name is shown in the sidebar or not.
 Setting it to `false` can be useful when the logo already contains the name of the package.
 Defaults to `true`.
@@ -388,6 +392,7 @@ struct HTML <: Documenter.Writer
     highlights    :: Vector{String}
     mathengine    :: Union{MathEngine,Nothing}
     footer        :: Union{Markdown.MD, Nothing}
+    ansicolor     :: Bool
     lang          :: String
     warn_outdated :: Bool
 
@@ -403,6 +408,7 @@ struct HTML <: Documenter.Writer
             highlights    :: Vector{String} = String[],
             mathengine    :: Union{MathEngine,Nothing} = KaTeX(),
             footer        :: Union{String, Nothing} = "Powered by [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl) and the [Julia Programming Language](https://julialang.org/).",
+            ansicolor     :: Bool = false, # true in 0.28
             # deprecated keywords
             edit_branch   :: Union{String, Nothing, Default} = Default(nothing),
             lang          :: String = "en",
@@ -434,7 +440,7 @@ struct HTML <: Documenter.Writer
         end
         isa(edit_link, Default) && (edit_link = edit_link[])
         new(prettyurls, disable_git, edit_link, canonical, assets, analytics,
-            collapselevel, sidebar_sitename, highlights, mathengine, footer, lang, warn_outdated)
+            collapselevel, sidebar_sitename, highlights, mathengine, footer, ansicolor, lang, warn_outdated)
     end
 end
 
@@ -493,6 +499,8 @@ module RD
             ["\$"],
             raw"""
             $(document).ready(function() {
+                hljs.configure({ignoreUnescapedHTML: true}); // for ANSI color support
+                /* TODO: add a plugin for unescaped HTML */
                 hljs.highlightAll();
             })
             """
@@ -1622,6 +1630,28 @@ function collect_subsections(page::Documents.Page)
     return sections
 end
 
+function domify_ansicoloredtext(text::AbstractString, class = "")
+    @tags pre
+    stack = DOM.Node[pre()] # this `pre` is dummy
+    function cb(io::IO, printer, tag::String, attrs::Dict{Symbol, String})
+        text = String(take!(io))
+        children = stack[end].nodes
+        isempty(text) || push!(children, Tag(Symbol("#RAW#"))(text))
+        if startswith(tag, "/")
+            pop!(stack)
+        else
+            parent = Tag(Symbol(tag))[attrs]
+            push!(children, parent)
+            push!(stack, parent)
+        end
+        return true
+    end
+    ansiclass = isempty(class) ? "ansi" : class * " ansi"
+    printer = ANSIColoredPrinters.HTMLPrinter(IOBuffer(text), callback = cb,
+                                              root_tag = "code", root_class = ansiclass)
+    show(IOBuffer(), MIME"text/html"(), printer)
+    return stack[1].nodes
+end
 
 # mdconvert
 # ------------------------------------------------------------------------------
@@ -1660,7 +1690,11 @@ function mdconvert(c::Markdown.Code, parent::MDBlockContext; kwargs...)
     @tags pre code
     language = Utilities.codelang(c.language)
     class = isempty(language) ? "nohighlight" : "language-$(language)"
-    pre(code[".$class"](c.code))
+    if language == "julia-repl"
+        return pre(domify_ansicoloredtext(c.code, class))
+    else
+        return pre(code[".$class"](c.code))
+    end
 end
 mdconvert(c::Markdown.Code, parent; kwargs...) = Tag(:code)(c.code)
 
@@ -1855,7 +1889,8 @@ function mdconvert(d::Dict{MIME,Any}, parent; kwargs...)
         out = Markdown.parse(d[MIME"text/markdown"()])
     elseif haskey(d, MIME"text/plain"())
         @tags pre
-        return pre[".documenter-example-output"](d[MIME"text/plain"()])
+        text = d[MIME"text/plain"()]
+        return pre[".documenter-example-output"](domify_ansicoloredtext(text, "nohighlight"))
     else
         error("this should never happen.")
     end

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -59,6 +59,8 @@ import ...Documenter:
 
 import Markdown
 
+import ANSIColoredPrinters
+
 mutable struct Context{I <: IO} <: IO
     io::I
     in_header::Bool
@@ -400,7 +402,9 @@ function latex(io::IO, d::Dict{MIME,Any})
     elseif haskey(d, MIME"text/markdown"())
         latex(io, Markdown.parse(d[MIME"text/markdown"()]))
     elseif haskey(d, MIME"text/plain"())
-        latex(io, Markdown.Code(d[MIME"text/plain"()]))
+        text = d[MIME"text/plain"()]
+        out = repr(MIME"text/plain"(), ANSIColoredPrinters.PlainTextPrinter(IOBuffer(text)))
+        latex(io, Markdown.Code(out))
     else
         error("this should never happen.")
     end
@@ -446,6 +450,8 @@ function latex(io::IO, code::Markdown.Code)
     language = isempty(language) ? "none" :
         (language == "julia-repl") ? "jlcon" : # the julia-repl is called "jlcon" in Pygments
         language
+    text = IOBuffer(code.code)
+    code.code = repr(MIME"text/plain"(), ANSIColoredPrinters.PlainTextPrinter(text))
     escape = '⊻' ∈ code.code
     if language in LEXER
         _print(io, "\n\\begin{minted}")

--- a/src/Writers/MarkdownWriter.jl
+++ b/src/Writers/MarkdownWriter.jl
@@ -11,6 +11,8 @@ import ...Documenter:
     Documenter,
     Utilities
 
+import ANSIColoredPrinters
+
 # import Markdown as MarkdownStdlib
 module _Markdown
     import Markdown
@@ -181,7 +183,9 @@ function render(io::IO, mime::MIME"text/plain", d::Dict{MIME,Any}, page, doc)
             ![]($(filename).gif)
             """)
     elseif haskey(d, MIME"text/plain"())
-        render(io, mime, MarkdownStdlib.Code(d[MIME"text/plain"()]), page, doc)
+        text = d[MIME"text/plain"()]
+        out = repr(MIME"text/plain"(), ANSIColoredPrinters.PlainTextPrinter(IOBuffer(text)))
+        render(io, mime, MarkdownStdlib.Code(out), page, doc)
     else
         error("this should never happen.")
     end


### PR DESCRIPTION
This starts from a Discourse topic: https://discourse.julialang.org/t/how-do-i-enable-ansi-colored-text-output-within-documenter-jl/48398

This changes:
- ~add a new field / argument `ansicolor` to `User` / `makedocs()`~
  - ~for global setting~
- add support for a keyword argument `ansicolor` in the `@example` block
  - for per-block setting to overide the global setting
- use the `ansicolor` option for the `:color` I/O context property
- translate "text/plain" output with ANSI escape codes in `HTMLWriter`
- add styles for ANSI colors to the default themes

These changes allow you to colorize the lazy print objects in the `@example` output blocks.
![ansi2](https://user-images.githubusercontent.com/12679384/96405194-aebb7280-1217-11eb-80c4-d88025f18803.png)

However, there are some issues to be resolved.

I've put an ANSI escape code translator for HTML in a new package [`AnsiColoredPrinters.jl`](https://github.com/kimikage/AnsiColoredPrinters.jl) to make this feature work. The package is experimental and under development, and there are things left to be discussed before it is registered, including the name of the package. I won't refuse to contribute it as part of Documenter.jl, but I prefer to modularize the functionality into minimal packages.

The other is that currently there is no way to specify the `:color` I/O context property for output to `stdout` / `stderr`. (**Edit:** solved by https://github.com/JuliaDocs/IOCapture.jl/pull/1)
~This means that even if the `@example` or `@repl` code potentially supports ANSI colors, we cannot get the colored result.~

~Also, although `ansicolor` is `false` by default and is the responsibility of the user,~ we need to strip the ANSI escape codes if the output format does not support ANSI colors.  (This will be implemented soon.)

When the solutions for the above are found, we will need to discuss the compatibility with `highlight.js`, the theme for system 16 colors, etc.