### PR TITLE
Update links

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"
 
 [compat]
-DocumenterTools = "=0.1.6"
+DocumenterTools = "=0.1.8"

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -17,7 +17,7 @@ Feel free to nominate commits that should be backported by opening an issue. Req
 
 ### `release-*` branches
 
-  * Each new minor version `x.y.0` gets a branch called `release-x.y` (a [protected branch](https://help.github.com/en/github/administering-a-repository/about-protected-branches)).
+  * Each new minor version `x.y.0` gets a branch called `release-x.y` (a [protected branch](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/about-protected-branches)).
   * New versions are usually tagged only from the `release-x.y` branches.
   * For patch releases, changes get backported to the `release-x.y` branch via a single PR with the standard name "Backports for x.y.z" and label ["Type: Backport"](https://github.com/JuliaDocs/Documenter.jl/pulls?q=label%3A%22Type%3A+Backport%22). The PR message links to all the PRs that are providing commits to the backport. The PR gets merged as a merge commit (i.e. not squashed).
   * The old `release-*` branches may be removed once they have outlived their usefulness.

--- a/docs/src/man/examples.md
+++ b/docs/src/man/examples.md
@@ -36,7 +36,6 @@ Packages that have tagged versions available in the general Registry:
 - [Gadfly.jl](https://gadflyjl.org/stable/)
 - [GeoStats.jl](https://juliaearth.github.io/GeoStats.jl/stable/)
 - [Highlights.jl](https://juliadocs.github.io/Highlights.jl/stable/)
-- [IntervalConstraintProgramming.jl](https://juliaintervals.github.io/IntervalConstraintProgramming.jl/stable/)
 - [Luxor.jl](https://juliagraphics.github.io/Luxor.jl/stable/)
 - [MergedMethods.jl](https://michaelhatherly.github.io/MergedMethods.jl/stable/)
 - [Mimi.jl](https://www.mimiframework.org/Mimi.jl/stable/)
@@ -56,7 +55,7 @@ Packages that have tagged versions available in the general Registry:
 Some projects or organizations maintain dedicated documentation repositories that are
 separate from specific packages.
 
-- [DifferentialEquations.jl](https://docs.sciml.ai/dev/)
+- [DifferentialEquations.jl](https://diffeq.sciml.ai/dev/)
 - [JuliaDocs landing page](https://juliadocs.github.io/dev/)
 - [JuliaImages](https://juliaimages.org)
 - [JuliaMusic](https://juliamusic.github.io/JuliaMusic_documentation.jl/dev/)

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -207,9 +207,9 @@ jobs:
 which will install Julia, checkout the correct commit of your repository, and run the
 build of the documentation. The `julia-version:`, `julia-arch:` and `os:` entries decide
 the environment from which the docs are built and deployed. In the example above we will
-thus build and deploy the documentation from a ubuntu worker running Julia 1.2. For more
-information on how to setup a GitHub workflow see the manual for
-[Configuring a workflow](https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow).
+thus build and deploy the documentation from a ubuntu worker running Julia 1.4. For more
+information on how to setup a GitHub workflow see the manual:
+[Learn GitHub Actions](https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions).
 
 The commands in the lines in the `run:` section do the same as for Travis,
 see the previous section.
@@ -246,7 +246,7 @@ see the previous section.
 
 When running from GitHub Actions it is possible to authenticate using
 [the GitHub Actions authentication token
-(`GITHUB_TOKEN`)](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token). This is done by adding
+(`GITHUB_TOKEN`)](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow). This is done by adding
 
 ```yaml
 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -279,13 +279,13 @@ DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
 
 to the configuration file, as showed in the [previous section](@ref GitHub-Actions).
 See GitHub's manual for
-[Creating and using encrypted secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)
+[Encrypted secrets](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets)
 for more information.
 
 ### Add code coverage from documentation builds
 
 If you want code run during the documentation deployment to be covered by Codecov,
-you can edit the end of the docs part of your workflow configuration file so that 
+you can edit the end of the docs part of your workflow configuration file so that
 `docs/make.jl` is run with the `--code-coverage=user` flag and the coverage reports
 are uploaded to Codecov:
 
@@ -376,8 +376,9 @@ aware that Documenter may overwrite existing content without warning.
 If you wish to create the `gh-pages` branch manually that can be done following
 [these instructions](https://coderwall.com/p/0n3soa/create-a-disconnected-git-branch).
 
-You also need to make sure that you have "gh-pages branch" selected as [the source of the GitHub
-Pages site in your GitHub repository settings](https://help.github.com/en/github/working-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site),
+You also need to make sure that you have "gh-pages branch" selected as
+[the source of the GitHub Pages site in your GitHub repository
+settings](https://docs.github.com/en/free-pro-team@latest/github/working-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site),
 so that GitHub would actually serve the contents as a website.
 
 ## Documentation Versions

--- a/src/deployconfig.jl
+++ b/src/deployconfig.jl
@@ -272,7 +272,7 @@ when using the `GitHubActions` configuration:
    see the manual section for [GitHub Actions](@ref) for more information.
 
 The `GITHUB_*` variables are set automatically on GitHub Actions, see the
-[documentation](https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables).
+[documentation](https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables).
 """
 struct GitHubActions <: DeployConfig
     github_repository::String

--- a/test/themes/Project.toml
+++ b/test/themes/Project.toml
@@ -3,4 +3,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"
 
 [compat]
-DocumenterTools = "=0.1.6"
+DocumenterTools = "=0.1.8"


### PR DESCRIPTION
This fixes the Linkcheck errors with https://github.com/JuliaDocs/DocumenterTools.jl/pull/43.

The documentation of `InnervalConstraintProgramming.jl` seems to be no longer published in gh-pages due to a key error. The latest version of the documentation can be found in JuliaHub.

This is not an urgent issue and can be modified to reflect the circumstances.