### PR TITLE
Add the `throwerrors` keyword argument to `makedocs`

### DIFF
--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -220,6 +220,9 @@ determined from the source file path. E.g. for `src/foo.md` it is set to `build/
 
 Note that `workdir` does not affect doctests.
 
+**`throwerrors`** -- if set to `true`, [`makedocs`](@ref) will error if any of the
+`@example` or `@repl` blocks throws an exception. Default: `false`.
+
 ## Output formats
 **`format`** allows the output format to be specified. The default format is
 [`Documenter.HTML`](@ref) which creates a set of HTML files.

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -231,6 +231,7 @@ struct User
     authors :: String
     version :: String # version string used in the version selector by default
     highlightsig::Bool  # assume leading unlabeled code blocks in docstrings to be Julia.
+    throwerrors::Bool # throw an exception if any of the `@example` or `@repl` blocks throws an exception
 end
 
 """
@@ -286,6 +287,7 @@ function Document(plugins = nothing;
         authors  :: AbstractString   = "",
         version :: AbstractString    = "",
         highlightsig::Bool           = true,
+        throwerrors::Bool            = false,
         others...
     )
     Utilities.check_kwargs(others)
@@ -318,7 +320,8 @@ function Document(plugins = nothing;
         sitename,
         authors,
         version,
-        highlightsig
+        highlightsig,
+        throwerrors,
     )
     internal = Internal(
         Utilities.assetsdir(),

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -550,7 +550,7 @@ function Selectors.runner(::Type{ExampleBlocks}, x, page, doc)
             code = x.code
         end
         for (ex, str) in Utilities.parseblock(code, doc, page; keywords = false)
-            c = IOCapture.iocapture(throwerrors=false) do
+            c = IOCapture.iocapture(throwerrors=doc.user.throwerrors) do
                 cd(page.workdir) do
                     Core.eval(mod, ex)
                 end
@@ -612,7 +612,7 @@ function Selectors.runner(::Type{REPLBlocks}, x, page, doc)
             # see https://github.com/JuliaLang/julia/pull/33864
             ex = REPL.softscope!(ex)
         end
-        c = IOCapture.iocapture(throwerrors=false) do
+        c = IOCapture.iocapture(throwerrors=doc.user.throwerrors) do
             cd(page.workdir) do
                 Core.eval(mod, ex)
             end


### PR DESCRIPTION
This pull request adds the `throwerrors` keyword argument to `makedocs`.

If `throwerrors` is `true`, then `makedocs` will error if any of the `@example` or `@repl` blocks throws an exception. The default value is `throwerrors = false`. I have documented this as an experimental keyword argument. Please note: this option will apply globally to all `@example` and `@repl` blocks.

This is a non-breaking change.