### PR TITLE
If a `@example` block throws an exception, show the stacktrace in the warning message

### DIFF
--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -565,7 +565,7 @@ function Selectors.runner(::Type{ExampleBlocks}, x, page, doc)
                     ```$(x.language)
                     $(x.code)
                     ```
-                    """, c.value)
+                    """, exception=(c.value, c.backtrace))
                 page.mapping[x] = x
                 return
             end


### PR DESCRIPTION
Before this PR, if an `@example` block throws an exception, `makedocs` prints a warning message that includes:
1. The exception that was thrown

After this PR, if an `@example` block throws an exception, `makedocs` prints a warning message that includes:
1. The exception that was thrown
2. The stack trace

I would consider this to be a non-breaking change.