### PR TITLE
Empty Selector cache before running build pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * ![Bugfix][badge-bugfix] `Documenter.doctest` now correctly accepts the `doctestfilters` keyword, similar to `Documenter.makedocs`. ([#1364][github-1364], [#1435][github-1435])
 
+* ![Bugfix][badge-bugfix] The `Selectors.dispatch` function now uses a cache to avoid calling `subtypes` on selectors multiple times during a `makedocs` call to avoid slowdowns due to [`subtypes` being slow][julia-38079]. ([#1438][github-1438], [#1440][github-1440], [#1452][github-1452])
+
 ## Version `v0.25.2`
 
 * ![Deprecation][badge-deprecation] The `Documenter.MathJax` type, used to specify the mathematics rendering engine in the HTML output, is now deprecated in favor of `Documenter.MathJax2`. ([#1362][github-1362], [#1367][github-1367])
@@ -658,8 +660,13 @@
 [github-1400]: https://github.com/JuliaDocs/Documenter.jl/pull/1400
 [github-1428]: https://github.com/JuliaDocs/Documenter.jl/issues/1428
 [github-1430]: https://github.com/JuliaDocs/Documenter.jl/pull/1430
+[github-1438]: https://github.com/JuliaDocs/Documenter.jl/issues/1438
 [github-1364]: https://github.com/JuliaDocs/Documenter.jl/issues/1364
 [github-1435]: https://github.com/JuliaDocs/Documenter.jl/pull/1435
+[github-1440]: https://github.com/JuliaDocs/Documenter.jl/pull/1440
+[github-1452]: https://github.com/JuliaDocs/Documenter.jl/pull/1452
+
+[julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl
 [documentermarkdown]: https://github.com/JuliaDocs/DocumenterMarkdown.jl

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -237,6 +237,10 @@ in the [setup guide in the manual](@ref Package-Guide).
 """
 function makedocs(components...; debug = false, format = HTML(), kwargs...)
     document = Documents.Document(components; format=format, kwargs...)
+    # Before starting the build pipeline, we empty out the subtype cache used by
+    # Selectors.dispatch. This is to make sure that we pick up any new selector stages that
+    # may have been added to the selector pipelines between makedocs calls.
+    empty!(Selectors.selector_subtypes)
     cd(document.user.root) do
         Selectors.dispatch(Builder.DocumentPipeline, document)
     end


### PR DESCRIPTION
Small follow-up to #1440, to make sure that we would retain the feature where you can add selector stages between `makedocs` calls.

Just to make it concrete, with the current master the `DummyBuildStage` warning does not get printed if you run the following (but does work pre-#1440):

```julia
using Documenter: Documenter, makedocs, Selectors
makedocs(sitename = "foo")
abstract type DummyBuildStage <: Documenter.Builder.DocumentPipeline end
Selectors.order(::Type{DummyBuildStage}) = 2.5
Selectors.runner(::Type{DummyBuildStage}, args...) = @warn "DummyBuildStage"
makedocs(sitename = "foo")
```

@epatters I believe this should not affect the Catlab build times?

Close #1438