### PR TITLE
Do not capture interrupts with iocapture()

### DIFF
--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -217,7 +217,7 @@ function eval_repl(block, sandbox, meta::Dict, doc::Documents.Document, page)
                 # see https://github.com/JuliaLang/julia/pull/33864
                 ex = REPL.softscope!(ex)
             end
-            c = IOCapture.iocapture(throwerrors=false) do
+            c = IOCapture.iocapture(throwerrors = :interrupt) do
                 Core.eval(sandbox, ex)
             end
             Core.eval(sandbox, Expr(:global, Expr(:(=), :ans, QuoteNode(c.value))))
@@ -244,7 +244,7 @@ function eval_script(block, sandbox, meta::Dict, doc::Documents.Document, page)
     output = lstrip(output, '\n')
     result = Result(block, input, output, meta[:CurrentFile])
     for (ex, str) in Utilities.parseblock(input, doc, page; keywords = false, raise=false)
-        c = IOCapture.iocapture(throwerrors=false) do
+        c = IOCapture.iocapture(throwerrors = :interrupt) do
             Core.eval(sandbox, ex)
         end
         result.value = c.value

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -550,7 +550,7 @@ function Selectors.runner(::Type{ExampleBlocks}, x, page, doc)
             code = x.code
         end
         for (ex, str) in Utilities.parseblock(code, doc, page; keywords = false)
-            c = IOCapture.iocapture(throwerrors=false) do
+            c = IOCapture.iocapture(throwerrors = :interrupt) do
                 cd(page.workdir) do
                     Core.eval(mod, ex)
                 end
@@ -612,7 +612,7 @@ function Selectors.runner(::Type{REPLBlocks}, x, page, doc)
             # see https://github.com/JuliaLang/julia/pull/33864
             ex = REPL.softscope!(ex)
         end
-        c = IOCapture.iocapture(throwerrors=false) do
+        c = IOCapture.iocapture(throwerrors = :interrupt) do
             cd(page.workdir) do
                 Core.eval(mod, ex)
             end

--- a/test/TestUtilities.jl
+++ b/test/TestUtilities.jl
@@ -19,7 +19,7 @@ function Base.showerror(io::IO, e::QuietlyException)
 end
 
 function _quietly(f, expr, source)
-    c = IOCapture.iocapture(f; throwerrors=false)
+    c = IOCapture.iocapture(f; throwerrors = :interrupt)
     haskey(ENV, "DOCUMENTER_TEST_QUIETLY") && open(QUIETLY_LOG; write=true, append=true) do io
         println(io, "@quietly: c.error = $(c.error) / $(sizeof(c.output)) bytes of output captured")
         println(io, "@quietly: $(source.file):$(source.line)")

--- a/test/doctests/doctestapi.jl
+++ b/test/doctests/doctestapi.jl
@@ -15,7 +15,7 @@ import IOCapture
 # ------------------------------------
 function run_doctest(f, args...; kwargs...)
     (result, success, backtrace, output) =
-    c = IOCapture.iocapture(throwerrors=false) do
+    c = IOCapture.iocapture(throwerrors = :interrupt) do
         # Running inside a Task to make sure that the parent testsets do not interfere.
         t = Task(() -> doctest(args...; kwargs...))
         schedule(t)

--- a/test/doctests/doctests.jl
+++ b/test/doctests/doctests.jl
@@ -30,7 +30,7 @@ function run_makedocs(f, mdfiles, modules=Module[]; kwargs...)
         cp(joinpath(@__DIR__, "src", mdfile), joinpath(srcdir, mdfile))
     end
 
-    c = IOCapture.iocapture(throwerrors=false) do
+    c = IOCapture.iocapture(throwerrors = :interrupt) do
         makedocs(
             sitename = " ",
             root = dir,


### PR DESCRIPTION
Fixes a behaviour change introduced in #1422.