### PR TITLE
Respect user preference for color scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * ![Enhancement][badge-enhancement] Documenter now support Azure DevOps Repos URL scheme when generating edit and source links pointing to the repository. ([#1462][github-1462], [#1463][github-1463], [#1471][github-1471])
 
+* ![Enhancement][badge-enhancement] The HTML front end now respects the user's OS-level dark theme preference (determined via the `prefers-color-scheme: dark` media query). ([#1320][github-1320], [#1456][github-1456])
+
 ## Version `v0.25.4`
 
 * ![Feature][badge-feature] Documenter can now deploy from Buildkite CI to GitHub Pages with `Documenter.Buildkite`. ([#1469][github-1469])
@@ -657,6 +659,7 @@
 [github-1307]: https://github.com/JuliaDocs/Documenter.jl/pull/1307
 [github-1310]: https://github.com/JuliaDocs/Documenter.jl/pull/1310
 [github-1315]: https://github.com/JuliaDocs/Documenter.jl/pull/1315
+[github-1320]: https://github.com/JuliaDocs/Documenter.jl/issues/1320
 [github-1323]: https://github.com/JuliaDocs/Documenter.jl/pull/1323
 [github-1328]: https://github.com/JuliaDocs/Documenter.jl/pull/1328
 [github-1337]: https://github.com/JuliaDocs/Documenter.jl/issues/1337
@@ -687,6 +690,7 @@
 [github-1448]: https://github.com/JuliaDocs/Documenter.jl/pull/1448
 [github-1440]: https://github.com/JuliaDocs/Documenter.jl/pull/1440
 [github-1452]: https://github.com/JuliaDocs/Documenter.jl/pull/1452
+[github-1456]: https://github.com/JuliaDocs/Documenter.jl/pull/1456
 [github-1462]: https://github.com/JuliaDocs/Documenter.jl/issues/1462
 [github-1463]: https://github.com/JuliaDocs/Documenter.jl/pull/1463
 [github-1466]: https://github.com/JuliaDocs/Documenter.jl/issues/1466

--- a/assets/html/js/themes.js
+++ b/assets/html/js/themes.js
@@ -48,6 +48,10 @@ $(document).ready(function() {
       $('#documenter-themepicker option').each(function(i,e) {
         e.selected = (e.value === theme);
       })
+    } else {
+      $('#documenter-themepicker option').each(function(i,e) {
+        e.selected = $("html").hasClass(`theme--${e.value}`);
+      })
     }
   }
 })

--- a/assets/html/themeswap.js
+++ b/assets/html/themeswap.js
@@ -7,11 +7,9 @@ function set_theme_from_local_storage() {
   var theme =  window.localStorage.getItem("documenter-theme");
   // Check if the browser supports user color preference
   var darkPreference = false;
-  if(window.matchMedia('(prefers-color-scheme: dark)').media !== 'not all') {
-    // Check if the users preference is for dark color scheme
-    if(window.matchMedia('(prefers-color-scheme: dark)').matches === true) {
-      darkPreference = true;
-    }
+  // Check if the users preference is for dark color scheme
+  if(window.matchMedia('(prefers-color-scheme: dark)').matches === true) {
+    darkPreference = true;
   }
   // Initialize a few variables for the loop:
   //
@@ -33,8 +31,10 @@ function set_theme_from_local_storage() {
     // To distinguish the default (primary) theme, it needs to have the data-theme-primary
     // attribute set.
     var isprimary = (ss.ownerNode.getAttribute("data-theme-primary") !== null);
-    // If the ss is not primary then use it if the user's preference is towards dark colors
-    if(!isprimary) darkTheme = themename;
+    // Check if the theme is primary dark theme
+    var isDarkTheme = (ss.ownerNode.getAttribute("dark-theme-primary") !== null);
+    // Use ss is for dark theme then set the value of darkTheme
+    if(isDarkTheme) darkTheme = themename;
     // If we find a matching theme (and it's not the default), we'll set active to non-null
     if(themename === theme) active = i;
     // Store the style sheets of inactive themes so that we could disable them
@@ -48,7 +48,7 @@ function set_theme_from_local_storage() {
       ss.disabled = true;
     });
   }
-  else if(darkTheme !== null) {
+  else if(isDarkTheme !== null && darkPreference === true) {
     // If we did find an active theme, we'll (1) add the theme--$(theme) class to <html>
     document.getElementsByTagName('html')[0].className = "theme--" + darkTheme;
     // and (2) disable all the other theme stylesheets
@@ -57,12 +57,6 @@ function set_theme_from_local_storage() {
         ss.disabled = true;
       }
     });
-    // Store the theme in localStorage
-    if(typeof(window.localStorage) !== "undefined") {
-      window.localStorage.setItem("documenter-theme", darkTheme);
-    } else {
-      console.error("Browser does not support window.localStorage");
-    }
   }
 }
 set_theme_from_local_storage();

--- a/assets/html/themeswap.js
+++ b/assets/html/themeswap.js
@@ -1,10 +1,14 @@
 // Small function to quickly swap out themes. Gets put into the <head> tag..
 function set_theme_from_local_storage() {
-  // Browser does not support Web Storage, bail early.
-  if(typeof(window.localStorage) === "undefined") return;
-  // Get the user-picked theme from localStorage. May be `null`, which means the default
-  // theme.
-  var theme =  window.localStorage.getItem("documenter-theme");
+  // Intialize the theme to null, which means default
+  var theme = null;
+  // If the browser supports the localstorage and is not disabled then try to get the
+  // documenter theme
+  if(typeof(window.localStorage) != null) {
+    // Get the user-picked theme from localStorage. May be `null`, which means the default
+    // theme.
+    theme =  window.localStorage.getItem("documenter-theme");
+  }
   // Check if the browser supports user color preference
   var darkPreference = false;
   // Check if the users preference is for dark color scheme
@@ -32,8 +36,8 @@ function set_theme_from_local_storage() {
     // attribute set.
     var isprimary = (ss.ownerNode.getAttribute("data-theme-primary") !== null);
     // Check if the theme is primary dark theme
-    var isDarkTheme = (ss.ownerNode.getAttribute("dark-theme-primary") !== null);
-    // Use ss is for dark theme then set the value of darkTheme
+    var isDarkTheme = (ss.ownerNode.getAttribute("data-theme-primary-dark") !== null);
+    // If ss is for dark theme then set the value of darkTheme to the name of the theme
     if(isDarkTheme) darkTheme = themename;
     // If we find a matching theme (and it's not the default), we'll set active to non-null
     if(themename === theme) active = i;
@@ -48,7 +52,7 @@ function set_theme_from_local_storage() {
       ss.disabled = true;
     });
   }
-  else if(isDarkTheme !== null && darkPreference === true) {
+  else if(darkTheme !== null && darkPreference === true) {
     // If we did find an active theme, we'll (1) add the theme--$(theme) class to <html>
     document.getElementsByTagName('html')[0].className = "theme--" + darkTheme;
     // and (2) disable all the other theme stylesheets

--- a/assets/html/themeswap.js
+++ b/assets/html/themeswap.js
@@ -5,6 +5,14 @@ function set_theme_from_local_storage() {
   // Get the user-picked theme from localStorage. May be `null`, which means the default
   // theme.
   var theme =  window.localStorage.getItem("documenter-theme");
+  // Check if the browser supports user color preference
+  var darkPreference = false;
+  if(window.matchMedia('(prefers-color-scheme: dark)').media !== 'not all') {
+    // Check if the users preference is for dark color scheme
+    if(window.matchMedia('(prefers-color-scheme: dark)').matches === true) {
+      darkPreference = true;
+    }
+  }
   // Initialize a few variables for the loop:
   //
   //  - active: will contain the index of the theme that should be active. Note that there
@@ -14,7 +22,7 @@ function set_theme_from_local_storage() {
   //
   //  - disabled: style sheets that should be disabled (i.e. all the theme style sheets
   //    that are not the currently active theme)
-  var active = null; var disabled = [];
+  var active = null; var disabled = []; var darkTheme = null;
   for (var i = 0; i < document.styleSheets.length; i++) {
     var ss = document.styleSheets[i];
     // The <link> tag of each style sheet is expected to have a data-theme-name attribute
@@ -25,8 +33,10 @@ function set_theme_from_local_storage() {
     // To distinguish the default (primary) theme, it needs to have the data-theme-primary
     // attribute set.
     var isprimary = (ss.ownerNode.getAttribute("data-theme-primary") !== null);
+    // If the ss is not primary then use it if the user's preference is towards dark colors
+    if(!isprimary) darkTheme = themename;
     // If we find a matching theme (and it's not the default), we'll set active to non-null
-    if(!isprimary && themename === theme) active = i;
+    if(themename === theme) active = i;
     // Store the style sheets of inactive themes so that we could disable them
     if(themename !== theme) disabled.push(ss);
   }
@@ -37,6 +47,22 @@ function set_theme_from_local_storage() {
     disabled.forEach(function(ss){
       ss.disabled = true;
     });
+  }
+  else if(darkTheme !== null) {
+    // If we did find an active theme, we'll (1) add the theme--$(theme) class to <html>
+    document.getElementsByTagName('html')[0].className = "theme--" + darkTheme;
+    // and (2) disable all the other theme stylesheets
+    disabled.forEach(function(ss){
+      if (ss.ownerNode.getAttribute("data-theme-name") !== darkTheme) {
+        ss.disabled = true;
+      }
+    });
+    // Store the theme in localStorage
+    if(typeof(window.localStorage) !== "undefined") {
+      window.localStorage.setItem("documenter-theme", darkTheme);
+    } else {
+      console.error("Browser does not support window.localStorage");
+    }
   }
 }
 set_theme_from_local_storage();

--- a/assets/html/themeswap.js
+++ b/assets/html/themeswap.js
@@ -4,7 +4,7 @@ function set_theme_from_local_storage() {
   var theme = null;
   // If the browser supports the localstorage and is not disabled then try to get the
   // documenter theme
-  if(typeof(window.localStorage) != null) {
+  if(window.localStorage != null) {
     // Get the user-picked theme from localStorage. May be `null`, which means the default
     // theme.
     theme =  window.localStorage.getItem("documenter-theme");

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -856,7 +856,7 @@ function render_head(ctx, navnode)
                 Symbol("data-theme-name") => theme,
             ]
             (i == 1) && push!(e.attributes, Symbol("data-theme-primary") => "")
-            (i == 2) && push!(e.attributes, Symbol("dark-theme-primary") => "")
+            (i == 2) && push!(e.attributes, Symbol("data-theme-primary-dark") => "")
             return e
         end,
         script[:src => relhref(src, ctx.themeswap_js)],

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -856,6 +856,7 @@ function render_head(ctx, navnode)
                 Symbol("data-theme-name") => theme,
             ]
             (i == 1) && push!(e.attributes, Symbol("data-theme-primary") => "")
+            (i == 2) && push!(e.attributes, Symbol("dark-theme-primary") => "")
             return e
         end,
         script[:src => relhref(src, ctx.themeswap_js)],


### PR DESCRIPTION
Automatically switches to 'non-primary' theme if user prefers dark scheme.
If there is a theme specified in the local storage then that takes more preference over this.

Closes https://github.com/JuliaDocs/Documenter.jl/issues/1320