### PR TITLE
Remove duplicate footnotes for HTML pages

### DIFF
--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1158,6 +1158,17 @@ end
 
 # Article (page contents)
 # ------------------------------------------------------------------------------
+function unique_footnotes(footnotes)
+    unique_ids = Int[]
+    unique_footnotes = String[]
+    for (i, fn) in enumerate(footnotes)
+        if fn.id ∉ unique_footnotes
+            push!(unique_ids, i)
+            push!(unique_footnotes, fn.id)
+        end
+    end
+    return footnotes[unique_ids]
+end
 
 function render_article(ctx, navnode)
     @tags article section ul li hr span a div p
@@ -1167,7 +1178,8 @@ function render_article(ctx, navnode)
     art_body = article["#documenter-page.content"](domify(ctx, navnode))
     # Footnotes, if there are any
     if !isempty(ctx.footnotes)
-        fnotes = map(ctx.footnotes) do f
+        # remove duplicate footnotes (if there are any duplicates), then process them
+        fnotes = map(unique_footnotes(ctx.footnotes)) do f
             fid = "footnote-$(f.id)"
             citerefid = "citeref-$(f.id)"
             if length(f.text) == 1 && first(f.text) isa Markdown.Paragraph


### PR DESCRIPTION
## Issue 

Identical footnote IDs appearing multiple times in a docstring, or in different docstrings that are collected on the same HTML page, are rendered multiple times in the footnote list at the bottom of the HTML page. 

### Example

In [this documentation page](https://kahaaga.github.io/Entropies.jl/dev/generalized_entropy/), the footnote `[^Rényi1960]` appears four times in different methods.  This is caught by the doc checks:

```julia
Warning: footnote 'Rényi1960' has 4 bodies in src/generalized_entropy.md
```

but in the footnote list in the rendered HTML, duplicates are not handled:

<img width="838" alt="Skjermbilde 2020-11-07 kl  13 52 59" src="https://user-images.githubusercontent.com/5237566/98441806-f0e22080-2100-11eb-98a4-8300410b0d6b.png">


Multiple docstrings that reference the same footnote should be possible to render on the same page without filling the footnote list with duplicates.

## Solution
If there are any footnotes, this PR adds a simple check for duplicate footnote IDs. Any footnotes with duplicate IDs are removed. 


After this PR, the example above renders as follows.
<img width="835" alt="Skjermbilde 2020-11-07 kl  13 52 55" src="https://user-images.githubusercontent.com/5237566/98441814-fd667900-2100-11eb-8ddc-aaae6524a43f.png">

When running the doc checks, warnings about duplicate footnotes are still given, but any duplicates are removed from the final HTML.