### PR TITLE
Add page title to search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * ![Enhancement][badge-enhancement] Objects that render as equations and whose `text/latex` representations are wrapped in display equation delimiters `\[ ... \]` or `$$ ... $$` are now handled correctly in the HTML output. ([#1278][github-1278], [#1283][github-1283], [#1426][github-1426])
 
+* ![Enhancement][badge-enhancement] The search page in the HTML output now shows the page titles in the search results. ([#1468][github-1468])
+
 ## Version `v0.25.3`
 
 * ![Feature][badge-feature] Documenter can now deploy from GitLab CI to GitHub Pages with `Documenter.GitLab`. ([#1448][github-1448])
@@ -675,6 +677,7 @@
 [github-1448]: https://github.com/JuliaDocs/Documenter.jl/pull/1448
 [github-1440]: https://github.com/JuliaDocs/Documenter.jl/pull/1440
 [github-1452]: https://github.com/JuliaDocs/Documenter.jl/pull/1452
+[github-1468]: https://github.com/JuliaDocs/Documenter.jl/pull/1468
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 

--- a/assets/html/search.js
+++ b/assets/html/search.js
@@ -173,7 +173,7 @@ $(document).ready(function() {
   var store = {}
 
   documenterSearchIndex['docs'].forEach(function(e) {
-      store[e.location] = {title: e.title, category: e.category}
+      store[e.location] = {title: e.title, category: e.category, page: e.page}
   })
 
   $(function(){
@@ -213,7 +213,11 @@ $(document).ready(function() {
         data = store[result.ref]
         link = $('<a class="docs-label">'+data.title+'</a>')
         link.attr('href', documenterBaseURL+'/'+result.ref)
-        cat = $('<span class="docs-category">('+data.category+')</span>')
+        if (data.category != "page"){
+          cat = $('<span class="docs-category">('+data.category+', '+data.page+')</span>')
+        } else {
+          cat = $('<span class="docs-category">('+data.category+')</span>')
+        }
         li = $('<li>').append(link).append(" ").append(cat)
         searchresults.append(li)
       })


### PR DESCRIPTION
With multiple dispatch, often the context of a method name is lost in the search results. `rounding` is a good example, where 5 of the top 8 results will land you in the `Dates` section

Current behavior:
![image](https://user-images.githubusercontent.com/1694067/98628095-c0a6a780-22e3-11eb-8a13-597c8cd5deb9.png)

This PR:

![image](https://user-images.githubusercontent.com/1694067/98628014-8c32eb80-22e3-11eb-992f-b9802cb33c75.png)

I did wonder about whether the page name should preceded the result, or whether there was a nicer way to format it in its current form