### PR TITLE
Add support for deploying from Buildkite.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Version `v0.26.0`
 
+* ![Feature][badge-feature] Documenter can now deploy from Buildkite CI to GitHub Pages with `Documenter.Buildkite`. ([#1469][github-1469])
+
 * ![Enhancement][badge-enhancement] Objects that render as equations and whose `text/latex` representations are wrapped in display equation delimiters `\[ ... \]` or `$$ ... $$` are now handled correctly in the HTML output. ([#1278][github-1278], [#1283][github-1283], [#1426][github-1426])
 
 ## Version `v0.25.3`
@@ -675,6 +677,7 @@
 [github-1448]: https://github.com/JuliaDocs/Documenter.jl/pull/1448
 [github-1440]: https://github.com/JuliaDocs/Documenter.jl/pull/1440
 [github-1452]: https://github.com/JuliaDocs/Documenter.jl/pull/1452
+[github-1469]: https://github.com/JuliaDocs/Documenter.jl/pull/1469
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ## Version `v0.26.0`
 
-* ![Feature][badge-feature] Documenter can now deploy from Buildkite CI to GitHub Pages with `Documenter.Buildkite`. ([#1469][github-1469])
-
 * ![Enhancement][badge-enhancement] Objects that render as equations and whose `text/latex` representations are wrapped in display equation delimiters `\[ ... \]` or `$$ ... $$` are now handled correctly in the HTML output. ([#1278][github-1278], [#1283][github-1283], [#1426][github-1426])
 
 * ![Enhancement][badge-enhancement] The search page in the HTML output now shows the page titles in the search results. ([#1468][github-1468])
 
 * ![Enhancement][badge-enhancement] Documenter now support Azure DevOps Repos URL scheme when generating edit and source links pointing to the repository. ([#1462][github-1462], [#1463][github-1463], [#1471][github-1471])
+
+## Version `v0.25.4`
+
+* ![Feature][badge-feature] Documenter can now deploy from Buildkite CI to GitHub Pages with `Documenter.Buildkite`. ([#1469][github-1469])
 
 ## Version `v0.25.3`
 

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -460,9 +460,9 @@ It is possible to customize Documenter to use other systems then the ones descri
 the sections above. This is done by passing a configuration
 (a [`DeployConfig`](@ref Documenter.DeployConfig)) to `deploydocs` by the `deploy_config`
 keyword argument. Documenter supports [`Travis`](@ref Documenter.Travis),
-[`GitHubActions`](@ref Documenter.GitHubActions), and [`GitLab`](@ref Documenter.GitLab)
-natively, but it is easy to define your own by following the simple interface
-described below.
+[`GitHubActions`](@ref Documenter.GitHubActions), [`GitLab`](@ref Documenter.GitLab), and
+[`Buildkite`](@ref Documenter.Buildkite) natively, but it is easy to define your own by
+following the simple interface described below.
 
 ```@docs
 Documenter.DeployConfig
@@ -475,4 +475,5 @@ Documenter.documenter_key_previews
 Documenter.Travis
 Documenter.GitHubActions
 Documenter.GitLab
+Documenter.Buildkite
 ```

--- a/src/deployconfig.jl
+++ b/src/deployconfig.jl
@@ -672,7 +672,7 @@ end
 
 function Buildkite()
     commit_branch = get(ENV, "BUILDKITE_BRANCH", "")
-    pull_request = get(ENV, "BUILDKITE_PULL_REQUEST", "")
+    pull_request = get(ENV, "BUILDKITE_PULL_REQUEST", "false")
     commit_tag = get(ENV, "BUILDKITE_TAG", "")
     Buildkite(commit_branch, pull_request, commit_tag)
 end
@@ -699,7 +699,7 @@ function deploy_folder(
     println(io, "  Pull request: \"", cfg.pull_request, "\"")
     println(io, "  Commit tag: \"", cfg.commit_tag, "\"")
 
-    build_type = if cfg.pull_request != ""
+    build_type = if cfg.pull_request != "false"
         :preview
     elseif cfg.commit_tag != ""
         :release

--- a/test/deployconfig.jl
+++ b/test/deployconfig.jl
@@ -383,6 +383,90 @@ end end
     end
 end end
 
+@testset "Buildkite CI deploy configuration" begin; with_logger(NullLogger()) do
+    # Regular tag build
+    withenv("BUILDKITE" => "true",
+            "BUILDKITE_BRANCH" => "master",
+            "BUILDKITE_PULL_REQUEST" => "",
+            "BUILDKITE_TAG" => "v1.2.3",
+            "DOCUMENTER_KEY" => "SGVsbG8sIHdvcmxkLg==",
+        ) do
+        cfg = Documenter.Buildkite()
+        d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
+                                     devbranch="master", devurl="dev", push_preview=true)
+        @test d.all_ok
+        @test d.subfolder == "v1.2.3"
+        @test d.repo == "github.com/JuliaDocs/Documenter.jl.git"
+        @test d.branch == "gh-pages"
+        @test Documenter.documenter_key(cfg) === "SGVsbG8sIHdvcmxkLg=="
+        @test Documenter.authentication_method(cfg) === Documenter.SSH
+    end
+    # Broken tag build
+    withenv("BUILDKITE" => "true",
+            "BUILDKITE_BRANCH" => "master",
+            "BUILDKITE_PULL_REQUEST" => "",
+            "BUILDKITE_TAG" => "not-a-version",
+            "DOCUMENTER_KEY" => "SGVsbG8sIHdvcmxkLg==",
+        ) do
+        cfg = Documenter.Buildkite()
+        d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
+                                     devbranch="master", devurl="dev", push_preview=true)
+        @test !d.all_ok
+    end
+    # Regular/broken devbranch build
+    withenv(
+            "BUILDKITE" => "true",
+            "BUILDKITE_BRANCH" => "master",
+            "BUILDKITE_PULL_REQUEST" => "",
+            "BUILDKITE_TAG" => nothing,
+            "DOCUMENTER_KEY" => "SGVsbG8sIHdvcmxkLg==",
+        ) do
+        cfg = Documenter.Buildkite()
+        d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
+                                     devbranch="master", devurl="hello-world", push_preview=true)
+        @test d.all_ok
+        @test d.subfolder == "hello-world"
+        @test d.repo == "github.com/JuliaDocs/Documenter.jl.git"
+        @test d.branch == "gh-pages"
+        d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
+                                     devbranch="not-master", devurl="hello-world", push_preview=true)
+        @test !d.all_ok
+        @test Documenter.documenter_key(cfg) === "SGVsbG8sIHdvcmxkLg=="
+    end
+    # Regular pull request build
+    withenv("BUILDKITE" => "true",
+            "BUILDKITE_BRANCH" => "something",
+            "BUILDKITE_PULL_REQUEST" => "42",
+            "BUILDKITE_TAG" => nothing,
+            "DOCUMENTER_KEY" => "SGVsbG8sIHdvcmxkLg==",
+        ) do
+        cfg = Documenter.Buildkite()
+        d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
+                                     devbranch="master", devurl="hello-world", push_preview=true)
+        @test d.all_ok
+        @test d.subfolder == "previews/PR42"
+        @test d.repo == "github.com/JuliaDocs/Documenter.jl.git"
+        @test d.branch == "gh-pages"
+        d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
+                                     devbranch="master", devurl="hello-world", push_preview=false)
+        @test !d.all_ok
+        @test Documenter.documenter_key(cfg) === "SGVsbG8sIHdvcmxkLg=="
+    end
+    # Missing/broken environment variables
+    withenv(
+            "BUILDKITE" => "true",
+            "BUILDKITE_BRANCH" => "master",
+            "BUILDKITE_PULL_REQUEST" => "",
+            "BUILDKITE_TAG" => "v1.2.3",
+            "DOCUMENTER_KEY" => nothing,
+        ) do
+        cfg = Documenter.Buildkite()
+        d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
+                                     devbranch="master", devurl="hello-world", push_preview=false)
+        @test !d.all_ok
+    end
+end end
+
 struct CustomConfig <: Documenter.DeployConfig end
 Documenter.deploy_folder(::CustomConfig; kwargs...) = Documenter.DeployDecision(; all_ok = true, subfolder = "v1.2.3")
 struct BrokenConfig <: Documenter.DeployConfig end

--- a/test/deployconfig.jl
+++ b/test/deployconfig.jl
@@ -387,7 +387,7 @@ end end
     # Regular tag build
     withenv("BUILDKITE" => "true",
             "BUILDKITE_BRANCH" => "master",
-            "BUILDKITE_PULL_REQUEST" => "",
+            "BUILDKITE_PULL_REQUEST" => "false",
             "BUILDKITE_TAG" => "v1.2.3",
             "DOCUMENTER_KEY" => "SGVsbG8sIHdvcmxkLg==",
         ) do
@@ -404,7 +404,7 @@ end end
     # Broken tag build
     withenv("BUILDKITE" => "true",
             "BUILDKITE_BRANCH" => "master",
-            "BUILDKITE_PULL_REQUEST" => "",
+            "BUILDKITE_PULL_REQUEST" => "false",
             "BUILDKITE_TAG" => "not-a-version",
             "DOCUMENTER_KEY" => "SGVsbG8sIHdvcmxkLg==",
         ) do
@@ -417,7 +417,7 @@ end end
     withenv(
             "BUILDKITE" => "true",
             "BUILDKITE_BRANCH" => "master",
-            "BUILDKITE_PULL_REQUEST" => "",
+            "BUILDKITE_PULL_REQUEST" => "false",
             "BUILDKITE_TAG" => nothing,
             "DOCUMENTER_KEY" => "SGVsbG8sIHdvcmxkLg==",
         ) do
@@ -456,7 +456,7 @@ end end
     withenv(
             "BUILDKITE" => "true",
             "BUILDKITE_BRANCH" => "master",
-            "BUILDKITE_PULL_REQUEST" => "",
+            "BUILDKITE_PULL_REQUEST" => "false",
             "BUILDKITE_TAG" => "v1.2.3",
             "DOCUMENTER_KEY" => nothing,
         ) do


### PR DESCRIPTION
Modeled after GitLab, but I left out the slug and source since they seemed unused anyway.
Example of successful run: https://buildkite.com/julialang/cuda-dot-jl/builds/116