### PR TITLE
Stop warning for mailto: links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 * ![Bugfix][badge-bugfix] Type aliases of `Union`s (e.g. `const MyAlias = Union{Foo,Bar}`) are now correctly listed as "Type" in docstrings. ([#1466][github-1466], [#1474][github-1474])
 
+* ![Bugfix][badge-bugfix] HTMLWriter no longers prints a warning when encountering `mailto:` URLs in links. ([#1472][github-1472])
+
 ## Version `v0.25.3`
 
 * ![Feature][badge-feature] Documenter can now deploy from GitLab CI to GitHub Pages with `Documenter.GitLab`. ([#1448][github-1448])
@@ -691,6 +693,7 @@
 [github-1468]: https://github.com/JuliaDocs/Documenter.jl/pull/1468
 [github-1469]: https://github.com/JuliaDocs/Documenter.jl/pull/1469
 [github-1471]: https://github.com/JuliaDocs/Documenter.jl/pull/1471
+[github-1472]: https://github.com/JuliaDocs/Documenter.jl/pull/1472
 [github-1474]: https://github.com/JuliaDocs/Documenter.jl/pull/1474
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1786,6 +1786,9 @@ function fixlinks!(ctx, navnode, link::Markdown.Link)
     fixlinks!(ctx, navnode, link.text)
     Utilities.isabsurl(link.url) && return
 
+    # anything starting with mailto: doesn't need fixing
+    startswith(link.url, "mailto:") && return
+
     # links starting with a # are references within the same file -- there's nothing to fix
     # for such links
     startswith(link.url, '#') && return


### PR DESCRIPTION
Previously mailto: links got treated as a local link so triggered a warning