### PR TITLE
List Union{...} type aliases as "Type"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * ![Enhancement][badge-enhancement] The search page in the HTML output now shows the page titles in the search results. ([#1468][github-1468])
 
+* ![Bugfix][badge-bugfix] Type aliases of `Union`s (e.g. `const MyAlias = Union{Foo,Bar}`) are now correctly listed as "Type" in docstrings. ([#1466][github-1466], [#1474][github-1474])
+
 ## Version `v0.25.3`
 
 * ![Feature][badge-feature] Documenter can now deploy from GitLab CI to GitHub Pages with `Documenter.GitLab`. ([#1448][github-1448])
@@ -677,7 +679,9 @@
 [github-1448]: https://github.com/JuliaDocs/Documenter.jl/pull/1448
 [github-1440]: https://github.com/JuliaDocs/Documenter.jl/pull/1440
 [github-1452]: https://github.com/JuliaDocs/Documenter.jl/pull/1452
+[github-1466]: https://github.com/JuliaDocs/Documenter.jl/issues/1466
 [github-1468]: https://github.com/JuliaDocs/Documenter.jl/pull/1468
+[github-1474]: https://github.com/JuliaDocs/Documenter.jl/pull/1474
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -257,7 +257,7 @@ end
 doccat(b::Binding, ::Type)  = "Method"
 
 doccat(::Function) = "Function"
-doccat(::DataType) = "Type"
+doccat(::Type)     = "Type"
 doccat(x::UnionAll) = doccat(Base.unwrap_unionall(x))
 doccat(::Module)   = "Module"
 doccat(::Any)      = "Constant"

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -27,6 +27,10 @@ module UnitTests
     f(x) = x
 
     const pi = 3.0
+
+    const TA = Vector{UInt128}
+    const TB = Array{T, 8} where T
+    const TC = Union{Int64, Float64, String}
 end
 
 module OuterModule
@@ -97,6 +101,9 @@ end
     @test Documenter.Utilities.doccat(UnitTests.S) == "Type"
     @test Documenter.Utilities.doccat(UnitTests.f) == "Function"
     @test Documenter.Utilities.doccat(UnitTests.pi) == "Constant"
+    @test Documenter.Utilities.doccat(UnitTests.TA) == "Type"
+    @test Documenter.Utilities.doccat(UnitTests.TB) == "Type"
+    @test Documenter.Utilities.doccat(UnitTests.TC) == "Type"
 
     # repo type
     @test Documenter.Utilities.repo_host_from_url("https://bitbucket.org/somerepo") == Documenter.Utilities.RepoBitbucket


### PR DESCRIPTION
So if you do `const MyAlias = Union{Foo,Bar}`, it will show up as a "Type" in the docstring heading (and not "Constant"). I don't think there's any reason not to dispatch on `::Type` here. Fix #1466.