### PR TITLE
Don't run additional build stages on nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ os:
   - osx
 
 julia:
-  - nightly
   - 1
   - 1.4
   - 1.0
+  - nightly
 
 branches:
   only:


### PR DESCRIPTION
It means that they all get the `allow_failures` flag as well and so failures don't show up in status checks.