### PR TITLE
Fix the tests on nightly

### DIFF
--- a/test/doctests/fix/broken.jl
+++ b/test/doctests/fix/broken.jl
@@ -1,7 +1,7 @@
 module Foo
 """
 ```jldoctest
-julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+julia> Main.DocTestFixArray_2468
 4×1×1 Array{Int64,3}:
 [:, :, 1] =
  1
@@ -9,7 +9,7 @@ julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
  3
  4
 
-julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
+julia> Main.DocTestFixArray_1234
 4-element Array{Int64,1}:
  1
  2
@@ -17,14 +17,14 @@ julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
  4
 ```
 ```jldoctest
-julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
+julia> Main.DocTestFixArray_1234
 4-element Array{Int64,1}:
  1
  2
  3
  4
 
-julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+julia> Main.DocTestFixArray_2468
 4-element Array{Int64,1}:
  1
  2
@@ -32,14 +32,14 @@ julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
  4
 ```
 ```jldoctest
-julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+julia> Main.DocTestFixArray_2468
 4-element Array{Int64,1}:
  1
  2
  3
  4
 
-julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+julia> Main.DocTestFixArray_2468
 4-element Array{Int64,1}:
  1
  2
@@ -48,7 +48,7 @@ julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
 ```
 ```jldoctest
 julia> begin
-           reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+           Main.DocTestFixArray_2468
        end
 4-element Array{Int64,1}:
  1
@@ -57,7 +57,7 @@ julia> begin
  4
 ```
 ```jldoctest
-reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+Main.DocTestFixArray_2468
 
 # output
 
@@ -82,7 +82,7 @@ foo() = 1
     """
     ```jldoctest
     julia> begin
-               reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+               Main.DocTestFixArray_2468
            end
     4-element Array{Int64,1}:
      1

--- a/test/doctests/fix/broken.md
+++ b/test/doctests/fix/broken.md
@@ -3,7 +3,7 @@ DocTestFixTest.Foo.foo
 ```
 
 ```jldoctest
-julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+julia> Main.DocTestFixArray_2468
 4×1×1 Array{Int64,3}:
 [:, :, 1] =
  1
@@ -11,7 +11,7 @@ julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
  3
  4
 
-julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
+julia> Main.DocTestFixArray_1234
 4-element Array{Int64,1}:
  1
  2
@@ -19,14 +19,14 @@ julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
  4
 ```
 ```jldoctest
-julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
+julia> Main.DocTestFixArray_1234
 4-element Array{Int64,1}:
  1
  2
  3
  4
 
-julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+julia> Main.DocTestFixArray_2468
 4-element Array{Int64,1}:
  1
  2
@@ -34,14 +34,14 @@ julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
  4
 ```
 ```jldoctest
-julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+julia> Main.DocTestFixArray_2468
 4-element Array{Int64,1}:
  1
  2
  3
  4
 
-julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+julia> Main.DocTestFixArray_2468
 4-element Array{Int64,1}:
  1
  2
@@ -50,7 +50,7 @@ julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
 ```
 ```jldoctest
 julia> begin
-          reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+          Main.DocTestFixArray_2468
        end
 4-element Array{Int64,1}:
  1
@@ -59,7 +59,7 @@ julia> begin
  4
 ```
 ```jldoctest
-reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+Main.DocTestFixArray_2468
 
 # output
 

--- a/test/doctests/fix/fixed.jl
+++ b/test/doctests/fix/fixed.jl
@@ -1,7 +1,7 @@
 module Foo
 """
 ```jldoctest
-julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+julia> Main.DocTestFixArray_2468
 4×1×1 Array{Int64,3}:
 [:, :, 1] =
  2
@@ -9,7 +9,7 @@ julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
  6
  8
 
-julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
+julia> Main.DocTestFixArray_1234
 4×1×1 Array{Int64,3}:
 [:, :, 1] =
  1
@@ -18,7 +18,7 @@ julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
  4
 ```
 ```jldoctest
-julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
+julia> Main.DocTestFixArray_1234
 4×1×1 Array{Int64,3}:
 [:, :, 1] =
  1
@@ -26,7 +26,7 @@ julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
  3
  4
 
-julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+julia> Main.DocTestFixArray_2468
 4×1×1 Array{Int64,3}:
 [:, :, 1] =
  2
@@ -35,7 +35,7 @@ julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
  8
 ```
 ```jldoctest
-julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+julia> Main.DocTestFixArray_2468
 4×1×1 Array{Int64,3}:
 [:, :, 1] =
  2
@@ -43,7 +43,7 @@ julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
  6
  8
 
-julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+julia> Main.DocTestFixArray_2468
 4×1×1 Array{Int64,3}:
 [:, :, 1] =
  2
@@ -53,7 +53,7 @@ julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
 ```
 ```jldoctest
 julia> begin
-           reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+           Main.DocTestFixArray_2468
        end
 4×1×1 Array{Int64,3}:
 [:, :, 1] =
@@ -63,7 +63,7 @@ julia> begin
  8
 ```
 ```jldoctest
-reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+Main.DocTestFixArray_2468
 
 # output
 
@@ -91,7 +91,7 @@ foo() = 1
     """
     ```jldoctest
     julia> begin
-               reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+               Main.DocTestFixArray_2468
            end
     4×1×1 Array{Int64,3}:
     [:, :, 1] =

--- a/test/doctests/fix/fixed.md
+++ b/test/doctests/fix/fixed.md
@@ -3,7 +3,7 @@ DocTestFixTest.Foo.foo
 ```
 
 ```jldoctest
-julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+julia> Main.DocTestFixArray_2468
 4×1×1 Array{Int64,3}:
 [:, :, 1] =
  2
@@ -11,7 +11,7 @@ julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
  6
  8
 
-julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
+julia> Main.DocTestFixArray_1234
 4×1×1 Array{Int64,3}:
 [:, :, 1] =
  1
@@ -20,7 +20,7 @@ julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
  4
 ```
 ```jldoctest
-julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
+julia> Main.DocTestFixArray_1234
 4×1×1 Array{Int64,3}:
 [:, :, 1] =
  1
@@ -28,7 +28,7 @@ julia> reshape(Int64[1, 2, 3, 4], (4,1,1))
  3
  4
 
-julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+julia> Main.DocTestFixArray_2468
 4×1×1 Array{Int64,3}:
 [:, :, 1] =
  2
@@ -37,7 +37,7 @@ julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
  8
 ```
 ```jldoctest
-julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+julia> Main.DocTestFixArray_2468
 4×1×1 Array{Int64,3}:
 [:, :, 1] =
  2
@@ -45,7 +45,7 @@ julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
  6
  8
 
-julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+julia> Main.DocTestFixArray_2468
 4×1×1 Array{Int64,3}:
 [:, :, 1] =
  2
@@ -55,7 +55,7 @@ julia> reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
 ```
 ```jldoctest
 julia> begin
-          reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+          Main.DocTestFixArray_2468
        end
 4×1×1 Array{Int64,3}:
 [:, :, 1] =
@@ -65,7 +65,7 @@ julia> begin
  8
 ```
 ```jldoctest
-reshape(Int64[1, 2, 3, 4] * 2, (4,1,1))
+Main.DocTestFixArray_2468
 
 # output
 

--- a/test/doctests/fix/tests.jl
+++ b/test/doctests/fix/tests.jl
@@ -20,24 +20,25 @@ function test_doctest_fix(dir)
     # fix up
     include(joinpath(srcdir, "src.jl")); @eval import .Foo
     @debug "Running doctest/fix doctests with doctest=:fix"
-    makedocs(sitename="-", modules = [Foo], source = srcdir, build = builddir, doctest = :fix)
+    @quietly makedocs(sitename="-", modules = [Foo], source = srcdir, build = builddir, doctest = :fix)
 
     # test that strict = true works
     include(joinpath(srcdir, "src.jl")); @eval import .Foo
     @debug "Running doctest/fix doctests with doctest=true"
-    makedocs(sitename="-", modules = [Foo], source = srcdir, build = builddir, strict = true)
+    @quietly makedocs(sitename="-", modules = [Foo], source = srcdir, build = builddir, strict = true)
 
     # also test that we obtain the expected output
     @test read(joinpath(srcdir, "index.md"), String) == read(joinpath(@__DIR__, "fixed.md"), String)
     @test read(joinpath(srcdir, "src.jl"), String) == read(joinpath(@__DIR__, "fixed.jl"), String)
 end
 
-@info "Testing `doctest = :fix` in $(@__FILE__)"
-if haskey(ENV, "DOCUMENTER_TEST_DEBUG")
-    # in this mode the directories remain
-    test_doctest_fix(mktempdir(@__DIR__))
-else
-    @quietly mktempdir(test_doctest_fix, @__DIR__)
+@testset "doctest fixing" begin
+    if haskey(ENV, "DOCUMENTER_TEST_DEBUG")
+        # in this mode the directories remain
+        test_doctest_fix(mktempdir(@__DIR__))
+    else
+        mktempdir(test_doctest_fix, @__DIR__)
+    end
 end
 
 end # module

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -211,7 +211,8 @@ examples_html_doc = if "html" in EXAMPLE_BUILDS
         )),
     )
 else
-    @info "Skipping build: HTML/deploy" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
+    @info "Skipping build: HTML/deploy"
+    @debug "Controlling variables:" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
     nothing
 end
 
@@ -234,7 +235,8 @@ examples_html_mathjax2_custom_doc = if "html-mathjax2-custom" in EXAMPLE_BUILDS
         ),
     )
 else
-    @info "Skipping build: HTML/deploy MathJax v2 (custom URL)" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
+    @info "Skipping build: HTML/deploy MathJax v2 (custom URL)"
+    @debug "Controlling variables:" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
     nothing
 end
 examples_html_mathjax3_doc = if "html-mathjax3" in EXAMPLE_BUILDS
@@ -250,7 +252,8 @@ examples_html_mathjax3_doc = if "html-mathjax3" in EXAMPLE_BUILDS
         )),
     )
 else
-    @info "Skipping build: HTML/deploy MathJax v3" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
+    @info "Skipping build: HTML/deploy MathJax v3"
+    @debug "Controlling variables:" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
     nothing
 end
 examples_html_mathjax3_custom_doc = if "html-mathjax3-custom" in EXAMPLE_BUILDS
@@ -269,7 +272,8 @@ examples_html_mathjax3_custom_doc = if "html-mathjax3-custom" in EXAMPLE_BUILDS
         ),
     )
 else
-    @info "Skipping build: HTML/deploy MathJax v3 (custom URL)" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
+    @info "Skipping build: HTML/deploy MathJax v3 (custom URL)"
+    @debug "Controlling variables:" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
     nothing
 end
 
@@ -295,7 +299,8 @@ examples_html_local_doc = if "html-local" in EXAMPLE_BUILDS
         ),
     )
 else
-    @info "Skipping build: HTML/local" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
+    @info "Skipping build: HTML/local"
+    @debug "Controlling variables:" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
     nothing
 end
 
@@ -311,7 +316,8 @@ examples_markdown_doc = if "markdown" in EXAMPLE_BUILDS
         expandfirst = expandfirst,
     )
 else
-    @info "Skipping build: Markdown" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
+    @info "Skipping build: Markdown"
+    @debug "Controlling variables:" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
     nothing
 end
 
@@ -329,7 +335,8 @@ examples_latex_simple_doc = if "latex_simple" in EXAMPLE_BUILDS
         debug = true,
     )
 else
-    @info "Skipping build: LaTeXWriter/simple" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
+    @info "Skipping build: LaTeXWriter/simple"
+    @debug "Controlling variables:" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
     nothing
 end
 
@@ -373,7 +380,8 @@ examples_latex_doc = if "latex" in EXAMPLE_BUILDS
         debug = true,
     )
 else
-    @info "Skipping build: LaTeXWriter/latex" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
+    @info "Skipping build: LaTeXWriter/latex"
+    @debug "Controlling variables:" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
     nothing
 end
 
@@ -390,7 +398,8 @@ examples_latex_simple_nondocker_doc = if "latex_simple_nondocker" in EXAMPLE_BUI
         debug = true,
     )
 else
-    @info "Skipping build: LaTeXWriter/latex_simple_nondocker" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
+    @info "Skipping build: LaTeXWriter/latex_simple_nondocker"
+    @debug "Controlling variables:" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
     nothing
 end
 
@@ -434,6 +443,7 @@ examples_latex_texonly_doc = if "latex_texonly" in EXAMPLE_BUILDS
         debug = true,
     )
 else
-    @info "Skipping build: LaTeXWriter/latex_texonly" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
+    @info "Skipping build: LaTeXWriter/latex_texonly"
+    @debug "Controlling variables:" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
     nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,11 +12,8 @@ include("TestUtilities.jl"); using .TestUtilities
     @quietly include("missingdocs/make.jl")
 
     # Error reporting.
-    println("="^50)
-    @info("The following errors are expected output.")
-    include("errors/make.jl")
-    @info("END of expected error output.")
-    println("="^50)
+    @info "Building errors/make.jl"
+    @quietly include("errors/make.jl")
 
     # Unit tests for module internals.
     include("utilities.jl")
@@ -36,6 +33,7 @@ include("TestUtilities.jl"); using .TestUtilities
     include("docsystem.jl")
 
     # DocTest unit tests.
+    @info "Running tests in doctests/"
     include("doctests/docmeta.jl")
     include("doctests/doctestapi.jl")
     include("doctests/doctests.jl")
@@ -60,17 +58,21 @@ include("TestUtilities.jl"); using .TestUtilities
     include("examples/tests.jl")
 
     # Documenter package docs with other formats.
-    include("formats/markdown.jl")
+    @info "Building formats/markdown.jl"
+    @quietly include("formats/markdown.jl")
 
     # A simple build outside of a Git repository
-    include("nongit/tests.jl")
+    @info "Building nongit/tests.jl"
+    @quietly include("nongit/tests.jl")
 
     # A simple build evaluating code outside build directory
-    include("workdir/tests.jl")
+    @info "Building workdir/tests.jl"
+    @quietly include("workdir/tests.jl")
 
     # Passing a writer positionally (https://github.com/JuliaDocs/Documenter.jl/issues/1046)
     @test_throws ArgumentError makedocs(sitename="", HTML())
 
     # Running doctest() on our own manual
-    include("manual.jl")
+    @info "doctest() Documenter's manual"
+    @quietly include("manual.jl")
 end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -2,6 +2,7 @@ module UtilitiesTests
 
 using Test
 import Base64: stringmime
+include("TestUtilities.jl"); using .TestUtilities
 
 import Documenter
 import Markdown
@@ -324,11 +325,11 @@ end
             @test length(md) == 2
         end
 
-        @info "Expected error output:"
-        @test_throws ArgumentError mdparse("!!! adm", mode=:span)
-        @test_throws ArgumentError mdparse("x\n\ny")
-        @test_throws ArgumentError mdparse("x\n\ny", mode=:span)
-        @info ".. end of expected error output."
+        @quietly begin
+            @test_throws ArgumentError mdparse("!!! adm", mode=:span)
+            @test_throws ArgumentError mdparse("x\n\ny")
+            @test_throws ArgumentError mdparse("x\n\ny", mode=:span)
+        end
     end
 
     @testset "JSDependencies" begin


### PR DESCRIPTION
Due to printing changes in for `Array`s, the doctest fixing tests were broken on nightly. With this patch we no longer depend on how Base prints Arrays.

Also, hide all the "expected error output" etc in the build logs to make them easier to read and to actually find the real errors. The way I did it is pretty blunt though, so there is a good chance that sometimes this will hide useful error messages.