### PR TITLE
If an `@example` block throws an exception, print the stacktrace as a `@debug` message

### DIFF
--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -560,6 +560,7 @@ function Selectors.runner(::Type{ExampleBlocks}, x, page, doc)
             print(buffer, c.output)
             if c.error
                 push!(doc.internal.errors, :example_block)
+                @debug "" exception=(c.value, c.backtrace)
                 @warn("""
                     failed to run `@example` block in $(Utilities.locrepr(page.source, lines))
                     ```$(x.language)


### PR DESCRIPTION
This is a replacement for #1446 

If an `@example` block throws an exception, this pull request will print the stacktrace as a `@debug` message.

So, by default, the stacktrace will not be shown. The user can show the stacktraces by doing e.g. `export JULIA_DEBUG=all`.