### PR TITLE
Print a warning when main/master confusion detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * ![Enhancement][badge-enhancement] The HTML front end now respects the user's OS-level dark theme preference (determined via the `prefers-color-scheme: dark` media query). ([#1320][github-1320], [#1456][github-1456])
 
+* ![Enhancement][badge-enhancement] `deploydocs` now prints a warning on GitHub Actions, Travis CI and Buildkite if the current branch is `main`, but `devbranch = "master`, which indicates a possible Documenter misconfiguration due to GitHub changing the default primary branch of a repository to `main`. ([#1489][github-1489])
+
 ## Version `v0.25.5`
 
 * ![Bugfix][badge-bugfix] In the HTML output, display equations that are wider than the page now get a scrollbar instead of overflowing. ([#1470][github-1470], [#1476][github-1476])
@@ -705,6 +707,7 @@
 [github-1472]: https://github.com/JuliaDocs/Documenter.jl/pull/1472
 [github-1474]: https://github.com/JuliaDocs/Documenter.jl/pull/1474
 [github-1476]: https://github.com/JuliaDocs/Documenter.jl/pull/1476
+[github-1489]: https://github.com/JuliaDocs/Documenter.jl/pull/1489
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 

--- a/src/deployconfig.jl
+++ b/src/deployconfig.jl
@@ -236,6 +236,19 @@ function deploy_folder(cfg::Travis;
     println(io, "- $(marker(type_ok)) ENV[\"TRAVIS_EVENT_TYPE\"]=\"$(cfg.travis_event_type)\" is not \"cron\"")
     print(io, "Deploying: $(marker(all_ok))")
     @info String(take!(io))
+    if build_type === :devbranch && !branch_ok && devbranch == "master" && cfg.travis_branch == "main"
+        @warn """
+        Possible deploydocs() misconfiguration: main vs master
+        Documenter's configured primary development branch (`devbranch`) is "master", but the
+        current branch (\$TRAVIS_BRANCH) is "main". This can happen because Documenter uses
+        GitHub's old default primary branch name as the default value for `devbranch`.
+
+        If your primary development branch is 'main', you must explicitly pass `devbranch = "main"`
+        to deploydocs.
+
+        See #1443 for more discussion: https://github.com/JuliaDocs/Documenter.jl/issues/1443
+        """
+    end
     if all_ok
         return DeployDecision(; all_ok = true,
                                 branch = deploy_branch,
@@ -375,6 +388,19 @@ function deploy_folder(cfg::GitHubActions;
     end
     print(io, "Deploying: $(marker(all_ok))")
     @info String(take!(io))
+    if build_type === :devbranch && !branch_ok && devbranch == "master" && cfg.github_ref == "refs/heads/main"
+        @warn """
+        Possible deploydocs() misconfiguration: main vs master
+        Documenter's configured primary development branch (`devbranch`) is "master", but the
+        current branch (from \$GITHUB_REF) is "main". This can happen because Documenter uses
+        GitHub's old default primary branch name as the default value for `devbranch`.
+
+        If your primary development branch is 'main', you must explicitly pass `devbranch = "main"`
+        to deploydocs.
+
+        See #1443 for more discussion: https://github.com/JuliaDocs/Documenter.jl/issues/1443
+        """
+    end
     if all_ok
         return DeployDecision(; all_ok = true,
                                 branch = deploy_branch,
@@ -762,6 +788,19 @@ function deploy_folder(
 
     print(io, "Deploying to folder $(repr(subfolder)): $(marker(all_ok))")
     @info String(take!(io))
+    if build_type === :devbranch && !branch_ok && devbranch == "master" && cfg.commit_branch == "main"
+        @warn """
+        Possible deploydocs() misconfiguration: main vs master
+        Documenter's configured primary development branch (`devbranch`) is "master", but the
+        current branch (\$BUILDKITE_BRANCH) is "main". This can happen because Documenter uses
+        GitHub's old default primary branch name as the default value for `devbranch`.
+
+        If your primary development branch is 'main', you must explicitly pass `devbranch = "main"`
+        to deploydocs.
+
+        See #1443 for more discussion: https://github.com/JuliaDocs/Documenter.jl/issues/1443
+        """
+    end
 
     if all_ok
         return DeployDecision(;


### PR DESCRIPTION
Print something like this in `deploydocs`

```
┌ Info: 
│ Buildkite config:
│   Commit branch: "main"
│   Pull request: "false"
│   Commit tag: ""
│ Detected build type: devbranch
│ - ✘ ENV["BUILDKITE_BRANCH"] matches devbranch="master"
│ - ✔ ENV["DOCUMENTER_KEY"] exists
└ Deploying to folder "dev": ✘
┌ Warning: Possible deploydocs() misconfiguration: main vs master
│ Documenter's configured primary development branch (`devbranch`) is "master", but the
│ current branch ($BUILDKITE_BRANCH) is "main". This can happen because Documenter uses
│ GitHub's old default primary branch name as the default value for `devbranch`.
│ 
│ If your primary development branch is 'main', you must explicitly pass `devbranch = "main"`
│ to deploydocs.
│ 
│ See #1443 for more discussion: https://github.com/JuliaDocs/Documenter.jl/issues/1443
└ @ Documenter ~/Julia/JuliaDocs/Documenter/src/deployconfig.jl:792
```

on Travis, GitHub Actions and BuildKite if the branch is `main`, but `devbranch` is not set. It doesn't detect the case where the user explicitly set `devbranch = "master"`, but I think we can live with that (not worth the complexity).

Related to #1443.