### PR TITLE
Throw an error early in HTMLWriter when there are no pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * ![Enhancement][badge-enhancement] The HTML front end now respects the user's OS-level dark theme preference (determined via the `prefers-color-scheme: dark` media query). ([#1320][github-1320], [#1456][github-1456])
 
+* ![Enhancement][badge-enhancement] HTML output now bails early if there are no pages, instead of throwing an `UndefRefError`. In addition, it will also warn if `index.md` is missing and it is not able to generate the main landing page (`index.html`). ([#1201][github-1201], [#1491][github-1491])
+
 ## Version `v0.25.5`
 
 * ![Bugfix][badge-bugfix] In the HTML output, display equations that are wider than the page now get a scrollbar instead of overflowing. ([#1470][github-1470], [#1476][github-1476])
@@ -640,6 +642,7 @@
 [github-1194]: https://github.com/JuliaDocs/Documenter.jl/pull/1194
 [github-1195]: https://github.com/JuliaDocs/Documenter.jl/pull/1195
 [github-1200]: https://github.com/JuliaDocs/Documenter.jl/issues/1200
+[github-1201]: https://github.com/JuliaDocs/Documenter.jl/issues/1201
 [github-1212]: https://github.com/JuliaDocs/Documenter.jl/issues/1212
 [github-1216]: https://github.com/JuliaDocs/Documenter.jl/pull/1216
 [github-1222]: https://github.com/JuliaDocs/Documenter.jl/pull/1222
@@ -705,6 +708,7 @@
 [github-1472]: https://github.com/JuliaDocs/Documenter.jl/pull/1472
 [github-1474]: https://github.com/JuliaDocs/Documenter.jl/pull/1474
 [github-1476]: https://github.com/JuliaDocs/Documenter.jl/pull/1476
+[github-1491]: https://github.com/JuliaDocs/Documenter.jl/pull/1491
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -627,6 +627,11 @@ getpage(ctx, navnode::Documents.NavNode) = getpage(ctx, navnode.page)
 function render(doc::Documents.Document, settings::HTML=HTML())
     @info "HTMLWriter: rendering HTML pages."
     !isempty(doc.user.sitename) || error("HTML output requires `sitename`.")
+    if isempty(doc.blueprint.pages)
+        error("Aborting HTML build: no pages under src/")
+    elseif !haskey(doc.blueprint.pages, "index.md")
+        @warn "Can't generate landing page (index.html): src/index.md missing" keys(doc.blueprint.pages)
+    end
 
     ctx = HTMLContext(doc, settings)
     ctx.search_index_js = "search_index.js"
@@ -955,7 +960,7 @@ function render_sidebar(ctx, navnode)
     )
 
     # The menu itself
-    menu = navitem(NavMenuContext(ctx, navnode, ))
+    menu = navitem(NavMenuContext(ctx, navnode))
     push!(menu.attributes, :class => "docs-menu")
     push!(navmenu.nodes, menu)
 

--- a/test/doctests/doctests.jl
+++ b/test/doctests/doctests.jl
@@ -29,6 +29,9 @@ function run_makedocs(f, mdfiles, modules=Module[]; kwargs...)
     for mdfile in mdfiles
         cp(joinpath(@__DIR__, "src", mdfile), joinpath(srcdir, mdfile))
     end
+    # Create a dummy index.md file so that we wouldn't generate the "can't generated landing
+    # page" warning.
+    touch(joinpath(srcdir, "index.md"))
 
     c = IOCapture.iocapture(throwerrors = :interrupt) do
         makedocs(


### PR DESCRIPTION
The `UndefRefError` in #1201 happens when you do not have any pages (i.e. any `.md` files under `src/`). Then `menu` at
https://github.com/JuliaDocs/Documenter.jl/blob/bc1f73c1fc936cdf19cf92fa21889e39a5841ac8/src/Writers/HTMLWriter.jl#L963-L964
will be a `Node("")` with uninitialized fields. It doesn't really make sense to build anything if there are no pages, so we'll try to bail early with a more helpful message in that situation.

Having an `index.md` is not actually necessary for a build to complete, but the docs do end up slightly broken if you don't have it, so we'll also print a warning if `src/index.md` is missing.

