### PR TITLE
Un-deprecate built-in PDF/LaTeX output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version `v0.26.0`
 
+* ![BREAKING][badge-breaking] The PDF/LaTeX output is again provided as a Documenter built-in and can be enabled by passing an instance of `Documenter.LaTeX` to `format`. The DocumenterLaTeX package has been deprecated. ([#1493][github-1493])
+
+  **For upgrading:** If using the PDF/LaTeX output, change the `format` argument of `makedocs` to `format = Documenter.LaTeX(...)` and remove all references to the DocumenterLaTeX package (e.g. from `docs/Project.toml`).
+
 * ![Enhancement][badge-enhancement] Objects that render as equations and whose `text/latex` representations are wrapped in display equation delimiters `\[ ... \]` or `$$ ... $$` are now handled correctly in the HTML output. ([#1278][github-1278], [#1283][github-1283], [#1426][github-1426])
 
 * ![Enhancement][badge-enhancement] The search page in the HTML output now shows the page titles in the search results. ([#1468][github-1468])
@@ -705,6 +709,7 @@
 [github-1472]: https://github.com/JuliaDocs/Documenter.jl/pull/1472
 [github-1474]: https://github.com/JuliaDocs/Documenter.jl/pull/1474
 [github-1476]: https://github.com/JuliaDocs/Documenter.jl/pull/1476
+[github-1493]: https://github.com/JuliaDocs/Documenter.jl/pull/1493
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 

--- a/docs/pdf/Project.toml
+++ b/docs/pdf/Project.toml
@@ -1,5 +1,4 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-DocumenterLaTeX = "cd674d7a-5f81-5cf3-af33-235ef1834b99"
 DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/docs/pdf/make.jl
+++ b/docs/pdf/make.jl
@@ -1,4 +1,4 @@
-using Documenter, DocumenterTools, DocumenterLaTeX
+using Documenter, DocumenterTools
 using Test
 
 const ROOT = joinpath(@__DIR__, "..")
@@ -10,7 +10,7 @@ doc = makedocs(
     build = "pdf/build",
     modules = [Documenter, DocumenterTools],
     clean = false,
-    format = LaTeX(platform = "docker"),
+    format = Documenter.LaTeX(platform = "docker"),
     sitename = "Documenter.jl",
     authors = "Michael Hatherly, Morten Piibeleht, and contributors.",
     pages = [

--- a/docs/src/man/other-formats.md
+++ b/docs/src/man/other-formats.md
@@ -1,9 +1,75 @@
 # Other Output Formats
 
-In addition to the default native HTML output, plugin packages enable Documenter to generate
-output in other formats. Once the corresponding package is loaded, the output format can be
+In addition to the default native HTML output, Documenter also provides [a built-in
+LaTeX-based PDF output](@ref pdf-output). Additional output formats are provided through
+plugin packages. Once the corresponding package is loaded, the output format can be
 specified using the `format` option in [`makedocs`](@ref).
 
+## [PDF Output via LaTeX](@id pdf-output)
+
+`makedocs` can be switched over to use the PDF/LaTeX backend by passing a
+[`Documenter.LaTeX`](@ref) object as the `format` keyword:
+
+```julia
+using Documenter
+makedocs(format = LaTeX(), ...)
+```
+
+Documenter will then generate a PDF file of the documentation using LaTeX, which will be
+placed in the output (`build/`) directory.
+
+The `makedocs` argument `sitename` will be used for the `\title` field in the tex document,
+and if the build is for a release tag (i.e. when the `"TRAVIS_TAG"` environment variable is set)
+the version number will be appended to the title.
+The `makedocs` argument `authors` should also be specified, it will be used for the
+`\authors` field in the tex document.
+
+### Compiling using natively installed latex
+
+The following is required to build the documentation:
+
+* You need `pdflatex` command to be installed and available to Documenter.
+* You need the [minted](https://ctan.org/pkg/minted) LaTeX package and its backend source
+  highlighter [Pygments](https://pygments.org/) installed.
+* You need the [_DejaVu Sans_ and _DejaVu Sans Mono_](https://dejavu-fonts.github.io/) fonts installed.
+
+### Compiling using docker image
+
+It is also possible to use a prebuilt [docker image](https://hub.docker.com/r/juliadocs/documenter-latex/)
+to compile the `.tex` file. The image contains all of the required installs described in the section
+above. The only requirement for using the image is that `docker` is installed and available for
+the builder to call. You also need to tell Documenter to use the docker image, instead of natively
+installed tex which is the default. This is done with the `LaTeX` specifier:
+
+```
+using DocumenterLaTeX
+makedocs(
+    format = LaTeX(platform = "docker"),
+    ...
+)
+```
+
+If you build the documentation on Travis you need to add
+
+```
+services:
+  - docker
+```
+
+to your `.travis.yml` file.
+
+### Compiling to LaTeX only
+
+There's a possibility to save only the `.tex` file and skip the PDF compilation.
+For this purpose use the `platform="none"` keyword:
+
+```
+using DocumenterLaTeX
+makedocs(
+    format = LaTeX(platform = "none"),
+    ...
+)
+```
 
 ## Markdown & MkDocs
 
@@ -145,68 +211,3 @@ extra_javascript:
 Following this guide and adding the necessary changes to the configuration files should
 enable properly rendered mathematical equations within your documentation both locally and
 when built and deployed using the Travis built service.
-
-
-## PDF Output via LaTeX
-
-LaTeX/PDF output requires the [`DocumenterLaTeX`](https://github.com/JuliaDocs/DocumenterLaTeX.jl)
-package to be available and loaded in `make.jl` with
-
-```
-using DocumenterLaTeX
-```
-
-When `DocumenterLaTeX` is loaded, you can set `format = LaTeX()` in [`makedocs`](@ref),
-and Documenter will generate a PDF version of the documentation using LaTeX.
-The `makedocs` argument `sitename` will be used for the `\\title` field in the tex document,
-and if the build is for a release tag (i.e. when the `"TRAVIS_TAG"` environment variable is set)
-the version number will be appended to the title.
-The `makedocs` argument `authors` should also be specified, it will be used for the
-`\\authors` field in the tex document.
-
-### Compiling using natively installed latex
-
-The following is required to build the documentation:
-
-* You need `pdflatex` command to be installed and available to Documenter.
-* You need the [minted](https://ctan.org/pkg/minted) LaTeX package and its backend source
-  highlighter [Pygments](https://pygments.org/) installed.
-* You need the [_DejaVu Sans_ and _DejaVu Sans Mono_](https://dejavu-fonts.github.io/) fonts installed.
-
-### Compiling using docker image
-
-It is also possible to use a prebuilt [docker image](https://hub.docker.com/r/juliadocs/documenter-latex/)
-to compile the `.tex` file. The image contains all of the required installs described in the section
-above. The only requirement for using the image is that `docker` is installed and available for
-the builder to call. You also need to tell Documenter to use the docker image, instead of natively
-installed tex which is the default. This is done with the `LaTeX` specifier:
-
-```
-using DocumenterLaTeX
-makedocs(
-    format = LaTeX(platform = "docker"),
-    ...
-)
-```
-
-If you build the documentation on Travis you need to add
-
-```
-services:
-  - docker
-```
-
-to your `.travis.yml` file.
-
-### Compiling to LaTeX only
-
-There's a possibility to save only the `.tex` file and skip the PDF compilation.
-For this purpose use the `platform="none"` keyword:
-
-```
-using DocumenterLaTeX
-makedocs(
-    format = LaTeX(platform = "none"),
-    ...
-)
-```

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -52,6 +52,7 @@ include("Deps.jl")
 import .Utilities: Selectors
 import .Writers.HTMLWriter: HTML, asset
 import .Writers.HTMLWriter.RD: KaTeX, MathJax, MathJax2, MathJax3
+import .Writers.LaTeXWriter: LaTeX
 
 # User Interface.
 # ---------------
@@ -223,14 +224,15 @@ determined from the source file path. E.g. for `src/foo.md` it is set to `build/
 Note that `workdir` does not affect doctests.
 
 ## Output formats
-**`format`** allows the output format to be specified. The default format is
-[`Documenter.HTML`](@ref) which creates a set of HTML files.
 
-There are other possible formats that are enabled by using other addon-packages.
-For examples, the `DocumenterMarkdown` package define the `DocumenterMarkdown.Markdown()`
-format for use with e.g. MkDocs, and the `DocumenterLaTeX` package define the
-`DocumenterLaTeX.LaTeX()` format for LaTeX / PDF output.
-See the [Other Output Formats](@ref) for more information.
+**`format`** allows the output format to be specified. The default format is
+[`Documenter.HTML`](@ref) which creates a set of HTML files, but Documenter also provides
+PDF output via the [`Documenter.LaTeX`](@ref) writer.
+
+Other formats can be enabled by using other addon-packages. For example, the
+[DocumenterMarkdown](https://github.com/JuliaDocs/DocumenterMarkdown.jl) package provides
+the original Markdown -> Markdown output. See the [Other Output Formats](@ref) for more
+information.
 
 # See Also
 

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -16,14 +16,14 @@ module LaTeXWriter
 import ...Documenter: Documenter
 
 """
-    LaTeXWriter.LaTeX(; kwargs...)
+    Documenter.LaTeX(; kwargs...)
 
 Output format specifier that results in LaTeX/PDF output.
 Used together with [`makedocs`](@ref Documenter.makedocs), e.g.
 
 ```julia
 makedocs(
-    format = LaTeX()
+    format = Documenter.LaTeX()
 )
 ```
 

--- a/src/Writers/Writers.jl
+++ b/src/Writers/Writers.jl
@@ -82,27 +82,6 @@ function render(doc::Documents.Document)
 
             See the Output Backends section in the manual for more information.
             """
-        elseif isa(each, LaTeXWriter.LaTeX) && !backends_enabled[:latex]
-            @warn """Deprecated format
-
-            The LaTeX/PDF backend must now be imported from a separate package.
-            Add DocumenterLaTeX to your documentation dependencies and add
-
-                using DocumenterLaTeX
-
-            to your make.jl script, and use
-
-                makedocs(
-                    format = LaTeX(),
-                    ...
-                )
-
-            in the call to `makedocs`.
-            Built-in support for LaTeX/PDF output will be removed completely in a future
-            Documenter version, causing builds to fail completely.
-
-            See the Output Backends section in the manual for more information.
-            """
         end
         Selectors.dispatch(FormatSelector, each, doc)
     end
@@ -116,18 +95,12 @@ include("MarkdownWriter.jl")
 include("HTMLWriter.jl")
 include("LaTeXWriter.jl")
 
-# This is hack to enable shell packages that would behave as in the supplementary Writer
-# modules have been moved out of Documenter.
-#
-# External packages DocumenterMarkdown and DocumenterLaTeX can use the enable_backend
-# function to mark that a certain backend is loaded in backends_enabled. That is used to
-# determine whether a deprecation warning should be printed in the render method above.
-#
-# enable_backend() is not part of the API and will be removed as soon as LaTeXWriter and
-# MarkdownWriter are actually moved out into a separate module (TODO).
+# This is hack to enable the DocumenterMarkdown shell package to behave as if it provides
+# the MarkdownWriter, even though the actual writer code has not yet been moved out of
+# Documenter (TODO). enable_backend() is not part of the API and will be removed as soon as
+# MarkdownWriter is actually moved out into a separate module.
 backends_enabled = Dict(
     :markdown => false,
-    :latex => false
 )
 
 function enable_backend(backend::Symbol)

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -421,7 +421,7 @@ end
 examples_latex_simple_nondocker_doc = if "latex_simple_nondocker" in EXAMPLE_BUILDS
     @info("Building mock package docs: LaTeXWriter/latex_simple_nondocker")
     @quietly makedocs(
-        format = Documenter.Writers.LaTeXWriter.LaTeX(),
+        format = Documenter.LaTeX(),
         sitename = "Documenter LaTeX Simple Non-Docker",
         root  = examples_root,
         build = "builds/latex_simple_nondocker",
@@ -439,7 +439,7 @@ end
 examples_latex_texonly_doc = if "latex_texonly" in EXAMPLE_BUILDS
     @info("Building mock package docs: LaTeXWriter/latex_texonly")
     @quietly makedocs(
-        format = Documenter.Writers.LaTeXWriter.LaTeX(platform = "none"),
+        format = Documenter.LaTeX(platform = "none"),
         sitename = "Documenter LaTeX",
         root  = examples_root,
         build = "builds/latex_texonly",


### PR DESCRIPTION
At some point the idea was that we'll relegate the LaTeX output to a separate package to reduce the maintenance burden. However, for a while now, I've felt that we want to give the PDF/LaTeX output similar importance as to the HTML backend.

So in order to avoid having to bump `[compat]` in yet another package, this effectively deprecates the DocumenterLaTeX. In the future, people need to set `format = Documenter.LaTeX(...)` to compile PDFs.

Technically non-breaking, but breaking in practice:

* People who use DocumenterLaTeX won't be able to install that package together with Documenter 0.26.
* Setups that reference `Documenter.Writers.LaTeXWriter.LaTeX()` directly will technically keep working, but they should update to `Documenter.LaTeX()`.