### PR TITLE
Smallfixes

### DIFF
--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -66,7 +66,11 @@ srcpath(source, root, file) = normpath(joinpath(relpath(root, source), file))
 Slugify a string into a suitable URL.
 """
 function slugify(s::AbstractString)
-    s = lstrip(x->x ∉ 'a':'z' && x ∉ 'A':'Z',s)
+    stripped_s = lstrip(!isletter,s)
+    # in case there is no letter at all, take the original approach
+    if !isempty(stripped_s)
+        s = stripped_s
+    end
     s = replace(s, r"\s+" => "-")
     s = replace(s, r"^\d+" => "")
     s = replace(s, r"&" => "-and-")

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -66,6 +66,7 @@ srcpath(source, root, file) = normpath(joinpath(relpath(root, source), file))
 Slugify a string into a suitable URL.
 """
 function slugify(s::AbstractString)
+    s = lstrip(x->x ∉ 'a':'z' && x ∉ 'A':'Z',s)
     s = replace(s, r"\s+" => "-")
     s = replace(s, r"^\d+" => "")
     s = replace(s, r"&" => "-and-")

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -461,6 +461,14 @@ end
         @test Documenter.Utilities.codelang("\t julia   \tx=y ") == "julia"
         @test Documenter.Utilities.codelang("&%^ ***") == "&%^"
     end
+
+    @testset "slugify" begin
+        @test Documenter.Utilities.slugify("iam") == "iam"
+        @test Documenter.Utilities.slugify(" one  two  three ") == "one-two-three"
+        @test Documenter.Utilities.slugify("one&two") == "one-and-two"
+        @test Documenter.Utilities.slugify("1) problematic heading 1") == "problematic-heading-1"
+        @test Documenter.Utilities.slugify("α alpha") == "α-alpha"
+    end
 end
 
 end


### PR DESCRIPTION
While working on an EPUB exporter, I saw opportunity for small improvements.
- `slugify`ed pieces should start with an letter
- only extract the number for referenced issues