### PR TITLE
Update highlightjs version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Documenter.jl changelog
 
+## Version `v0.27.0`
+
+* ![Enhancement][badge-enhancement] The JS dependencies have been updated to their respective latest versions.
+
+  - highlight.js has been updated to `v10.5.0`, which also brings various updates to the highlighting of Julia code. Due to the changes in highlight.js, code highlighting will not work on IE11. ([#1503][github-1503])
+
 ## Version `v0.26.1`
 
 * ![Bugfix][badge-bugfix] HTML assets that are copied directly from Documenters source to the build output now has correct file permissions. ([#1497][github-1497])
@@ -722,6 +728,7 @@
 [github-1491]: https://github.com/JuliaDocs/Documenter.jl/pull/1491
 [github-1493]: https://github.com/JuliaDocs/Documenter.jl/pull/1493
 [github-1497]: https://github.com/JuliaDocs/Documenter.jl/pull/1497
+[github-1503]: https://github.com/JuliaDocs/Documenter.jl/pull/1503
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -465,7 +465,7 @@ module RD
         # NOTE: the CSS themes for hightlightjs are compiled into the Documenter CSS
         # When updating this dependency, it is also necessary to update the the CSS
         # files the CSS files in assets/html/scss/highlightjs
-        hljs_version = "9.15.10"
+        hljs_version = "10.5.0"
         push!(r, RemoteLibrary(
             "highlight",
             "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/$(hljs_version)/highlight.min.js"
@@ -481,7 +481,7 @@ module RD
         end
         push!(r, Snippet(
             vcat(["jquery", "highlight"], ["highlight-$(jsescape(language))" for language in languages]),
-            ["\$", "hljs"],
+            ["\$"],
             raw"""
             $(document).ready(function() {
                 hljs.initHighlighting();


### PR DESCRIPTION
The update to the newest version of highlightjs ~~pulls in the work of @fredrikekre~~ to improve `julia` and `julia-repl`. This won't work on IE11, but ¯\_(ツ)_/¯...

The CSS files haven't changed with this update.