### PR TITLE
Remove GitHub token build trigger warning

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -259,12 +259,6 @@ to the configuration file, as showed in the [previous section](@ref GitHub-Actio
     of the deployment is the same as the current repository. In order to push
     elsewhere you should instead use a SSH deploy key.
 
-!!! warning "GitHub Pages and GitHub Token"
-    Currently the GitHub Page build is not triggered when the GitHub provided
-    `GITHUB_TOKEN` is used for authentication. See
-    [issue #1177](https://github.com/JuliaDocs/Documenter.jl/issues/1177)
-    for more information.
-
 ### Authentication: SSH Deploy Keys
 
 It is also possible to authenticate using a SSH deploy key, just as described in

--- a/src/deployconfig.jl
+++ b/src/deployconfig.jl
@@ -414,17 +414,7 @@ function deploy_folder(cfg::GitHubActions;
     end
 end
 
-function authentication_method(::GitHubActions)
-    if env_nonempty("DOCUMENTER_KEY")
-        return SSH
-    else
-        @warn "Currently the GitHub Pages build is not triggered when " *
-              "using `GITHUB_TOKEN` for authentication. See issue #1177 " *
-              "(https://github.com/JuliaDocs/Documenter.jl/issues/1177) " *
-              "for more information."
-        return HTTPS
-    end
-end
+authentication_method(::GitHubActions) = env_nonempty("DOCUMENTER_KEY") ? SSH : HTTPS
 function authenticated_repo_url(cfg::GitHubActions)
     return "https://$(ENV["GITHUB_ACTOR"]):$(ENV["GITHUB_TOKEN"])@github.com/$(cfg.github_repository).git"
 end


### PR DESCRIPTION
This PR removes a warning from the documentation and from the CI output, saying that GitHub Page builds are not triggered when using a GitHub token for authentication.

As discussed in #1177, the build trigger seems to be fixed now. I tested the following scenarios:

* Direct push
* Merging a pull request
* Pushing a tag to an older commit

These tests were made without pushing a commit manually to the `gh-pages`. The Pages build was correctly triggered in all cases.

Note that there is still a warning in the documentation for tags created with GitHub tokens (e.g. by TagBot).

Closes #1177