### PR TITLE
A few PDF improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 * ![Enhancement][badge-enhancement] `doctest()` no longer throws an error if cleaning up the temporary directory fails for some reason. ([#1513][github-1513], [#1526][github-1526])
 
+* ![Enhancement][badge-enhancement] Cosmetic improvements to the PDF output. ([#1342][github-1342], [#1527][github-1527])
+
 * ![Bugfix][badge-bugfix] Script-type doctests that have an empty output section no longer crash Documenter. ([#1510][github-1510])
 
 * ![Bugfix][badge-bugfix] When checking for authentication keys when deploying, Documenter now more appropriately checks if the environment variables are non-empty, rather than just whether they are defined. ([#1511][github-1511])
@@ -700,6 +702,7 @@
 [github-1337]: https://github.com/JuliaDocs/Documenter.jl/issues/1337
 [github-1338]: https://github.com/JuliaDocs/Documenter.jl/issues/1338
 [github-1339]: https://github.com/JuliaDocs/Documenter.jl/pull/1339
+[github-1342]: https://github.com/JuliaDocs/Documenter.jl/issues/1342
 [github-1344]: https://github.com/JuliaDocs/Documenter.jl/issues/1344
 [github-1345]: https://github.com/JuliaDocs/Documenter.jl/pull/1345
 [github-1349]: https://github.com/JuliaDocs/Documenter.jl/pull/1349
@@ -749,6 +752,7 @@
 [github-1519]: https://github.com/JuliaDocs/Documenter.jl/pull/1519
 [github-1520]: https://github.com/JuliaDocs/Documenter.jl/pull/1520
 [github-1526]: https://github.com/JuliaDocs/Documenter.jl/pull/1526
+[github-1527]: https://github.com/JuliaDocs/Documenter.jl/pull/1527
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -214,10 +214,12 @@ function writeheader(io::IO, doc::Documents.Document)
     isfile(custom) ? cp(custom, "custom.sty"; force = true) : touch("custom.sty")
     preamble =
         """
-        \\documentclass{memoir}
+        \\documentclass[oneside]{memoir}
 
         \\usepackage{./documenter}
         \\usepackage{./custom}
+
+        \\settocdepth{section}
 
         \\title{
             {\\HUGE $(doc.user.sitename)}\\\\
@@ -229,6 +231,7 @@ function writeheader(io::IO, doc::Documents.Document)
 
         \\frontmatter
         \\maketitle
+        \\clearpage
         \\tableofcontents
 
         \\mainmatter


### PR DESCRIPTION
Ref: #1342 

1. Use the `oneside` option of the memoir class, which is better for reading on a screen and anything that isn't a bound book.
2. For now hardcode ToC depth to section.
3. Clear page after the title.