### PR TITLE
Remove unused fallback method for post_status

### DIFF
--- a/src/deployconfig.jl
+++ b/src/deployconfig.jl
@@ -99,7 +99,6 @@ This method must be supported by configs that push with HTTPS, see
 function authenticated_repo_url end
 
 post_status(cfg::Union{DeployConfig,Nothing}; kwargs...) = nothing
-post_status(; kwargs...) = post_status(auto_detect_deploy_system(); kwargs...)
 
 marker(x) = x ? "✔" : "✘"
 


### PR DESCRIPTION
In `git_push` we only use the method that passes the `DeployConfig` as the first positional argument, so this one is unnecessary. Potentially using this method in Documenter in the future is probably a bad idea, since it calls `auto_detect_deploy_system()` again, potentially introducing environment-dependent bugs.