### PR TITLE
Illusrtate submodules in `@autodocs` example

### DIFF
--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -66,12 +66,12 @@ This is equivalent to manually adding all the docstrings in a `@docs` block.
 
 ````markdown
 ```@autodocs
-Modules = [Foo, Bar]
+Modules = [Foo, Bar, Bar.Baz]
 Order   = [:function, :type]
 ```
 ````
 
-The above `@autodocs` block adds all the docstrings found in modules `Foo` and `Bar` that
+The above `@autodocs` block adds all the docstrings found in modules `Foo`, `Bar`, and `Bar.Baz` that
 refer to functions or types to the document.
 
 Each module is added in order and so all docs from `Foo` will appear before those of `Bar`.

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -73,6 +73,7 @@ Order   = [:function, :type]
 
 The above `@autodocs` block adds all the docstrings found in modules `Foo`, `Bar`, and `Bar.Baz` that
 refer to functions or types to the document.
+Note that a submodule must be listed explicitly in order to include the docstrings within it.
 
 Each module is added in order and so all docs from `Foo` will appear before those of `Bar`.
 Possible values for the `Order` vector are


### PR DESCRIPTION
I briefly expected `@autodocs` to recurse through defined submodules, and this example would have corrected my misunderstanding.