### PR TITLE
Refactor sandbox module creation

### DIFF
--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -124,12 +124,7 @@ function doctest(ctx::DocTestContext, block_immutable::Markdown2.CodeBlock)
     if startswith(lang, "jldoctest")
         # Define new module or reuse an old one from this page if we have a named doctest.
         name = match(r"jldoctest[ ]?(.*)$", split(lang, ';', limit = 2)[1])[1]
-        if isempty(name)
-            sym = Symbol("__doctest__", lstrip(string(gensym()), '#'))
-        else
-            sym = Symbol("__doctest__named__", name)
-        end
-        sandbox = get!(() -> Expanders.get_new_sandbox(sym), ctx.meta, sym)
+        sandbox = Utilities.get_sandbox_module!(ctx.meta, "doctest", name)
 
         # Normalise line endings.
         block = MutableMD2CodeBlock(block_immutable)

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -600,7 +600,7 @@ function Selectors.runner(::Type{REPLBlocks}, x, page, doc)
     matched = match(r"^@repl[ ]?(.*)$", x.language)
     matched === nothing && error("invalid '@repl' syntax: $(x.language)")
     name = matched[1]
-    mod  = mod = Utilities.get_sandbox_module!(page.globals.meta, "atexample", name)
+    mod = Utilities.get_sandbox_module!(page.globals.meta, "atexample", name)
     code = split(x.code, '\n'; limit = 2)[end]
     result, out = nothing, IOBuffer()
     for (ex, str) in Utilities.parseblock(x.code, doc, page; keywords = false)

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -532,8 +532,8 @@ end
 function Selectors.runner(::Type{ExampleBlocks}, x, page, doc)
     # The sandboxed module -- either a new one or a cached one from this page.
     name = match(r"^@example[ ]?(.*)$", first(split(x.language, ';', limit = 2)))[1]
-    sym  = isempty(name) ? gensym("ex-") : Symbol("ex-", name)
-    mod  = get!(() -> get_new_sandbox(sym), page.globals.meta, sym)
+    mod = Utilities.get_sandbox_module!(page.globals.meta, "atexample", name)
+    sym = nameof(mod)
     lines = Utilities.find_block_in_file(x.code, page.source)
 
     # "parse" keyword arguments to example (we only need to look for continued = true)
@@ -600,8 +600,7 @@ function Selectors.runner(::Type{REPLBlocks}, x, page, doc)
     matched = match(r"^@repl[ ]?(.*)$", x.language)
     matched === nothing && error("invalid '@repl' syntax: $(x.language)")
     name = matched[1]
-    sym  = isempty(name) ? gensym("ex-") : Symbol("ex-", name)
-    mod  = get!(() -> get_new_sandbox(sym), page.globals.meta, sym)
+    mod  = mod = Utilities.get_sandbox_module!(page.globals.meta, "atexample", name)
     code = split(x.code, '\n'; limit = 2)[end]
     result, out = nothing, IOBuffer()
     for (ex, str) in Utilities.parseblock(x.code, doc, page; keywords = false)
@@ -644,8 +643,7 @@ function Selectors.runner(::Type{SetupBlocks}, x, page, doc)
     matched === nothing && error("invalid '@setup <name>' syntax: $(x.language)")
     # The sandboxed module -- either a new one or a cached one from this page.
     name = matched[1]
-    sym  = isempty(name) ? gensym("ex-") : Symbol("ex-", name)
-    mod  = get!(() -> get_new_sandbox(sym), page.globals.meta, sym)
+    mod = Utilities.get_sandbox_module!(page.globals.meta, "atexample", name)
 
     # Evaluate whole @setup block at once instead of piecewise
     page.mapping[x] =
@@ -714,15 +712,6 @@ function prepend_prompt(input)
         println(out, n == 1 ? prompt : padding, line)
     end
     rstrip(String(take!(out)))
-end
-
-function get_new_sandbox(name::Symbol)
-    m = Module(name)
-    # eval(expr) is available in the REPL (i.e. Main) so we emulate that for the sandbox
-    Core.eval(m, :(eval(x) = Core.eval($m, x)))
-    # modules created with Module() does not have include defined
-    Core.eval(m, :(include(x) = Base.include($m, abspath(x))))
-    return m
 end
 
 highlightsig!(x) = nothing

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -661,6 +661,25 @@ function codelang(infostring::AbstractString)
     return m[1]
 end
 
+function get_sandbox_module!(meta, prefix, name = "")
+    sym = if isempty(name)
+        Symbol("__", prefix, "__", lstrip(string(gensym()), '#'))
+    else
+        Symbol("__", prefix, "__named__", name)
+    end
+    # Either fetch and return an existing sandbox from the meta dictionary (based on the generated name),
+    # or initialize a new clean one, which gets stored in meta for future re-use.
+    get!(meta, sym) do
+        # If the module does not exists already, we need to construct a new one.
+        m = Module(sym)
+        # eval(expr) is available in the REPL (i.e. Main) so we emulate that for the sandbox
+        Core.eval(m, :(eval(x) = Core.eval($m, x)))
+        # modules created with Module() does not have include defined
+        Core.eval(m, :(include(x) = Base.include($m, abspath(x))))
+        return m
+    end
+end
+
 include("DOM.jl")
 include("MDFlatten.jl")
 include("TextDiff.jl")


### PR DESCRIPTION
Follow-up to #1540, since I remembered that we also create temporary modules for the at-blocks. Refactors the code to reduce duplication, and makes the names of the modules consistent again between the doctests and at-blocks.