### PR TITLE
Fix highlight.js warning due to invalid "language-none"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * ![Enhancement][badge-enhancement] The JS dependencies have been updated to their respective latest versions.
 
-  - highlight.js has been updated to `v10.5.0`, which also brings various updates to the highlighting of Julia code. Due to the changes in highlight.js, code highlighting will not work on IE11. ([#1503][github-1503])
+  - highlight.js has been updated to `v10.5.0`, which also brings various updates to the highlighting of Julia code. Due to the changes in highlight.js, code highlighting will not work on IE11. ([#1503][github-1503], [#1551][github-1551])
 
 * ![Enhancement][badge-enhancement] `deploydocs` now throws an error if something goes wrong with the Git invocations used to deploy to `gh-pages`. ([#1529][github-1529])
 
@@ -765,6 +765,7 @@
 [github-1531]: https://github.com/JuliaDocs/Documenter.jl/issues/1531
 [github-1533]: https://github.com/JuliaDocs/Documenter.jl/pull/1533
 [github-1540]: https://github.com/JuliaDocs/Documenter.jl/pull/1540
+[github-1551]: https://github.com/JuliaDocs/Documenter.jl/pull/1551
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 [julia-39841]: https://github.com/JuliaLang/julia/pull/39841

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1620,8 +1620,8 @@ mdconvert(b::Markdown.Bold, parent; kwargs...) = Tag(:strong)(mdconvert(b.text, 
 function mdconvert(c::Markdown.Code, parent::MDBlockContext; kwargs...)
     @tags pre code
     language = Utilities.codelang(c.language)
-    language = isempty(language) ? "none" : language
-    pre(code[".language-$(language)"](c.code))
+    class = isempty(language) ? "nohighlight" : "language-$(language)"
+    pre(code[".$class"](c.code))
 end
 mdconvert(c::Markdown.Code, parent; kwargs...) = Tag(:code)(c.code)
 


### PR DESCRIPTION
In highlight.js v10, only "nohighlight" and "no-highlight" are valid for ignoring highlighting.

```
WARN: Could not find the language 'none', did you forget to load/include a language module?
```