### PR TITLE
Handle faulty doctest keyword arguments better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 
 * ![Enhancement][badge-enhancement] Cosmetic improvements to the PDF output. ([#1342][github-1342], [#1527][github-1527])
 
+* ![Enhancement][badge-enhancement] If `jldoctest` keyword arguments fail to parse, these now get logged as doctesting failures, rather than being ignored with a warning or making `makedocs` throw an error (depending on why they fail to parse). ([#1556][github-1556], [#1557][github-1557])
+
 * ![Bugfix][badge-bugfix] Script-type doctests that have an empty output section no longer crash Documenter. ([#1510][github-1510])
 
 * ![Bugfix][badge-bugfix] When checking for authentication keys when deploying, Documenter now more appropriately checks if the environment variables are non-empty, rather than just whether they are defined. ([#1511][github-1511])
@@ -774,6 +776,8 @@
 [github-1540]: https://github.com/JuliaDocs/Documenter.jl/pull/1540
 [github-1549]: https://github.com/JuliaDocs/Documenter.jl/pull/1549
 [github-1551]: https://github.com/JuliaDocs/Documenter.jl/pull/1551
+[github-1556]: https://github.com/JuliaDocs/Documenter.jl/issues/1556
+[github-1557]: https://github.com/JuliaDocs/Documenter.jl/pull/1557
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 [julia-39841]: https://github.com/JuliaLang/julia/pull/39841

--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -134,7 +134,22 @@ function doctest(ctx::DocTestContext, block_immutable::Markdown2.CodeBlock)
         d = Dict()
         idx = findfirst(c -> c == ';', lang)
         if idx !== nothing
-            kwargs = Meta.parse("($(lang[nextind(lang, idx):end]),)")
+            kwargs = try
+                Meta.parse("($(lang[nextind(lang, idx):end]),)")
+            catch e
+                e isa Meta.ParseError || rethrow(e)
+                file = ctx.meta[:CurrentFile]
+                lines = Utilities.find_block_in_file(block.code, file)
+                @warn("""
+                    Unable to parse doctest keyword arguments in $(Utilities.locrepr(file, lines))
+                    Use ```jldoctest name; key1 = value1, key2 = value2
+
+                    ```$(lang)
+                    $(block.code)
+                    ```
+                    """, parse_error = e)
+                return false
+            end
             for kwarg in kwargs.args
                 if !(isa(kwarg, Expr) && kwarg.head === :(=) && isa(kwarg.args[1], Symbol))
                     file = ctx.meta[:CurrentFile]

--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -138,6 +138,7 @@ function doctest(ctx::DocTestContext, block_immutable::Markdown2.CodeBlock)
                 Meta.parse("($(lang[nextind(lang, idx):end]),)")
             catch e
                 e isa Meta.ParseError || rethrow(e)
+                push!(ctx.doc.internal.errors, :doctest)
                 file = ctx.meta[:CurrentFile]
                 lines = Utilities.find_block_in_file(block.code, file)
                 @warn("""
@@ -152,6 +153,7 @@ function doctest(ctx::DocTestContext, block_immutable::Markdown2.CodeBlock)
             end
             for kwarg in kwargs.args
                 if !(isa(kwarg, Expr) && kwarg.head === :(=) && isa(kwarg.args[1], Symbol))
+                    push!(ctx.doc.internal.errors, :doctest)
                     file = ctx.meta[:CurrentFile]
                     lines = Utilities.find_block_in_file(block.code, file)
                     @warn("""

--- a/test/TestUtilities.jl
+++ b/test/TestUtilities.jl
@@ -25,20 +25,17 @@ function _quietly(f, expr, source)
         println(io, "@quietly: $(source.file):$(source.line)")
         println(io, "@quietly: typeof(result) = ", typeof(c.value))
         println(io, "@quietly: STDOUT")
-        println(io, output)
+        println(io, c.output)
         println(io, "@quietly: end of STDOUT")
-        if success
-            println(io, "@quietly: result =")
-            println(io, c.value)
-        else
+        if c.error
             println(io, "@quietly: result (error) =")
             showerror(io, c.value, c.backtrace)
+        else
+            println(io, "@quietly: result =")
+            println(io, c.value)
         end
     end
-    if !c.error
-        printstyled("@quietly: success, $(sizeof(c.output)) bytes of output hidden\n"; color=:magenta)
-        return c.value
-    else
+    if c.error
         @error """
         An error was thrown in @quietly, $(sizeof(c.output)) bytes of output captured
         $(typeof(c.value)) at $(source.file):$(source.line) in expression:
@@ -51,6 +48,22 @@ function _quietly(f, expr, source)
             printstyled("$("="^27) @quietly: end of output $("="^28)\n"; color=:magenta)
         end
         throw(QuietlyException(c.value, c.backtrace))
+    elseif c.value isa Test.DefaultTestSet && !is_success(c.value)
+        @error """
+        @quietly: a testset with failures, $(sizeof(c.output)) bytes of output captured
+        $(typeof(c.value)) at $(source.file):$(source.line) in expression:
+        $(expr)
+        """ TestSet = c.value
+        if !isempty(c.output)
+            printstyled("$("="^21) @quietly: output from the expression $("="^21)\n"; color=:magenta)
+            print(c.output)
+            last(c.output) != "\n" && println()
+            printstyled("$("="^27) @quietly: end of output $("="^28)\n"; color=:magenta)
+        end
+        return c.value
+    else
+        printstyled("@quietly: success, $(sizeof(c.output)) bytes of output hidden\n"; color=:magenta)
+        return c.value
     end
 end
 macro quietly(expr)
@@ -61,6 +74,15 @@ macro quietly(expr)
             $(esc(expr))
         end
     end
+end
+
+is_success(testset::Test.DefaultTestSet) = !(testset.anynonpass || !is_success(testset.results))
+is_success(ts::AbstractArray) = all(is_success.(ts))
+is_success(::Test.Fail) = false
+is_success(::Test.Pass) = true
+function is_success(x)
+    @warn "Unimplemented TestUtilities.is_success method" typeof(x) x
+    return false
 end
 
 end

--- a/test/doctests/doctestapi.jl
+++ b/test/doctests/doctestapi.jl
@@ -171,6 +171,22 @@ module PR1075
     @doc @doc(bar) function baz end
 end
 
+"""
+```jldoctest;
+julia> 2 + 2
+4
+```
+"""
+module BadDocTestKwargs1 end
+
+"""
+```jldoctest; %%%
+julia> 2 + 2
+4
+```
+"""
+module BadDocTestKwargs2 end
+
 @testset "Documenter.doctest" begin
     # DocTest1
     run_doctest(nothing, [DocTest1]) do result, success, backtrace, output
@@ -247,6 +263,16 @@ end
     run_doctest(nothing, [PR1075]) do result, success, backtrace, output
         @test success
         @test result isa Test.DefaultTestSet
+    end
+
+    # Issue 1556, PR 1557
+    run_doctest(nothing, [BadDocTestKwargs1]) do result, success, backtrace, output
+        @test !success
+        @test result isa TestSetException
+    end
+    run_doctest(nothing, [BadDocTestKwargs2]) do result, success, backtrace, output
+        @test !success
+        @test result isa TestSetException
     end
 end
 

--- a/test/doctests/doctestapi.jl
+++ b/test/doctests/doctestapi.jl
@@ -187,6 +187,14 @@ julia> 2 + 2
 """
 module BadDocTestKwargs2 end
 
+"""
+```jldoctest; foo
+julia> 2 + 2
+4
+```
+"""
+module BadDocTestKwargs3 end
+
 @testset "Documenter.doctest" begin
     # DocTest1
     run_doctest(nothing, [DocTest1]) do result, success, backtrace, output
@@ -271,6 +279,10 @@ module BadDocTestKwargs2 end
         @test result isa TestSetException
     end
     run_doctest(nothing, [BadDocTestKwargs2]) do result, success, backtrace, output
+        @test !success
+        @test result isa TestSetException
+    end
+    run_doctest(nothing, [BadDocTestKwargs3]) do result, success, backtrace, output
         @test !success
         @test result isa TestSetException
     end


### PR DESCRIPTION
Does two things:

1. If `Meta.parse` fails to parse the doctest keyword arguments (x-ref #1556), it will gracefully report a doctest failure and move on (rather than making `makedocs` throw an unhelpful `Meta.ParseError`).
2. If the keyword argument parsing fails, these now get logged as doctesting errors, and will fail the build with `strict = true`. Currently we just print a warning and move on.

Will close #1556. @fingolfin, do you mind trying out this branch for your case?