### PR TITLE
Change Julia v1.4 -> v1.6 in Travis CI/Github Actions workflows

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -51,7 +51,7 @@ file. Note that the snippet below will not work by itself and must be accompanie
 jobs:
   include:
     - stage: "Documentation"
-      julia: 1.4
+      julia: 1.6
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
@@ -62,7 +62,7 @@ jobs:
 
 where the `julia:` and `os:` entries decide the worker from which the docs are built and
 deployed. In the example above we will thus build and deploy the documentation from a linux
-worker running Julia 1.4. For more information on how to setup a build stage, see the Travis
+worker running Julia 1.6. For more information on how to setup a build stage, see the Travis
 manual for [Build Stages](https://docs.travis-ci.com/user/build-stages).
 
 The three lines in the `script:` section do the following:
@@ -194,7 +194,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.4'
+          version: '1.6'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
@@ -207,7 +207,7 @@ jobs:
 which will install Julia, checkout the correct commit of your repository, and run the
 build of the documentation. The `julia-version:`, `julia-arch:` and `os:` entries decide
 the environment from which the docs are built and deployed. In the example above we will
-thus build and deploy the documentation from a ubuntu worker running Julia 1.4. For more
+thus build and deploy the documentation from a ubuntu worker running Julia 1.6. For more
 information on how to setup a GitHub workflow see the manual:
 [Learn GitHub Actions](https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions).
 


### PR DESCRIPTION
This PR changes the Travis CI and Github Actions workflows for deploying the Docs to use Julia v1.6 (instead of v1.4).