### PR TITLE
restore the global seed after calling into IOCapture

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 

--- a/test/doctests/src/working.md
+++ b/test/doctests/src/working.md
@@ -60,3 +60,16 @@ Empty output:
 nothing
 # output
 ```
+
+RNG seeding
+
+```jldoctest; setup = :(using Random; Random.seed!(1))
+julia> a = rand();
+
+julia> Random.seed!(1);
+
+julia> b = rand();
+
+julia> a == b
+true
+```


### PR DESCRIPTION
See the discussion in https://github.com/JuliaLang/julia/pull/41184#issuecomment-859384653.