### PR TITLE
check for empty entries in generate_version_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Documenter.jl changelog
 
+## Version `v0.27.1`
+
+* ![Bugfix][badge-bugfix] Documenter no longer throws an error when generating the version selector if there are no deployed versions. ([#1594][github-1594], [#1596][github-1596])
+
 ## Version `v0.27.0`
 
 * ![Enhancement][badge-enhancement] The JS dependencies have been updated to their respective latest versions.
@@ -808,6 +812,8 @@
 [github-1567]: https://github.com/JuliaDocs/Documenter.jl/pull/1567
 [github-1577]: https://github.com/JuliaDocs/Documenter.jl/pull/1577
 [github-1590]: https://github.com/JuliaDocs/Documenter.jl/pull/1590
+[github-1594]: https://github.com/JuliaDocs/Documenter.jl/issues/1594
+[github-1596]: https://github.com/JuliaDocs/Documenter.jl/pull/1596
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 [julia-39841]: https://github.com/JuliaLang/julia/pull/39841

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1312,6 +1312,9 @@ function generate_version_file(versionfile::AbstractString, entries, symlinks = 
         end
         println(buf, "];")
 
+        # entries is empty if no versions have been built at all
+        isempty(entries) && return
+
         # The first element in entries corresponds to the latest version, but is usually not the full version
         # number. So this essentially follows the symlinks that will be generated to figure out the full
         # version number (stored in DOCUMENTER_CURRENT_VERSION in siteinfo.js).


### PR DESCRIPTION
Should fix https://github.com/JuliaDocs/Documenter.jl/issues/1594.

Should be perfectly fine to omit writing `DOCUMENTER_NEWEST` and `DOCUMENTER_STABLE` if there are no previously generated docs, since the warning will not be shown in that case anyways.