### PR TITLE
Fix ANSI colors for `@repl` blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version `v0.27.4`
 
-* ![Feature][badge-feature] `@example`- and `@repl`-blocks now support colored output by mapping ANSI escape sequences to HTML. This requires Julia >= 1.6 and passing `ansicolor=true` to `Documenter.HTML` (e.g. `makedocs(format=Documenter.HTML(ansicolor=true, ...), ...)`). In Documenter 0.28.0 this will be the default so to (preemptively) opt-out pass `ansicolor=false`. ([#1441][github-1441])
+* ![Feature][badge-feature] `@example`- and `@repl`-blocks now support colored output by mapping ANSI escape sequences to HTML. This requires Julia >= 1.6 and passing `ansicolor=true` to `Documenter.HTML` (e.g. `makedocs(format=Documenter.HTML(ansicolor=true, ...), ...)`). In Documenter 0.28.0 this will be the default so to (preemptively) opt-out pass `ansicolor=false`. ([#1441][github-1441], [#1628][github-1628])
 
 * ![Bugfix][badge-bugfix] Dollar signs in the HTML output no longer get accidentally misinterpreted as math delimiters in the browser. ([#890](github-890), [#1625](github-1625))
 
@@ -852,6 +852,7 @@
 [github-1616]: https://github.com/JuliaDocs/Documenter.jl/pull/1616
 [github-1617]: https://github.com/JuliaDocs/Documenter.jl/pull/1617
 [github-1625]: https://github.com/JuliaDocs/Documenter.jl/pull/1625
+[github-1628]: https://github.com/JuliaDocs/Documenter.jl/pull/1628
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 [julia-39841]: https://github.com/JuliaLang/julia/pull/39841

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -169,6 +169,24 @@ struct MultiOutput
     content::Vector
 end
 
+struct MultiCodeBlock
+    language::String
+    content::Vector
+end
+function join_multiblock(mcb::MultiCodeBlock)
+    io = IOBuffer()
+    for (i, thing) in enumerate(mcb.content)
+        print(io, thing.code)
+        if i != length(mcb.content)
+            println(io)
+            if findnext(x -> x.language == mcb.language, mcb.content, i + 1) == i + 1
+                println(io)
+            end
+        end
+    end
+    return Markdown.Code(mcb.language, String(take!(io)))
+end
+
 # Navigation
 # ----------------------
 

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -478,6 +478,10 @@ function latex(io::IO, code::Markdown.Code)
     end
 end
 
+function latex(io::IO, mcb::Documents.MultiCodeBlock)
+    latex(io, Documents.join_multiblock(mcb))
+end
+
 function _print_code_escapes_minted(io, s::AbstractString)
     for ch in s
         ch === '#' ? _print(io, "##%") :

--- a/src/Writers/MarkdownWriter.jl
+++ b/src/Writers/MarkdownWriter.jl
@@ -145,6 +145,10 @@ function render(io::IO, mime::MIME"text/plain", node::Documents.EvalNode, page, 
     node.result === nothing ? nothing : render(io, mime, node.result, page, doc)
 end
 
+function render(io::IO, mime::MIME"text/plain", mcb::Documents.MultiCodeBlock, page, doc)
+    render(io, mime, Documents.join_multiblock(mcb), page, doc)
+end
+
 # Select the "best" representation for Markdown output.
 using Base64: base64decode
 function render(io::IO, mime::MIME"text/plain", d::Documents.MultiOutput, page, doc)


### PR DESCRIPTION
Each `@repl` block are now constructed of multiple `<code>` blocks under the same `<pre>`. Input blocks have `class="language-julia-repl"` (enabling highlightjs) and output blocks have `class="nohighlight"` (disabling highlightjs).