### PR TITLE
Remove highlight.js configuration for ignoring unescaped HTML in code blocks.

### DIFF
--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -499,8 +499,6 @@ module RD
             ["\$"],
             raw"""
             $(document).ready(function() {
-                hljs.configure({ignoreUnescapedHTML: true}); // for ANSI color support
-                /* TODO: add a plugin for unescaped HTML */
                 hljs.highlightAll();
             })
             """


### PR DESCRIPTION
This is not needed after https://github.com/JuliaDocs/Documenter.jl/pull/1628 since the ansi html is in a separate block.