### PR TITLE
Insert correct linenumbernodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * ![Enhancement][badge-enhancement] The sandbox module used for evaluating `@repl` and `@example` blocks is now removed (replaced with `Main`) in text output. ([#1633][github-1633])
 
+* ![Enhancement][badge-enhancement] `@repl`, `@example`, and `@eval` blocks now have `LineNumberNodes` inserted such that e.g. `@__FILE__` and `@__LINE__` give better output and not just `"none"` for the file and `1` for the line. This requires Julia 1.6 or higher (no change on earlier Julia versions). ([#1634][github-1634])
+
 * ![Bugfix][badge-bugfix] Dollar signs in the HTML output no longer get accidentally misinterpreted as math delimiters in the browser. ([#890](github-890), [#1625](github-1625))
 
 ## Version `v0.27.3`
@@ -856,6 +858,7 @@
 [github-1625]: https://github.com/JuliaDocs/Documenter.jl/pull/1625
 [github-1628]: https://github.com/JuliaDocs/Documenter.jl/pull/1628
 [github-1633]: https://github.com/JuliaDocs/Documenter.jl/pull/1633
+[github-1634]: https://github.com/JuliaDocs/Documenter.jl/pull/1634
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 [julia-39841]: https://github.com/JuliaLang/julia/pull/39841

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -198,6 +198,7 @@ htmlbuild_pages = Any[
     "latex.md",
     "example-output.md",
     "fonts.md",
+    "linenumbers.md",
 ]
 
 function html_doc(build_directory, mathengine)
@@ -451,6 +452,7 @@ examples_latex_texonly_doc = if "latex_texonly" in EXAMPLE_BUILDS
                 "unicode.md",
                 hide("hidden.md"),
                 "example-output.md",
+                "linenumbers.md",
             ],
             # SVG images nor code blocks in footnotes are allowed in LaTeX
             # "Manual" => [

--- a/test/examples/src/linenumbers.md
+++ b/test/examples/src/linenumbers.md
@@ -1,0 +1,36 @@
+# `@repl`, `@example`, and `@eval` have correct `LineNumberNode`s inserted
+
+Add new things at the bottom!!
+
+```@repl
+println("@__FILE__ should be REPL[1]: ", @__FILE__)
+println("@__FILE__ should be REPL[2]: ", @__FILE__)
+println("@__LINE__ should be 1: ", @__LINE__)
+@warn "@__FILE__ should be REPL[4] and @__LINE__ 1"
+begin
+    println("@__FILE__ should be REPL[5]: ", @__FILE__)
+    println("@__FILE__ should be REPL[5]: ", @__FILE__)
+    println("@__LINE__ should be 4: ", @__LINE__)
+    @warn "@__FILE__ should be REPL[5] and @__LINE__ 5"
+end
+```
+
+```@example
+println("@__FILE__ should be linenumbers.md: ", @__FILE__)
+println("@__LINE__ should be 20: ", @__LINE__)
+@warn "@__FILE__ should be linenumbers.md and @__LINE__ 21"
+begin
+    println("@__FILE__ should be linenumbers.md: ", @__FILE__)
+    println("@__LINE__ should be 24: ", @__LINE__)
+    @warn "@__FILE__ should be linenumbers.md and @__LINE__ 25"
+end
+```
+
+````@eval
+import Markdown
+Markdown.parse("""```
+\$(@__FILE__):\$(@__LINE__) should be linenumbers.md:32: $(@__FILE__):$(@__LINE__)
+\$(@__FILE__):\$(@__LINE__) should be linenumbers.md:33: $(@__FILE__):$(@__LINE__)
+```
+""")
+````

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -134,7 +134,7 @@ end
 
         @test realpath(doc.internal.assets) == realpath(joinpath(dirname(@__FILE__), "..", "..", "assets"))
 
-        @test length(doc.blueprint.pages) == 20
+        @test length(doc.blueprint.pages) == 21
 
         let headers = doc.internal.headers
             @test Documenter.Anchors.exists(headers, "Documentation")


### PR DESCRIPTION
Example: this block
````
```@repl
println("@__FILE__ should be REPL[1]: ", @__FILE__)
println("@__FILE__ should be REPL[2]: ", @__FILE__)
println("@__LINE__ should be 1: ", @__LINE__)
@warn "@__FILE__ should be REPL[4] and @__LINE__ 1"
begin
    println("@__FILE__ should be REPL[5]: ", @__FILE__)
    println("@__FILE__ should be REPL[5]: ", @__FILE__)
    println("@__LINE__ should be 4: ", @__LINE__)
    @warn "@__FILE__ should be REPL[5] and @__LINE__ 5"
end
```
````

gives before this PR (and https://github.com/JuliaDocs/Documenter.jl/pull/1633) (notice all `none` and `Main.__atexample__258` for example)

```
julia> println("@__FILE__ should be REPL[1]: ", @__FILE__)
@__FILE__ should be REPL[1]: none

julia> println("@__FILE__ should be REPL[2]: ", @__FILE__)
@__FILE__ should be REPL[2]: none

julia> println("@__LINE__ should be 1: ", @__LINE__)
@__LINE__ should be 1: 1

julia> @warn "@__FILE__ should be REPL[4] and @__LINE__ 1"
┌ Warning: @__FILE__ should be REPL[4] and @__LINE__ 1
└ @ Main.__atexample__258 none:1

julia> begin
           println("@__FILE__ should be REPL[5]: ", @__FILE__)
           println("@__FILE__ should be REPL[5]: ", @__FILE__)
           println("@__LINE__ should be 4: ", @__LINE__)
           @warn "@__FILE__ should be REPL[5] and @__LINE__ 5"
       end
@__FILE__ should be REPL[5]: none
@__FILE__ should be REPL[5]: none
@__LINE__ should be 4: 4
┌ Warning: @__FILE__ should be REPL[5] and @__LINE__ 5
└ @ Main.__atexample__258 none:5
```

and after:
```
julia> println("@__FILE__ should be REPL[1]: ", @__FILE__)
@__FILE__ should be REPL[1]: REPL[1]

julia> println("@__FILE__ should be REPL[2]: ", @__FILE__)
@__FILE__ should be REPL[2]: REPL[2]

julia> println("@__LINE__ should be 1: ", @__LINE__)
@__LINE__ should be 1: 1

julia> @warn "@__FILE__ should be REPL[4] and @__LINE__ 1"
┌ Warning: @__FILE__ should be REPL[4] and @__LINE__ 1
└ @ Main REPL[4]:1

julia> begin
           println("@__FILE__ should be REPL[5]: ", @__FILE__)
           println("@__FILE__ should be REPL[5]: ", @__FILE__)
           println("@__LINE__ should be 4: ", @__LINE__)
           @warn "@__FILE__ should be REPL[5] and @__LINE__ 5"
       end
@__FILE__ should be REPL[5]: REPL[5]
@__FILE__ should be REPL[5]: REPL[5]
@__LINE__ should be 4: 4
┌ Warning: @__FILE__ should be REPL[5] and @__LINE__ 5
└ @ Main REPL[5]:5
```