### PR TITLE
WIP: enable `@repl`, `@example` etc in admonition, lists etc

### DIFF
--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -39,11 +39,26 @@ function expand(doc::Documents.Document)
         @debug "Running ExpanderPipeline on $src"
         empty!(page.globals.meta)
         for element in page.elements
-            Selectors.dispatch(ExpanderPipeline, element, page, doc)
+            run_dispatch(element, page, doc)
         end
         pagecheck(page)
     end
 end
+
+run_dispatch(element, page, doc) = Selectors.dispatch(ExpanderPipeline, element, page, doc)
+function run_dispatch(element::Markdown.List, page, doc)
+    Selectors.dispatch(ExpanderPipeline, element, page, doc)
+    foreach(x -> run_dispatch(x, page, doc), element.items)
+end
+function run_dispatch(element::Markdown.Admonition, page, doc)
+    Selectors.dispatch(ExpanderPipeline, element, page, doc)
+    foreach(x -> run_dispatch(x, page, doc), element.content)
+end
+function run_dispatch(element::Vector, page, doc)
+    foreach(x -> run_dispatch(x, page, doc), element)
+end
+
+
 
 # run some checks after expanding the page
 function pagecheck(page)


### PR DESCRIPTION
This is a WIP to show one possible way of solving https://github.com/JuliaDocs/Documenter.jl/issues/491. It does this by recursing through the AST expand non-root nodes. Then in the HTML writer, the mapping created is passed through down all the way to `mdconvert` in a keyword argument and we then look up if we have an expanded version to use.

For a markdown with the following content:

````md
- foo
  ```@repl
  1+1
  ```
  - bar
    ```@example
    1+1 == 2
    ```

!!! warning
    ```@repl
    1+1
    ```

```@repl
2+2
````

it generates a HTML page as:

![bild](https://user-images.githubusercontent.com/1282691/124797242-587f9280-df52-11eb-9d6b-c0ed1043fcc1.png)

No tests or anything yet because it would be good to get some feedback if the proposed method makes sense.