### PR TITLE
Theme the `julia>` prompt in the `julia-repl` language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   ```
   _This feature is experimental and subject to change in future releases._ ([#1627][github-1627])
 
+* ![Enhancement][badge-enhancement] The `julia>` prompt is now colored in green in the `julia-repl` language highlighting. ([#1639][github-1639], [#1641][github-1641])
+
 * ![Enhancement][badge-enhancement] The sandbox module used for evaluating `@repl` and `@example` blocks is now removed (replaced with `Main`) in text output. ([#1633][github-1633])
 
 * ![Enhancement][badge-enhancement] `@repl`, `@example`, and `@eval` blocks now have `LineNumberNodes` inserted such that e.g. `@__FILE__` and `@__LINE__` give better output and not just `"none"` for the file and `1` for the line. This requires Julia 1.6 or higher (no change on earlier Julia versions). ([#1634][github-1634])
@@ -875,6 +877,8 @@
 [github-1628]: https://github.com/JuliaDocs/Documenter.jl/pull/1628
 [github-1633]: https://github.com/JuliaDocs/Documenter.jl/pull/1633
 [github-1634]: https://github.com/JuliaDocs/Documenter.jl/pull/1634
+[github-1639]: https://github.com/JuliaDocs/Documenter.jl/issues/1639
+[github-1641]: https://github.com/JuliaDocs/Documenter.jl/pull/1641
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 [julia-39841]: https://github.com/JuliaLang/julia/pull/39841

--- a/assets/html/scss/documenter-dark.scss
+++ b/assets/html/scss/documenter-dark.scss
@@ -93,6 +93,12 @@ html.theme--#{$themename} {
 
   @import "documenter/ansicolors";
 
+  // highlight.js color scheme override for the julia> prompt
+  code.language-julia-repl > span.hljs-meta {
+    color: $ansi-green;
+    font-weight: bolder;
+  }
+
   // FIXME: Hack to get a proper theme for highlight.js in the Darkly theme
   @import "highlightjs/a11y-dark";
   // Also, a11y-dark does not highlight string interpolation properly.

--- a/assets/html/scss/documenter-light.scss
+++ b/assets/html/scss/documenter-light.scss
@@ -21,6 +21,12 @@
 
 @import "documenter/ansicolors";
 
+// highlight.js color scheme override for the julia> prompt
+code.language-julia-repl > span.hljs-meta {
+  color: $ansi-green;
+  font-weight: bolder;
+}
+
 // Workaround to compile in highlightjs theme, so that we could have different
 // themes for both
 @import "highlightjs/default"

--- a/assets/html/scss/documenter/_patches.scss
+++ b/assets/html/scss/documenter/_patches.scss
@@ -53,7 +53,6 @@ pre, code {
   background: initial !important;
   padding: initial !important;
 }
-
 // There appears to be a rendering bug in Chrome, where elements with `position: absolute` in
 // an overflow container affect whether the outer container is overflowing / needs
 // scrollbars.

--- a/assets/html/themes/documenter-dark.css
+++ b/assets/html/themes/documenter-dark.css
@@ -7685,6 +7685,9 @@ html.theme--documenter-dark {
     background-color: #1db4c9; }
   html.theme--documenter-dark .ansi span.sgr107 {
     background-color: #ecf0f1; }
+  html.theme--documenter-dark code.language-julia-repl > span.hljs-meta {
+    color: #2ecc71;
+    font-weight: bolder; }
   html.theme--documenter-dark .hljs {
     background: #2b2b2b;
     color: #f8f8f2; }

--- a/assets/html/themes/documenter-light.css
+++ b/assets/html/themes/documenter-light.css
@@ -7702,6 +7702,10 @@ html {
 .ansi span.sgr107 {
   background-color: whitesmoke; }
 
+code.language-julia-repl > span.hljs-meta {
+  color: #1a9847;
+  font-weight: bolder; }
+
 /*!
   Theme: Default
   Description: Original highlight.js style


### PR DESCRIPTION
Theme the `julia>` prompt in the `julia-repl` language as green using the same color as the ANSI color green for respective theme.