### PR TITLE
[RFC] Tweak color schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version `v0.27.4`
 
-* ![Feature][badge-feature] `@example`- and `@repl`-blocks now support colored output by mapping ANSI escape sequences to HTML. This requires Julia >= 1.6 and passing `ansicolor=true` to `Documenter.HTML` (e.g. `makedocs(format=Documenter.HTML(ansicolor=true, ...), ...)`). In Documenter 0.28.0 this will be the default so to (preemptively) opt-out pass `ansicolor=false`. ([#1441][github-1441], [#1628][github-1628])
+* ![Feature][badge-feature] `@example`- and `@repl`-blocks now support colored output by mapping ANSI escape sequences to HTML. This requires Julia >= 1.6 and passing `ansicolor=true` to `Documenter.HTML` (e.g. `makedocs(format=Documenter.HTML(ansicolor=true, ...), ...)`). In Documenter 0.28.0 this will be the default so to (preemptively) opt-out pass `ansicolor=false`. ([#1441][github-1441], [#1628][github-1628], [#1629][github-1629], [#1647][github-1647])
 
 * ![Experimental][badge-experimental] ![Feature][badge-feature] Documenter's HTML output can now prerender syntax highlighting of code blocks, i.e. syntax highlighting is applied when generating the HTML page rather than on the fly in the browser after the page is loaded. This requires (i) passing `prerender=true` to `Documenter.HTML` and (ii) a `node` (NodeJS) executable available in `PATH`. A path to a `node` executable can be specified by passing the `node` keyword argument to `Documenter.HTML` (for example from the `NodeJS_16_jll` Julia package). In addition, the `highlightjs` keyword argument can be used to specify a file path to a highlight.js library (if this is not given the release used by Documenter will be used). Example configuration:
   ```julia
@@ -877,11 +877,13 @@
 [github-1625]: https://github.com/JuliaDocs/Documenter.jl/pull/1625
 [github-1627]: https://github.com/JuliaDocs/Documenter.jl/pull/1627
 [github-1628]: https://github.com/JuliaDocs/Documenter.jl/pull/1628
+[github-1629]: https://github.com/JuliaDocs/Documenter.jl/issues/1629
 [github-1633]: https://github.com/JuliaDocs/Documenter.jl/pull/1633
 [github-1634]: https://github.com/JuliaDocs/Documenter.jl/pull/1634
 [github-1639]: https://github.com/JuliaDocs/Documenter.jl/issues/1639
 [github-1641]: https://github.com/JuliaDocs/Documenter.jl/pull/1641
 [github-1645]: https://github.com/JuliaDocs/Documenter.jl/pull/1645
+[github-1647]: https://github.com/JuliaDocs/Documenter.jl/pull/1647
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 [julia-39841]: https://github.com/JuliaLang/julia/pull/39841

--- a/assets/html/scss/documenter-dark.scss
+++ b/assets/html/scss/documenter-dark.scss
@@ -14,11 +14,20 @@ $documenter-is-dark-theme: true;
 $family-sans-serif: 'Lato Medium', -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
 $family-monospace: 'JuliaMono', 'SFMono-Regular', 'Menlo', 'Consolas', 'Liberation Mono', 'DejaVu Sans Mono', monospace;
 
+$red: #cb3c33;
+$orange: #d56c00;
+$yellow: #f4c72f;
+$green: #259a12;
+$turquoise: #00a1b7;
+$cyan: #3489da;
+$blue: #3c5dcd;
+$purple: #9558b2;
+
 $info: #024c7d;
 $success: #008438;
 $warning: #ad8100;
 $danger: #9e1b0d;
-$turquoise: #137886;
+$compat: #137886;
 
 $admonition-background: (
   'default': $background, 'info': $background, 'success': $background, 'warning': $background,
@@ -38,7 +47,7 @@ $border-width: 1px;
 @import "documenter/utilities";
 @import "documenter/variables";
 
-$code: $red;
+$code: #e74c3c;
 $code-background: rgba(255, 255, 255, 0.05);
 
 $documenter-docstring-shadow: none;

--- a/assets/html/scss/documenter-light.scss
+++ b/assets/html/scss/documenter-light.scss
@@ -1,5 +1,12 @@
 @charset "UTF-8";
 
+// TODO: use default colors
+$info: #209cee;
+$success: #22c35b;
+$warning: #ffdd57;
+$danger: #da0b00;
+$compat: #1db5c9;
+
 @import "documenter/utilities";
 @import "documenter/variables";
 

--- a/assets/html/scss/documenter/_ansicolors.scss
+++ b/assets/html/scss/documenter/_ansicolors.scss
@@ -5,7 +5,7 @@ $ansi-yellow: null !default;
 $ansi-blue: null !default;
 $ansi-magenta: null !default;
 $ansi-cyan: null !default;
-$ansi-white: $grey-lighter !default;
+$ansi-white: null !default;
 
 $ansi-light-black: null !default;
 $ansi-light-red: null !default;
@@ -17,39 +17,38 @@ $ansi-light-cyan: null !default;
 $ansi-light-white: $white-ter !default;
 
 @if $documenter-is-dark-theme {
-  $ansi-red: $red !default;
-  $ansi-green: $green !default;
+  $ansi-red: adjust-color($red, $hue: 3, $saturation: 29, $lightness: 17) !default;
+  $ansi-green: adjust-color($green, $hue: -2, $saturation: -28, $lightness: 13) !default;
   $ansi-yellow: $yellow !default;
-  $ansi-blue: $blue !default;
-  $ansi-magenta: $purple !default;
-  $ansi-cyan: $turquoise !default;
+  $ansi-blue: adjust-color($blue, $hue: 5, $saturation: 21, $lightness: 18) !default;
+  $ansi-magenta: adjust-color($purple, $hue: 1, $saturation: 9, $lightness: 16) !default;
+  $ansi-cyan: adjust-color($turquoise, $hue: 2, $saturation: -45, $lightness: 18) !default;
+  $ansi-white: lighten($grey-light, 14) !default;
 
-  $ansi-light-black: $grey-light !default;
-
-  $ansi-light-red: lighten($ansi-red, 15) !default;
-  $ansi-light-green: lighten($ansi-green, 15) !default;
-  $ansi-light-yellow: lighten($ansi-yellow, 10) !default;
-  $ansi-light-blue: lighten($ansi-blue, 15) !default;
-  $ansi-light-magenta: lighten($ansi-magenta, 10) !default;
-  $ansi-light-cyan: lighten($ansi-cyan, 15) !default;
+  $ansi-light-black: darken($ansi-white, 12) !default;
+  $ansi-light-red: adjust-color($ansi-red, $hue: 1, $saturation: 11, $lightness: 6) !default;
+  $ansi-light-green: adjust-color($ansi-green, $hue: -2, $saturation: 6, $lightness: 14) !default;
+  $ansi-light-yellow: adjust-color($ansi-yellow, $hue: 4, $saturation: 10, $lightness: 14) !default;
+  $ansi-light-blue: adjust-color($ansi-blue, $hue: 1, $saturation: 20, $lightness: 7) !default;
+  $ansi-light-magenta: adjust-color($ansi-magenta, $hue: 0, $saturation: 11, $lightness: 9) !default;
+  $ansi-light-cyan: adjust-color($ansi-cyan, $hue: 1, $saturation: 6, $lightness: 10) !default;
 }
-
 @else {
+  $ansi-light-black: darken($grey, 4) !default;
   $ansi-light-red: $red !default;
-  $ansi-light-green: $green !default;
-  $ansi-light-yellow: $yellow !default;
+  $ansi-light-green: adjust-color($green, $hue: 2, $saturation: 21, $lightness: -8) !default;
+  $ansi-light-yellow: adjust-color($yellow, $hue: 2, $saturation: 10, $lightness: -24) !default;
   $ansi-light-blue: $blue !default;
-  $ansi-light-magenta: $purple !default;
-  $ansi-light-cyan: $turquoise !default;
+  $ansi-light-magenta: adjust-color($purple, $hue: 0, $saturation: -1, $lightness: -1) !default;
+  $ansi-light-cyan: adjust-color($turquoise, $hue: 0, $saturation: 0, $lightness: -4) !default;
 
-  $ansi-light-black: $grey !default;
-
-  $ansi-red: darken($ansi-light-red, 10) !default;
-  $ansi-green: darken($ansi-light-green, 10) !default;
-  $ansi-yellow: darken($ansi-light-yellow, 18) !default;
-  $ansi-blue: darken($ansi-light-blue, 10) !default;
-  $ansi-magenta: darken($ansi-light-magenta, 15) !default;
-  $ansi-cyan: darken($ansi-light-cyan, 10) !default;
+  $ansi-red: adjust-color($ansi-light-red, $hue: -3, $saturation: 9, $lightness: -11) !default;
+  $ansi-green: adjust-color($ansi-light-green, $hue: 3, $saturation: 0, $lightness: -4) !default;
+  $ansi-yellow: adjust-color($ansi-light-yellow, $hue: 0, $saturation: 0, $lightness: -7) !default;
+  $ansi-blue: adjust-color($ansi-light-blue, $hue: -3, $saturation: 9, $lightness: -11) !default;
+  $ansi-magenta: adjust-color($ansi-light-magenta, $hue: 0, $saturation: 2, $lightness: -8) !default;
+  $ansi-cyan: adjust-color($ansi-light-cyan, $hue: 0, $saturation: 0, $lightness: -5) !default;
+  $ansi-white: lighten($ansi-light-black, 12) !default;
 }
 
 .ansi span {

--- a/assets/html/scss/documenter/_variables.scss
+++ b/assets/html/scss/documenter/_variables.scss
@@ -4,10 +4,18 @@
 // Colors
 // ------
 $primary: #4eb5de !default;
-$red: #da0b00 !default;
-$blue: #2e63b8 !default;
-$green: #22c35b !default;
-$turquoise: #1db5c9 !default;
+
+$red: #cb3c33 !default;
+$orange: #d56c00 !default;
+$yellow: #f4c72f !default;
+$green: #259a12 !default;
+$turquoise: #00a1b7 !default;
+$cyan: #3489da !default;
+$blue: #3c5dcd !default;
+$purple: #9558b2 !default;
+
+$link: #2e63b8 !default;
+$compat: $turquoise !default;
 $text: #222222 !default;
 $text-strong: $text !default;
 $code: #000000 !default;

--- a/assets/html/scss/documenter/components/_admonition.scss
+++ b/assets/html/scss/documenter/components/_admonition.scss
@@ -2,7 +2,7 @@
 // Original copyright (c) 2019 Jeremy Thomas, The MIT License (MIT)
 $admonition-colors: (
   'default': $grey-darker, 'info': $info, 'success': $success, 'warning': $warning,
-  'danger': $danger, 'compat': $turquoise,
+  'danger': $danger, 'compat': $compat,
 ) !default;
 
 $admonition-background: () !default;

--- a/assets/html/themes/documenter-dark.css
+++ b/assets/html/themes/documenter-dark.css
@@ -7624,69 +7624,69 @@ html.theme--documenter-dark {
   html.theme--documenter-dark .ansi span.sgr30 {
     color: #242424; }
   html.theme--documenter-dark .ansi span.sgr31 {
-    color: #e74c3c; }
+    color: #f6705f; }
   html.theme--documenter-dark .ansi span.sgr32 {
-    color: #2ecc71; }
+    color: #4fb43a; }
   html.theme--documenter-dark .ansi span.sgr33 {
-    color: #f1b70e; }
+    color: #f4c72f; }
   html.theme--documenter-dark .ansi span.sgr34 {
-    color: #3498db; }
+    color: #7587f0; }
   html.theme--documenter-dark .ansi span.sgr35 {
-    color: #8e44ad; }
+    color: #bc89d3; }
   html.theme--documenter-dark .ansi span.sgr36 {
-    color: #137886; }
+    color: #49b6ca; }
   html.theme--documenter-dark .ansi span.sgr37 {
-    color: #dbdee0; }
+    color: #b3bdbe; }
   html.theme--documenter-dark .ansi span.sgr40 {
     background-color: #242424; }
   html.theme--documenter-dark .ansi span.sgr41 {
-    background-color: #e74c3c; }
+    background-color: #f6705f; }
   html.theme--documenter-dark .ansi span.sgr42 {
-    background-color: #2ecc71; }
+    background-color: #4fb43a; }
   html.theme--documenter-dark .ansi span.sgr43 {
-    background-color: #f1b70e; }
+    background-color: #f4c72f; }
   html.theme--documenter-dark .ansi span.sgr44 {
-    background-color: #3498db; }
+    background-color: #7587f0; }
   html.theme--documenter-dark .ansi span.sgr45 {
-    background-color: #8e44ad; }
+    background-color: #bc89d3; }
   html.theme--documenter-dark .ansi span.sgr46 {
-    background-color: #137886; }
+    background-color: #49b6ca; }
   html.theme--documenter-dark .ansi span.sgr47 {
-    background-color: #dbdee0; }
+    background-color: #b3bdbe; }
   html.theme--documenter-dark .ansi span.sgr90 {
-    color: #8c9b9d; }
+    color: #92a0a2; }
   html.theme--documenter-dark .ansi span.sgr91 {
-    color: #ef8b80; }
+    color: #ff8674; }
   html.theme--documenter-dark .ansi span.sgr92 {
-    color: #69dd9a; }
+    color: #79d462; }
   html.theme--documenter-dark .ansi span.sgr93 {
-    color: #f4c53e; }
+    color: #ffe76b; }
   html.theme--documenter-dark .ansi span.sgr94 {
-    color: #75b9e7; }
+    color: #8a98ff; }
   html.theme--documenter-dark .ansi span.sgr95 {
-    color: #a563c1; }
+    color: #d2a4e6; }
   html.theme--documenter-dark .ansi span.sgr96 {
-    color: #1db4c9; }
+    color: #6bc8db; }
   html.theme--documenter-dark .ansi span.sgr97 {
     color: #ecf0f1; }
   html.theme--documenter-dark .ansi span.sgr100 {
-    background-color: #8c9b9d; }
+    background-color: #92a0a2; }
   html.theme--documenter-dark .ansi span.sgr101 {
-    background-color: #ef8b80; }
+    background-color: #ff8674; }
   html.theme--documenter-dark .ansi span.sgr102 {
-    background-color: #69dd9a; }
+    background-color: #79d462; }
   html.theme--documenter-dark .ansi span.sgr103 {
-    background-color: #f4c53e; }
+    background-color: #ffe76b; }
   html.theme--documenter-dark .ansi span.sgr104 {
-    background-color: #75b9e7; }
+    background-color: #8a98ff; }
   html.theme--documenter-dark .ansi span.sgr105 {
-    background-color: #a563c1; }
+    background-color: #d2a4e6; }
   html.theme--documenter-dark .ansi span.sgr106 {
-    background-color: #1db4c9; }
+    background-color: #6bc8db; }
   html.theme--documenter-dark .ansi span.sgr107 {
     background-color: #ecf0f1; }
   html.theme--documenter-dark code.language-julia-repl > span.hljs-meta {
-    color: #2ecc71;
+    color: #4fb43a;
     font-weight: bolder; }
   html.theme--documenter-dark .hljs {
     background: #2b2b2b;

--- a/assets/html/themes/documenter-light.css
+++ b/assets/html/themes/documenter-light.css
@@ -751,7 +751,7 @@ a.has-text-link:hover, a.has-text-link:focus {
   color: #209cee !important; }
 
 a.has-text-info:hover, a.has-text-info:focus {
-  color: #0f81cc !important; }
+  color: #1081cb !important; }
 
 .has-background-info {
   background-color: #209cee !important; }
@@ -1210,7 +1210,7 @@ a.box:active {
     border-color: #b5b5b5;
     color: #363636; }
   .button:focus, .button.is-focused {
-    border-color: #2e63b8;
+    border-color: #3c5dcd;
     color: #363636; }
     .button:focus:not(:active), .button.is-focused:not(:active) {
       box-shadow: 0 0 0 0.125em rgba(46, 99, 184, 0.25); }
@@ -1658,7 +1658,7 @@ a.box:active {
     border-color: transparent;
     color: #fff; }
     .button.is-info:hover, .button.is-info.is-hovered {
-      background-color: #1496ed;
+      background-color: #1497ed;
       border-color: transparent;
       color: #fff; }
     .button.is-info:focus, .button.is-info.is-focused {
@@ -1667,7 +1667,7 @@ a.box:active {
       .button.is-info:focus:not(:active), .button.is-info.is-focused:not(:active) {
         box-shadow: 0 0 0 0.125em rgba(32, 156, 238, 0.25); }
     .button.is-info:active, .button.is-info.is-active {
-      background-color: #118fe4;
+      background-color: #1190e3;
       border-color: transparent;
       color: #fff; }
     .button.is-info[disabled],
@@ -1794,7 +1794,7 @@ a.box:active {
     border-color: transparent;
     color: rgba(0, 0, 0, 0.7); }
     .button.is-warning:hover, .button.is-warning.is-hovered {
-      background-color: #ffdb4a;
+      background-color: #ffda4a;
       border-color: transparent;
       color: rgba(0, 0, 0, 0.7); }
     .button.is-warning:focus, .button.is-warning.is-focused {
@@ -1803,7 +1803,7 @@ a.box:active {
       .button.is-warning:focus:not(:active), .button.is-warning.is-focused:not(:active) {
         box-shadow: 0 0 0 0.125em rgba(255, 221, 87, 0.25); }
     .button.is-warning:active, .button.is-warning.is-active {
-      background-color: #ffd83d;
+      background-color: #ffd83e;
       border-color: transparent;
       color: rgba(0, 0, 0, 0.7); }
     .button.is-warning[disabled],
@@ -3087,7 +3087,7 @@ a.tag:hover, .docstring > section > a.docs-sourcelink:hover {
   .select.is-info select {
     border-color: #209cee; }
     .select.is-info select:hover, .select.is-info select.is-hovered {
-      border-color: #118fe4; }
+      border-color: #1190e3; }
     .select.is-info select:focus, .select.is-info select.is-focused, .select.is-info select:active, .select.is-info select.is-active {
       box-shadow: 0 0 0 0.125em rgba(32, 156, 238, 0.25); }
   .select.is-success:not(:hover)::after {
@@ -3103,7 +3103,7 @@ a.tag:hover, .docstring > section > a.docs-sourcelink:hover {
   .select.is-warning select {
     border-color: #ffdd57; }
     .select.is-warning select:hover, .select.is-warning select.is-hovered {
-      border-color: #ffd83d; }
+      border-color: #ffd83e; }
     .select.is-warning select:focus, .select.is-warning select.is-focused, .select.is-warning select:active, .select.is-warning select.is-active {
       box-shadow: 0 0 0 0.125em rgba(255, 221, 87, 0.25); }
   .select.is-danger:not(:hover)::after {
@@ -3246,7 +3246,7 @@ a.tag:hover, .docstring > section > a.docs-sourcelink:hover {
     border-color: transparent;
     color: #fff; }
   .file.is-info:hover .file-cta, .file.is-info.is-hovered .file-cta {
-    background-color: #1496ed;
+    background-color: #1497ed;
     border-color: transparent;
     color: #fff; }
   .file.is-info:focus .file-cta, .file.is-info.is-focused .file-cta {
@@ -3254,7 +3254,7 @@ a.tag:hover, .docstring > section > a.docs-sourcelink:hover {
     box-shadow: 0 0 0.5em rgba(32, 156, 238, 0.25);
     color: #fff; }
   .file.is-info:active .file-cta, .file.is-info.is-active .file-cta {
-    background-color: #118fe4;
+    background-color: #1190e3;
     border-color: transparent;
     color: #fff; }
   .file.is-success .file-cta {
@@ -3278,7 +3278,7 @@ a.tag:hover, .docstring > section > a.docs-sourcelink:hover {
     border-color: transparent;
     color: rgba(0, 0, 0, 0.7); }
   .file.is-warning:hover .file-cta, .file.is-warning.is-hovered .file-cta {
-    background-color: #ffdb4a;
+    background-color: #ffda4a;
     border-color: transparent;
     color: rgba(0, 0, 0, 0.7); }
   .file.is-warning:focus .file-cta, .file.is-warning.is-focused .file-cta {
@@ -3286,7 +3286,7 @@ a.tag:hover, .docstring > section > a.docs-sourcelink:hover {
     box-shadow: 0 0 0.5em rgba(255, 221, 87, 0.25);
     color: rgba(0, 0, 0, 0.7); }
   .file.is-warning:active .file-cta, .file.is-warning.is-active .file-cta {
-    background-color: #ffd83d;
+    background-color: #ffd83e;
     border-color: transparent;
     color: rgba(0, 0, 0, 0.7); }
   .file.is-danger .file-cta {
@@ -4100,7 +4100,7 @@ a.list-item {
       color: #fff; }
     .message.is-info .message-body {
       border-color: #209cee;
-      color: #12537e; }
+      color: #12537d; }
   .message.is-success {
     background-color: #f6fdf9; }
     .message.is-success .message-header {
@@ -4116,7 +4116,7 @@ a.list-item {
       color: rgba(0, 0, 0, 0.7); }
     .message.is-warning .message-body {
       border-color: #ffdd57;
-      color: #3b3108; }
+      color: #3c3108; }
   .message.is-danger {
     background-color: #fff5f5; }
     .message.is-danger .message-header {
@@ -4562,7 +4562,7 @@ a.list-item {
     .navbar.is-info .navbar-brand .navbar-link:focus,
     .navbar.is-info .navbar-brand .navbar-link:hover,
     .navbar.is-info .navbar-brand .navbar-link.is-active {
-      background-color: #118fe4;
+      background-color: #1190e3;
       color: #fff; }
     .navbar.is-info .navbar-brand .navbar-link::after {
       border-color: #fff; }
@@ -4584,7 +4584,7 @@ a.list-item {
       .navbar.is-info .navbar-end .navbar-link:focus,
       .navbar.is-info .navbar-end .navbar-link:hover,
       .navbar.is-info .navbar-end .navbar-link.is-active {
-        background-color: #118fe4;
+        background-color: #1190e3;
         color: #fff; }
       .navbar.is-info .navbar-start .navbar-link::after,
       .navbar.is-info .navbar-end .navbar-link::after {
@@ -4592,7 +4592,7 @@ a.list-item {
       .navbar.is-info .navbar-item.has-dropdown:focus .navbar-link,
       .navbar.is-info .navbar-item.has-dropdown:hover .navbar-link,
       .navbar.is-info .navbar-item.has-dropdown.is-active .navbar-link {
-        background-color: #118fe4;
+        background-color: #1190e3;
         color: #fff; }
       .navbar.is-info .navbar-dropdown a.navbar-item.is-active {
         background-color: #209cee;
@@ -4652,7 +4652,7 @@ a.list-item {
     .navbar.is-warning .navbar-brand .navbar-link:focus,
     .navbar.is-warning .navbar-brand .navbar-link:hover,
     .navbar.is-warning .navbar-brand .navbar-link.is-active {
-      background-color: #ffd83d;
+      background-color: #ffd83e;
       color: rgba(0, 0, 0, 0.7); }
     .navbar.is-warning .navbar-brand .navbar-link::after {
       border-color: rgba(0, 0, 0, 0.7); }
@@ -4674,7 +4674,7 @@ a.list-item {
       .navbar.is-warning .navbar-end .navbar-link:focus,
       .navbar.is-warning .navbar-end .navbar-link:hover,
       .navbar.is-warning .navbar-end .navbar-link.is-active {
-        background-color: #ffd83d;
+        background-color: #ffd83e;
         color: rgba(0, 0, 0, 0.7); }
       .navbar.is-warning .navbar-start .navbar-link::after,
       .navbar.is-warning .navbar-end .navbar-link::after {
@@ -4682,7 +4682,7 @@ a.list-item {
       .navbar.is-warning .navbar-item.has-dropdown:focus .navbar-link,
       .navbar.is-warning .navbar-item.has-dropdown:hover .navbar-link,
       .navbar.is-warning .navbar-item.has-dropdown.is-active .navbar-link {
-        background-color: #ffd83d;
+        background-color: #ffd83e;
         color: rgba(0, 0, 0, 0.7); }
       .navbar.is-warning .navbar-dropdown a.navbar-item.is-active {
         background-color: #ffdd57;
@@ -5119,7 +5119,7 @@ a.navbar-item,
   .pagination-previous:focus,
   .pagination-next:focus,
   .pagination-link:focus {
-    border-color: #2e63b8; }
+    border-color: #3c5dcd; }
   .pagination-previous:active,
   .pagination-next:active,
   .pagination-link:active {
@@ -6868,7 +6868,7 @@ label.panel-block {
     .hero.is-info a.navbar-item:hover, .hero.is-info a.navbar-item.is-active,
     .hero.is-info .navbar-link:hover,
     .hero.is-info .navbar-link.is-active {
-      background-color: #118fe4;
+      background-color: #1190e3;
       color: #fff; }
     .hero.is-info .tabs a {
       color: #fff;
@@ -6886,10 +6886,10 @@ label.panel-block {
       border-color: #fff;
       color: #209cee; }
     .hero.is-info.is-bold {
-      background-image: linear-gradient(141deg, #04a6d7 0%, #209cee 71%, #3287f5 100%); }
+      background-image: linear-gradient(141deg, #05a6d6 0%, #209cee 71%, #3287f5 100%); }
       @media screen and (max-width: 768px) {
         .hero.is-info.is-bold .navbar-menu {
-          background-image: linear-gradient(141deg, #04a6d7 0%, #209cee 71%, #3287f5 100%); } }
+          background-image: linear-gradient(141deg, #05a6d6 0%, #209cee 71%, #3287f5 100%); } }
   .hero.is-success {
     background-color: #22c35b;
     color: #fff; }
@@ -6956,7 +6956,7 @@ label.panel-block {
     .hero.is-warning a.navbar-item:hover, .hero.is-warning a.navbar-item.is-active,
     .hero.is-warning .navbar-link:hover,
     .hero.is-warning .navbar-link.is-active {
-      background-color: #ffd83d;
+      background-color: #ffd83e;
       color: rgba(0, 0, 0, 0.7); }
     .hero.is-warning .tabs a {
       color: rgba(0, 0, 0, 0.7);
@@ -6974,10 +6974,10 @@ label.panel-block {
       border-color: rgba(0, 0, 0, 0.7);
       color: #ffdd57; }
     .hero.is-warning.is-bold {
-      background-image: linear-gradient(141deg, #ffaf24 0%, #ffdd57 71%, #fffa70 100%); }
+      background-image: linear-gradient(141deg, #ffae24 0%, #ffdd57 71%, #fffa71 100%); }
       @media screen and (max-width: 768px) {
         .hero.is-warning.is-bold .navbar-menu {
-          background-image: linear-gradient(141deg, #ffaf24 0%, #ffdd57 71%, #fffa70 100%); } }
+          background-image: linear-gradient(141deg, #ffae24 0%, #ffdd57 71%, #fffa71 100%); } }
   .hero.is-danger {
     background-color: #da0b00;
     color: #fff; }
@@ -7138,7 +7138,7 @@ h1:hover .docs-heading-anchor-permalink, h2:hover .docs-heading-anchor-permalink
     .admonition.is-default > .admonition-body {
       color: #fff; }
   .admonition.is-info {
-    background-color: #def0fd;
+    background-color: #def0fc;
     border-color: #209cee; }
     .admonition.is-info > .admonition-header {
       background-color: #209cee;
@@ -7610,100 +7610,100 @@ html {
   color: #242424; }
 
 .ansi span.sgr31 {
-  color: #a70800; }
+  color: #a7201f; }
 
 .ansi span.sgr32 {
-  color: #1a9847; }
+  color: #066f00; }
 
 .ansi span.sgr33 {
-  color: #fac800; }
+  color: #856b00; }
 
 .ansi span.sgr34 {
-  color: #244d8f; }
+  color: #2149b0; }
 
 .ansi span.sgr35 {
-  color: #931fff; }
+  color: #7d4498; }
 
 .ansi span.sgr36 {
-  color: #178d9c; }
+  color: #007989; }
 
 .ansi span.sgr37 {
-  color: #dbdbdb; }
+  color: #8f8f8f; }
 
 .ansi span.sgr40 {
   background-color: #242424; }
 
 .ansi span.sgr41 {
-  background-color: #a70800; }
+  background-color: #a7201f; }
 
 .ansi span.sgr42 {
-  background-color: #1a9847; }
+  background-color: #066f00; }
 
 .ansi span.sgr43 {
-  background-color: #fac800; }
+  background-color: #856b00; }
 
 .ansi span.sgr44 {
-  background-color: #244d8f; }
+  background-color: #2149b0; }
 
 .ansi span.sgr45 {
-  background-color: #931fff; }
+  background-color: #7d4498; }
 
 .ansi span.sgr46 {
-  background-color: #178d9c; }
+  background-color: #007989; }
 
 .ansi span.sgr47 {
-  background-color: #dbdbdb; }
+  background-color: #8f8f8f; }
 
 .ansi span.sgr90 {
-  color: #7a7a7a; }
+  color: #707070; }
 
 .ansi span.sgr91 {
-  color: #da0b00; }
+  color: #cb3c33; }
 
 .ansi span.sgr92 {
-  color: #22c35b; }
+  color: #0e8300; }
 
 .ansi span.sgr93 {
-  color: #ffdd57; }
+  color: #a98800; }
 
 .ansi span.sgr94 {
-  color: #2e63b8; }
+  color: #3c5dcd; }
 
 .ansi span.sgr95 {
-  color: #b86bff; }
+  color: #9256af; }
 
 .ansi span.sgr96 {
-  color: #1db5c9; }
+  color: #008fa3; }
 
 .ansi span.sgr97 {
   color: whitesmoke; }
 
 .ansi span.sgr100 {
-  background-color: #7a7a7a; }
+  background-color: #707070; }
 
 .ansi span.sgr101 {
-  background-color: #da0b00; }
+  background-color: #cb3c33; }
 
 .ansi span.sgr102 {
-  background-color: #22c35b; }
+  background-color: #0e8300; }
 
 .ansi span.sgr103 {
-  background-color: #ffdd57; }
+  background-color: #a98800; }
 
 .ansi span.sgr104 {
-  background-color: #2e63b8; }
+  background-color: #3c5dcd; }
 
 .ansi span.sgr105 {
-  background-color: #b86bff; }
+  background-color: #9256af; }
 
 .ansi span.sgr106 {
-  background-color: #1db5c9; }
+  background-color: #008fa3; }
 
 .ansi span.sgr107 {
   background-color: whitesmoke; }
 
 code.language-julia-repl > span.hljs-meta {
-  color: #1a9847;
+  color: #066f00;
   font-weight: bolder; }
 
 /*!


### PR DESCRIPTION
This will update the definition of basic color variables such as `$red`. This also tweaks the ANSI colors by deriving from those basic colors.
However, the colors for admonitions etc. are kept as they are, for compatibility.

![light](https://user-images.githubusercontent.com/12679384/126024043-bcf8775f-6b67-49b2-9e25-5e9ddadbfc85.png)
![dark](https://user-images.githubusercontent.com/12679384/126024048-7f49de87-af6f-46a1-8fd0-a98ab4cf07ab.png)


Closes #1629