### PR TITLE
WIP: Fix accesibility issues

### DIFF
--- a/assets/html/scss/documenter-dark.scss
+++ b/assets/html/scss/documenter-dark.scss
@@ -47,7 +47,7 @@ $border-width: 1px;
 @import "documenter/utilities";
 @import "documenter/variables";
 
-$code: #e74c3c;
+$code: #ececec;
 $code-background: rgba(255, 255, 255, 0.05);
 
 $documenter-docstring-shadow: none;

--- a/assets/html/scss/documenter-light.scss
+++ b/assets/html/scss/documenter-light.scss
@@ -7,6 +7,9 @@ $warning: #ffdd57;
 $danger: #da0b00;
 $compat: #1db5c9;
 
+// slightly increase contrast over default l: 48%
+$grey: hsl(0, 0%, 42%);
+
 @import "documenter/utilities";
 @import "documenter/variables";
 


### PR DESCRIPTION
The goal of this is to make sure Documenter-generated docs conform to [WCAG 2.0](https://www.w3.org/TR/WCAG20/).
I'm opening this early so I can document the changes as I work my way through them, which should hopefully make review a bit easier.

## Color contrast
### Light theme `Version` contrast
**From**: Contrast ratio 3.93
![image](https://user-images.githubusercontent.com/6735977/129349607-6621cb08-a239-4792-b84c-3af756d755c9.png)
**To**: Contrast ratio 5.26
![image](https://user-images.githubusercontent.com/6735977/129349794-8220cbf4-727a-4c3d-b590-091be782589c.png)

### Dark theme code contrast
**From**: Contrast ratio 3.55
![image](https://user-images.githubusercontent.com/6735977/129349986-ee34111c-1b52-4749-a064-2fe00a28f6b0.png)
**To**: Contrast ratio 11.49
![image](https://user-images.githubusercontent.com/6735977/129350087-bf3133ae-20a0-458e-b73e-0d402b372868.png)
