### PR TITLE
Pass file and line info to downstream loggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * ![Bugfix][badge-bugfix] Checking whether a PR comes from the correct repository when deciding to deploy a preview on GitHub Actions now works on Julia 1.0 too. ([#1665](github-1665))
 
+* ![Bugfix][badge-bugfix] When a doctest fails, pass file and line information associated to the location of the doctest instead of the location of the testing code in Documenter to the logger. ([#1687](github-1687))
+
 ## Version `v0.27.5`
 
 * ![Bugfix][badge-bugfix] Fix an error introduced in version `v0.27.4` (PR[#1634][github-1634]) which was triggered by trailing comments in `@eval`/`@repl`/`@example` blocks. ([#1655](github-1655), [#1661](github-1661))
@@ -904,6 +906,7 @@
 [github-1658]: https://github.com/JuliaDocs/Documenter.jl/pull/1658
 [github-1661]: https://github.com/JuliaDocs/Documenter.jl/pull/1661
 [github-1665]: https://github.com/JuliaDocs/Documenter.jl/pull/1665
+[github-1687]: https://github.com/JuliaDocs/Documenter.jl/pull/1687
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 [julia-39841]: https://github.com/JuliaLang/julia/pull/39841

--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -401,7 +401,7 @@ function report(result::Result, str, doc::Documents.Document)
 
         $(result.output)
 
-        """, diff, file=result.file, line=lines[1])
+        """, diff, _file=result.file, _line=lines[1])
 end
 
 function fix_doctest(result::Result, str, doc::Documents.Document)

--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -401,7 +401,7 @@ function report(result::Result, str, doc::Documents.Document)
 
         $(result.output)
 
-        """, diff)
+        """, diff, file=result.file, line=lines[1])
 end
 
 function fix_doctest(result::Result, str, doc::Documents.Document)


### PR DESCRIPTION
We can use `_file` and `_line` ([docs](https://docs.julialang.org/en/v1/stdlib/Logging/#Logging.@logmsg)) to cause the `@error` to act like it was emitted from where the doctest failed, instead of acting like it was emitted from `report` in Documenter. This is very useful because loggers can use the file and line info when trying to surface logs.

For instance, I want to use a GitHubActions.jl [GitHubActionLogger](https://github.com/julia-actions/GitHubActions.jl/blob/0f9a18e1421e7b350af9456ec18946410e6c8420/src/GitHubActions.jl#L209) which will emit GHA-friendly error messages, using the file and line info to create an inline-annotation in the diff showing where the error occurred:

<img width="1175" alt="Screenshot 2021-08-28 at 15 01 50" src="https://user-images.githubusercontent.com/5846501/131220193-2d912a90-2567-4818-a300-f6261aabb541.png">

(That needs a small fix in GitHubActionLogger as well: https://github.com/julia-actions/GitHubActions.jl/pull/15).

We can only pass a single line, so I just chose the first line of the failing doctest. We could alternately choose the last line.