### PR TITLE
Generalize `strict`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * ![Bugfix][badge-bugfix] Checking whether a PR comes from the correct repository when deciding to deploy a preview on GitHub Actions now works on Julia 1.0 too. ([#1665](github-1665))
 
+* ![Feature][badge-feature] The keyword argument `strict` in `makedocs` is more flexible: in addition to a boolean indicating whether or not any error should result in a failure, `strict` also accepts a `Symbol` or `Vector{Symbol}` indicating which error(s) should result in a build failure. ([][github-])
+
 ## Version `v0.27.5`
 
 * ![Bugfix][badge-bugfix] Fix an error introduced in version `v0.27.4` (PR[#1634][github-1634]) which was triggered by trailing comments in `@eval`/`@repl`/`@example` blocks. ([#1655](github-1655), [#1661](github-1661))

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -14,7 +14,7 @@ using DocStringExtensions
 import Markdown
 
 using Logging
-loglevel(doc) = doc.user.strict ? Logging.Error : Logging.Warn
+loglevel(doc) = doc.user.strict === true ? Logging.Error : Logging.Warn
 
 # Missing docstrings.
 # -------------------

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -133,8 +133,8 @@ produce the expected results. See the [Doctests](@ref) manual section for detail
 running doctests.
 
 Setting `doctest` to `:only` allows for doctesting without a full build. In this mode, most
-build stages are skipped and the `strict` keyword is ignore (a doctesting error will always
-make `makedocs` throw an error).
+build stages are skipped and the `strict` keyword is ignored (a doctesting error will always
+make `makedocs` throw an error in this mode).
 
 **`modules`** specifies a vector of modules that should be documented in `source`. If any
 inline docstrings from those modules are seen to be missing from the generated content then
@@ -199,13 +199,14 @@ when a minor version changes (i.e. except in patch releases).
 defined in the `modules` keyword that have a docstring attached have the docstring also
 listed in the manual (e.g. there's a `@docs` block with that docstring). Possible values
 are `:all` (check all names; the default), `:exports` (check only exported names) and
-`:none` (no checks are performed). If `strict` is also enabled then the build will fail if
+`:none` (no checks are performed). If `strict=true` (or `strict=:missing_docs` or `strict=[:missing_docs, ...]`) is also set then the build will fail if
 any missing docstrings are encountered.
 
 **`linkcheck`** -- if set to `true` [`makedocs`](@ref) uses `curl` to check the status codes
 of external-pointing links, to make sure that they are up-to-date. The links and their
-status codes are printed to the standard output. If `strict` is also enabled then the build
-will fail if there are any broken (400+ status code) links. Default: `false`.
+status codes are printed to the standard output. If `strict` is also set to `true`
+(or `:linkcheck` or a `Vector` including `:linkcheck`) then the build will fail if there
+are any broken (400+ status code) links. Default: `false`.
 
 **`linkcheck_ignore`** allows certain URLs to be ignored in `linkcheck`. The values should
 be a list of strings (which get matched exactly) or `Regex` objects. By default nothing is
@@ -214,8 +215,8 @@ ignored.
 **`linkcheck_timeout`** configures how long `curl` waits (in seconds) for a link request to
 return a response before giving up. The default is 10 seconds.
 
-**`strict`** -- [`makedocs`](@ref) fails the build right before rendering if it encountered
-any errors with the document in the previous build phases.
+**`strict`** -- if set to `true`, [`makedocs`](@ref) fails the build right before rendering if it encountered
+any errors with the document in the previous build phases. The keyword `strict` can also be set to a `Symbol` or `Vector{Symbol}` to specify which kind of error (or errors) should be fatal. Options are: `:doctest`, `:cross_references`, `:missing_docs`, `:footnote`, `:linkcheck`, `:meta_block`, `:docs_block`, `:autodocs_block`, `:eval_block`, `:example_block`, `:setup_block`, and `:parse_error`.
 
 **`workdir`** determines the working directory where `@example` and `@repl` code blocks are
 executed. It can be either a path or the special value `:build` (default).

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -241,7 +241,7 @@ struct User
     linkcheck_timeout::Real   # ..but only wait this many seconds for each one.
     checkdocs::Symbol         # Check objects missing from `@docs` blocks. `:none`, `:exports`, or `:all`.
     doctestfilters::Vector{Regex} # Filtering for doctests
-    strict::Bool              # Throw an exception when any warnings are encountered.
+    strict::Union{Bool,Symbol,Vector{Symbol}} # Throw an exception when any warnings are encountered.
     pages   :: Vector{Any}    # Ordering of document pages specified by the user.
     expandfirst::Vector{String} # List of pages that get "expanded" before others
     repo    :: String  # Template for URL to source code repo
@@ -295,7 +295,7 @@ function Document(plugins = nothing;
         linkcheck_timeout :: Real    = 10,
         checkdocs::Symbol            = :all,
         doctestfilters::Vector{Regex}= Regex[],
-        strict::Bool                 = false,
+        strict::Union{Bool,Symbol,Vector{Symbol}} = false,
         modules  :: Utilities.ModVec = Module[],
         pages    :: Vector           = Any[],
         expandfirst :: Vector        = String[],

--- a/test/doctests/doctests.jl
+++ b/test/doctests/doctests.jl
@@ -156,9 +156,11 @@ rfile(filename) = joinpath(@__DIR__, "stdouts", filename)
         @test is_same_as_file(output, rfile("5.stdout"))
     end
 
-    run_makedocs(["broken.md", "foobroken.md"]; modules=[FooBroken], strict=true) do result, success, backtrace, output
-        @test !success
-        @test is_same_as_file(output, rfile("6.stdout"))
+    for strict in (true, :doctest, [:doctest])
+        run_makedocs(["broken.md", "foobroken.md"]; modules=[FooBroken], strict=strict) do result, success, backtrace, output
+            @test !success
+            @test is_same_as_file(output, rfile("6.stdout"))
+        end
     end
 
     run_makedocs(["fooworking.md"]; modules=[FooWorking], strict=true) do result, success, backtrace, output
@@ -178,9 +180,12 @@ rfile(filename) = joinpath(@__DIR__, "stdouts", filename)
         @test is_same_as_file(output, rfile("11.stdout"))
     end
 
-    run_makedocs(["broken.md"]) do result, success, backtrace, output
-        @test success
-        @test is_same_as_file(output, rfile("12.stdout"))
+    # Three options that do not strictly check doctests, including testing the default
+    for strict_kw in ((; strict=false), NamedTuple(), (; strict=[:meta_block]))
+        run_makedocs(["broken.md"]; strict_kw...) do result, success, backtrace, output
+            @test success
+            @test is_same_as_file(output, rfile("12.stdout"))
+        end
     end
 
     # Tests for doctest = :only. The outout should reflect that the docs themselves do not

--- a/test/errors/make.jl
+++ b/test/errors/make.jl
@@ -18,4 +18,6 @@ using Documenter
 
 makedocs(sitename="-", modules = [ErrorsModule])
 
-@test_throws ErrorException makedocs(modules = [ErrorsModule], strict = true)
+for strict in (true, :doctest, [:doctest])
+    @test_throws ErrorException makedocs(modules = [ErrorsModule], strict = strict)
+end


### PR DESCRIPTION
Fixes https://github.com/JuliaDocs/Documenter.jl/issues/1686 by generalizing strict to accept a symbol or vector of symbols. I was going to do just `doctest` but looking at it, it seemed about as easy to do all of them.

I only found tests with `strict` for doctests though, but I modified those to try some of the new versions.