### PR TITLE
fix example (linspace -> LinRange, broadcast)

### DIFF
--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -418,7 +418,7 @@ g(x) = cos(x) - x
 and then we plot `f` over the interval from ``-π`` to ``π``
 
 ```@example 1
-x = LinRange(-π, π, 16)
+x = range(-π, π; length=50)
 plot(x, f.(x), color = "red")
 savefig("f-plot.svg"); nothing # hide
 ```
@@ -653,7 +653,7 @@ final document.
 ```@eval
 using PyPlot
 
-x = LinRange(-π, π, 16)
+x = range(-π, π; length=50)
 y = sin.(x)
 
 plot(x, y, color = "red")

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -418,8 +418,8 @@ g(x) = cos(x) - x
 and then we plot `f` over the interval from ``-π`` to ``π``
 
 ```@example 1
-x = linspace(-π, π)
-plot(x, f(x), color = "red")
+x = LinRange(-π, π, 16)
+plot(x, f.(x), color = "red")
 savefig("f-plot.svg"); nothing # hide
 ```
 
@@ -428,7 +428,7 @@ savefig("f-plot.svg"); nothing # hide
 and then we do the same with `g`
 
 ```@example 1
-plot(x, g(x), color = "blue")
+plot(x, g.(x), color = "blue")
 savefig("g-plot.svg"); nothing # hide
 ```
 
@@ -653,8 +653,8 @@ final document.
 ```@eval
 using PyPlot
 
-x = linspace(-π, π)
-y = sin(x)
+x = LinRange(-π, π, 16)
+y = sin.(x)
 
 plot(x, y, color = "red")
 savefig("plot.svg")


### PR DESCRIPTION
`linspace` has been removed, replaced with `LinRange`. Also I feel there should be a broadcast operation. Updated code worked as I would expect.