### PR TITLE
fix `DocTestFilters = nothing` in at-meta

### DIFF
--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -276,7 +276,7 @@ end
 function filter_doctests(strings::NTuple{2, AbstractString},
                          doc::Documents.Document, meta::Dict)
     meta_block_filters = get(meta, :DocTestFilters, [])
-    meta_block_filters == nothing && meta_block_filters == []
+    meta_block_filters === nothing && meta_block_filters = []
     doctest_local_filters = get(meta[:LocalDocTestArguments], :filter, [])
     for r in [doc.user.doctestfilters; meta_block_filters; doctest_local_filters]
         if all(occursin.((r,), strings))


### PR DESCRIPTION
Using 
````
```@meta
DocTestFilters = nothing
```
````
as [suggested in the docs](https://juliadocs.github.io/Documenter.jl/stable/man/doctests/#Filtering-Doctests), I get
```
ERROR: LoadError: MethodError: no method matching occursin(::Nothing, ::SubString{String})
Closest candidates are:
  occursin(::Union{AbstractChar, AbstractString}, ::AbstractString) at strings/search.jl:622
  occursin(::Regex, ::SubString; offset) at regex.jl:269
  occursin(::Regex, ::AbstractString; offset) at regex.jl:264
```
To me, it looks like this is the reason for this behavior.