### PR TITLE
Work around #1698

### DIFF
--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -402,7 +402,7 @@ function report(result::Result, str, doc::Documents.Document)
 
         $(result.output)
 
-        """, diff; _file=result.file, _line=line)
+        """, diff, _file=result.file, _line=line)
 end
 
 function fix_doctest(result::Result, str, doc::Documents.Document)

--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -402,7 +402,7 @@ function report(result::Result, str, doc::Documents.Document)
         $(result.output)
 
         """, diff; _file=result.file,
-          _line=lines === nothing ? (@__LINE__) : first(lines))
+          _line=lines === nothing ? nothing : first(lines))
 end
 
 function fix_doctest(result::Result, str, doc::Documents.Document)

--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -401,7 +401,8 @@ function report(result::Result, str, doc::Documents.Document)
 
         $(result.output)
 
-        """, diff, _file=result.file, _line=lines[1])
+        """, diff; _file=result.file,
+          _line=lines === nothing ? (@__LINE__) : first(lines))
 end
 
 function fix_doctest(result::Result, str, doc::Documents.Document)

--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -382,6 +382,7 @@ import .Utilities.TextDiff
 function report(result::Result, str, doc::Documents.Document)
     diff = TextDiff.Diff{TextDiff.Words}(result.output, rstrip(str))
     lines = Utilities.find_block_in_file(result.block.code, result.file)
+    line = lines === nothing ? nothing : first(lines)
     @error("""
         doctest failure in $(Utilities.locrepr(result.file, lines))
 
@@ -401,8 +402,7 @@ function report(result::Result, str, doc::Documents.Document)
 
         $(result.output)
 
-        """, diff; _file=result.file,
-          _line=lines === nothing ? nothing : first(lines))
+        """, diff; _file=result.file, _line=line)
 end
 
 function fix_doctest(result::Result, str, doc::Documents.Document)


### PR DESCRIPTION
I think this would revert to the old behavior if we can't find the line info. Not sure why that is though-- seems like we'd need to know that to know how to repro the error for a test.

fixes https://github.com/JuliaDocs/Documenter.jl/issues/1698