### PR TITLE
Allow attributes injection into HTMLAsset

### DIFF
--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -327,7 +327,10 @@ examples_html_local_doc = if "html-local" in EXAMPLE_BUILDS
         linkcheck = true,
         linkcheck_ignore = [r"(x|y).md", "z.md", r":func:.*"],
         format = Documenter.HTML(
-            assets = ["assets/custom.css"],
+            assets = [
+                "assets/custom.css",
+                asset("https://plausible.io/js/plausible.js", class=:js, attributes=Dict(Symbol("data-domain") => "example.com", :defer => ""))
+            ],
             prettyurls = false,
             edit_branch = nothing,
             footer = nothing,

--- a/test/htmlwriter.jl
+++ b/test/htmlwriter.jl
@@ -95,6 +95,17 @@ end
     end
     @test_logs (:error, "Local asset should not have an absolute URI: /foo/bar.ico") asset("/foo/bar.ico", islocal = true)
 
+    let asset = asset("https://plausible.io/js/plausible.js"; class=:js, attributes=Dict(Symbol("data-domain")=>"example.com", :defer=>""))
+        @test asset.uri == "https://plausible.io/js/plausible.js"
+        @test asset.class == :js
+        @test asset.islocal === false
+        link = assetlink("my/sub/page", asset)
+        @test link.node.name === :script
+        @test link.src == "https://plausible.io/js/plausible.js"
+        @test Base.getproperty(link, Symbol("data-domain")) == "example.com"
+        @test link.defer == ""
+    end
+
     # HTML format object
     @test Documenter.HTML() isa Documenter.HTML
     @test_throws ArgumentError Documenter.HTML(collapselevel=-200)


### PR DESCRIPTION
I would like to use a privacy conscious alternative to Google Analytics,
and for their needs I need to inject the following header:

```
<script defer data-domain="yourdomain.com" src="https://plausible.io/js/plausible.js"></script>
```

I checked that:

```
makedocs(;
    format=Documenter.HTML(;
        prettyurls=get(ENV, "CI", "false") == "true",
        assets=[
            asset("https://plausible.io/js/plausible.js", class=:js, attributes=Dict(Symbol("data-domain") => "yourdomain.com", :defer => ""))
	    ],
    ),
)
```

Does seem to generate the right HTML.
