### PR TITLE
Update index.md with correct version numbers

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,7 +15,6 @@ A package for building documentation from docstrings and markdown files.
 
 - Write all your documentation in [Markdown](https://en.wikipedia.org/wiki/Markdown).
 - Minimal configuration.
-- Supports Julia `0.7` and `1.x`.
 - Doctests Julia code blocks.
 - Cross references for docs and section headers.
 - [``\LaTeX`` syntax](@ref latex_syntax) support.


### PR DESCRIPTION
Maybe want to specify the version numbers explicitly but this is a better default for the most current version.  Reading it the old way I wasn't sure if it supported Julia 1.6.