### PR TITLE
Document collapselevel argument to HTML

### DIFF
--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -316,12 +316,13 @@ This allows search engines to know which version to send their users to. [See
 wikipedia for more information](https://en.wikipedia.org/wiki/Canonical_link_element).
 Default is `nothing`, in which case no canonical link is set.
 
-**`analytics`** can be used specify the Google Analytics tracking ID.
-
 **`assets`** can be used to include additional assets (JS, CSS, ICO etc. files). See below
 for more information.
 
-**`ansicolor`** can be used to enable/disable colored output from `@repl` and `@example` blocks globally.
+**`analytics`** can be used specify the Google Analytics tracking ID.
+
+**`collapselevel`** controls the navigation level visible in the sidebar. Defaults to `2`.
+To show fewer levels by default, set `collapselevel = 1`.
 
 **`sidebar_sitename`** determines whether the site name is shown in the sidebar or not.
 Setting it to `false` can be useful when the logo already contains the name of the package.
@@ -342,13 +343,15 @@ passing an instance of [`KaTeX`](@ref), [`MathJax2`](@ref), or
 [`MathJax3`](@ref) objects, respectively. The rendering engine can further be customized by
 passing options to the [`KaTeX`](@ref) or [`MathJax2`](@ref)/[`MathJax3`](@ref) constructors.
 
-**`lang`** specifies the [`lang` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang)
-of the top-level `<html>` element, declaring the language of the generated pages. The default
-value is `"en"`.
-
 **`footer`** can be a valid single-line markdown `String` or `nothing` and is displayed below
 the page navigation. Defaults to `"Powered by [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl)
 and the [Julia Programming Language](https://julialang.org/)."`.
+
+**`ansicolor`** can be used to enable/disable colored output from `@repl` and `@example` blocks globally.
+
+**`lang`** specifies the [`lang` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang)
+of the top-level `<html>` element, declaring the language of the generated pages. The default
+value is `"en"`.
 
 **`warn_outdated`** inserts a warning if the current page is not the newest version of the
 documentation.


### PR DESCRIPTION
Closes https://github.com/JuliaDocs/Documenter.jl/issues/1259

The arguments are also re-ordered to reflect their ordering in the actual function.