### PR TITLE
Default to accepting either master or main as the devbranch

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -529,6 +529,7 @@ Documenter.authentication_method
 Documenter.authenticated_repo_url
 Documenter.documenter_key
 Documenter.documenter_key_previews
+Documenter.CommonDevBranches
 Documenter.Travis
 Documenter.GitHubActions
 Documenter.GitLab

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -329,7 +329,7 @@ include("deployconfig.jl")
         branch = "gh-pages",
         deps = nothing | <Function>,
         make = nothing | <Function>,
-        devbranch = "master",
+        devbranch = CommonDevBranches(),
         devurl = "dev",
         versions = ["stable" => "v^", "v#.#", devurl => devurl],
         forcepush = false,
@@ -415,7 +415,9 @@ deps = Deps.pip("pygments", "mkdocs")
 executed.
 
 **`devbranch`** is the branch that "tracks" the in-development version of the generated
-documentation. By default this value is set to `"master"`.
+documentation. By default this value is set to `CommonDevBranches()`, which matches either
+`master` or `main`. But to set it explictly you can use a string. Which you should do if you
+use either `master` or `main` for some other purpose.
 
 **`devurl`** the folder that in-development version of the docs will be deployed.
 Defaults to `"dev"`.
@@ -491,7 +493,7 @@ function deploydocs(;
         deps   = nothing,
         make   = nothing,
 
-        devbranch = "master",
+        devbranch = CommonDevBranches(),
         devurl = "dev",
         versions = ["stable" => "v^", "v#.#", devurl => devurl],
         forcepush::Bool = false,

--- a/src/deployconfig.jl
+++ b/src/deployconfig.jl
@@ -114,7 +114,7 @@ accepts any of `master`, `main`.
 struct CommonDevBranches end
 
 matches_devbranch(branchname, devbranch) = branchname == devbranch
-matches_devbranch(branchname, ::CommonDevBranches) = branchname ∈ ("main", "master", "dev")
+matches_devbranch(branchname, ::CommonDevBranches) = branchname ∈ ("main", "master")
 
 #############
 # Travis CI #


### PR DESCRIPTION
Closes #1443

Basically this introduces a magic default value for `devbranch` which will match to either `master` or `main`.
This allows people to rename their default branch in git, without having to also having to add in the `devbranch` argument in the `docs/make.jl`.
Which is good if you have many repos to switch over.

This implementation doesn't depend on e.g. reading the git settings to find out the default branch, or probing git to see what branches exist.
It just naively accepts either name.
Which makes for easy implementation.

Technically this is breaking, if someone was using `main` as the name of some other branch unrelated to it being the devbranch, and didn't have `devbranch="master"` (or similar) set then suddenly docs would start deploying every time they pushed to that unrelated `main` branch.
I don't know if this is a realistic concern.
There are 3 responses to that:
 - A) It is not realistic don't worry about it, add this feature as nonbreaking.
 - B) It is realistic, add this feature as a breaking release. People who are not doing anything weird will have to update their `docs/Project.toml`
 - C) It is realistic, we should not do this, it is too spooky. People should stick to `master` or hard-code `devbranch="main"`