### PR TITLE
Update MathJax to v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* ![Enhancement][badge-enhancement] MathJax 3 has been updated to `v3.2.0` (minor version bump). ([#1743][github-1743])
+
 ## Version `v0.27.10`
 
 * ![Bugfix][badge-bugfix] Fix depth of headers in LaTeXWriter. ([#1716][github-1716])
@@ -944,6 +946,7 @@
 [github-1706]: https://github.com/JuliaDocs/Documenter.jl/pull/1706
 [github-1709]: https://github.com/JuliaDocs/Documenter.jl/pull/1709
 [github-1716]: https://github.com/JuliaDocs/Documenter.jl/pull/1716
+[github-1743]: https://github.com/JuliaDocs/Documenter.jl/pull/1743
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 [julia-39841]: https://github.com/JuliaLang/julia/pull/39841

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -615,7 +615,7 @@ module RD
         ))
     end
     function mathengine!(r::RequireJS, engine::MathJax3)
-        url = isempty(engine.url) ? "https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.4/es5/tex-svg.js" : engine.url
+        url = isempty(engine.url) ? "https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.0/es5/tex-svg.js" : engine.url
         push!(r, Snippet([], [],
             """
             window.MathJax = $(json_jsescape(engine.config, 2));


### PR DESCRIPTION
This PR bumps MathJax 3 to v3.2.0.

Specifically, I'm interested in the the fact that "Processing of raw Unicode characters in TeX input has been improved." (https://www.mathjax.org/MathJax-v3.2.0-available/#other). For the sake of nicely readable docs in the terminal, I'm motivated to include Unicode characters directly in the docstrings of functions:
```julia
"""
Calculates the bearing angle (``α``), defined as the angle between the meridian (at the
first coordinate) and the great circle connecting the first coordinate to the second. Angles
are measured eastward of north and will be in the range ``[-π,π]``. See also
[`bearing2`](@ref).
"""
function bearing end
```
so that you see the literal characters in the help (rather than requiring the user to read and interpret `\alpha` or `\pi`):
![image](https://user-images.githubusercontent.com/2965436/147883536-e63c38c3-abe0-4ba7-b033-b25d9ac5ccec.png)

The problem is that with the MathJax 3 renderer prior to v3.2.0, the math is rendered in the HTML docs as upright text characters rather than italic math characters:
![image](https://user-images.githubusercontent.com/2965436/147883623-4e989a0f-63d3-4108-b427-9d65de70b62a.png)

Upgrading to MathJax 3.2.0 fixes this issue (and brings it inline with the behavior of the MathJax 2 renderer):
![image](https://user-images.githubusercontent.com/2965436/147883705-a00bcfc3-f4c6-43c2-8e6e-d2d9f51d861d.png)
(Notice change in the alpha and pi characters.)