### PR TITLE
Enable recursive expansion of expanders within block-containing Markdown structures

### DIFF
--- a/src/Builder.jl
+++ b/src/Builder.jl
@@ -38,38 +38,38 @@ abstract type DocumentPipeline <: Selectors.AbstractSelector end
 """
 Creates the correct directory layout within the `build` folder and parses markdown files.
 """
-abstract type SetupBuildDirectory <: DocumentPipeline end
+struct SetupBuildDirectory <: DocumentPipeline end
 
 """
 Runs all the doctests in all docstrings and Markdown files.
 """
-abstract type Doctest <: DocumentPipeline end
+struct Doctest <: DocumentPipeline end
 
 """
 Executes a sequence of actions on each node of the parsed markdown files in turn.
 """
-abstract type ExpandTemplates <: DocumentPipeline end
+struct ExpandTemplates <: DocumentPipeline end
 
 """
 Finds and sets URLs for each `@ref` link in the document to the correct destinations.
 """
-abstract type CrossReferences <: DocumentPipeline end
+struct CrossReferences <: DocumentPipeline end
 
 """
 Checks that all documented objects are included in the document and runs doctests on all
 valid Julia code blocks.
 """
-abstract type CheckDocument <: DocumentPipeline end
+struct CheckDocument <: DocumentPipeline end
 
 """
 Populates the `ContentsNode`s and `IndexNode`s with links.
 """
-abstract type Populate <: DocumentPipeline end
+struct Populate <: DocumentPipeline end
 
 """
 Writes the document tree to the `build` directory.
 """
-abstract type RenderDocument <: DocumentPipeline end
+struct RenderDocument <: DocumentPipeline end
 
 Selectors.order(::Type{SetupBuildDirectory})   = 1.0
 Selectors.order(::Type{Doctest})               = 1.1

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -80,7 +80,7 @@ abstract type RecursiveExpanderPipeline <: ExpanderPipeline end
 Tracks all `Markdown.Header` nodes found in the parsed markdown files and stores an
 [`Anchors.Anchor`](@ref) object for each one.
 """
-abstract type TrackHeaders <: ExpanderPipeline end
+struct TrackHeaders <: ExpanderPipeline end
 
 """
 Parses each code block where the language is `@meta` and evaluates the key/value pairs found
@@ -95,7 +95,7 @@ end
 ```
 ````
 """
-abstract type MetaBlocks <: ExpanderPipeline end
+struct MetaBlocks <: ExpanderPipeline end
 
 """
 Parses each code block where the language is `@docs` and evaluates the expressions found
@@ -109,7 +109,7 @@ deploydocs
 ```
 ````
 """
-abstract type DocsBlocks <: ExpanderPipeline end
+struct DocsBlocks <: ExpanderPipeline end
 
 """
 Parses each code block where the language is `@autodocs` and replaces it with all the
@@ -122,7 +122,7 @@ Order   = [:function, :type]
 ```
 ````
 """
-abstract type AutoDocsBlocks <: ExpanderPipeline end
+struct AutoDocsBlocks <: ExpanderPipeline end
 
 """
 Parses each code block where the language is `@eval` and evaluates it's content. Replaces
@@ -140,9 +140,9 @@ Markdown.parse("![Plot](plot.svg)")
 ```
 ````
 """
-abstract type EvalBlocks <: RecursiveExpanderPipeline end
+struct EvalBlocks <: RecursiveExpanderPipeline end
 
-abstract type RawBlocks <: RecursiveExpanderPipeline end
+struct RawBlocks <: RecursiveExpanderPipeline end
 
 """
 Parses each code block where the language is `@index` and replaces it with an index of all
@@ -155,7 +155,7 @@ Pages = ["foo.md", "bar.md"]
 ```
 ````
 """
-abstract type IndexBlocks <: ExpanderPipeline end
+struct IndexBlocks <: ExpanderPipeline end
 
 """
 Parses each code block where the language is `@contents` and replaces it with a nested list
@@ -170,7 +170,7 @@ Depth = 1
 ````
 The default `Depth` value is `2`.
 """
-abstract type ContentsBlocks <: ExpanderPipeline end
+struct ContentsBlocks <: ExpanderPipeline end
 
 """
 Parses each code block where the language is `@example` and evaluates the parsed Julia code
@@ -185,23 +185,23 @@ a + b
 ```
 ````
 """
-abstract type ExampleBlocks <: RecursiveExpanderPipeline end
+struct ExampleBlocks <: RecursiveExpanderPipeline end
 
 """
 Similar to the [`ExampleBlocks`](@ref) expander, but inserts a Julia REPL prompt before each
 toplevel expression in the final document.
 """
-abstract type REPLBlocks <: RecursiveExpanderPipeline end
+struct REPLBlocks <: RecursiveExpanderPipeline end
 
 """
 Similar to the [`ExampleBlocks`](@ref) expander, but hides all output in the final document.
 """
-abstract type SetupBlocks <: RecursiveExpanderPipeline end
+struct SetupBlocks <: RecursiveExpanderPipeline end
 
 """
 Node in the pipeline used only to support expansion through recursive block elements.
 """
-abstract type Recurse <: RecursiveExpanderPipeline end
+struct Recurse <: RecursiveExpanderPipeline end
 
 Selectors.order(::Type{TrackHeaders})   = 1.0
 Selectors.order(::Type{MetaBlocks})     = 2.0
@@ -230,9 +230,6 @@ Selectors.matcher(::Type{RawBlocks},      node, page, doc) = iscode(node, r"^@ra
 Selectors.matcher(::Type{Recurse},        node, page, doc) =
     any(x->isa(node, x), (Markdown.Admonition, Markdown.BlockQuote, Markdown.List))
 
-
-Selectors.order(::Type{RecursiveExpanderPipeline}) = Inf
-Selectors.matcher(::Type{RecursiveExpanderPipeline}, node, page, doc) = false
 
 # Default Expander.
 

--- a/src/Utilities/Selectors.jl
+++ b/src/Utilities/Selectors.jl
@@ -163,7 +163,7 @@ Selectors.dispatch(MySelector, args...)
 """
 function dispatch(::Type{T}, x...) where T <: AbstractSelector
     types = get!(selector_subtypes, T) do
-        sort(subtypes(T); by = order)
+        sort(allsubtypes(T); by = order)
     end
     for t in types
         if !disable(t) && matcher(t, x...)
@@ -178,5 +178,13 @@ end
 # (https://github.com/JuliaLang/julia/issues/38079), so to ensure that
 # `dispatch` remains fast we cache the results of `subtypes` here.
 const selector_subtypes = Dict{Type,Vector}()
+
+function allsubtypes(::Type{T}) where T
+    sub = subtypes(T)
+    for t in sub
+        append!(sub, allsubtypes(t))
+    end
+    return sub
+end
 
 end

--- a/src/Utilities/Selectors.jl
+++ b/src/Utilities/Selectors.jl
@@ -12,8 +12,8 @@ selector code is described:
 abstract type MySelector <: Selectors.AbstractSelector end
 
 # The different cases we want to test.
-abstract type One    <: MySelector end
-abstract type NotOne <: MySelector end
+struct One    <: MySelector end
+struct NotOne <: MySelector end
 
 # The order in which to test the cases.
 Selectors.order(::Type{One})    = 0.0
@@ -180,9 +180,13 @@ end
 const selector_subtypes = Dict{Type,Vector}()
 
 function allsubtypes(::Type{T}) where T
-    sub = subtypes(T)
-    for t in sub
-        append!(sub, allsubtypes(t))
+    sub = Type[]
+    for t in subtypes(T)
+        if isconcretetype(t)
+            push!(sub, t)
+        else
+            append!(sub, allsubtypes(t))
+        end
     end
     return sub
 end

--- a/src/Writers/Writers.jl
+++ b/src/Writers/Writers.jl
@@ -25,9 +25,9 @@ import .Utilities: Selectors
 
 abstract type FormatSelector <: Selectors.AbstractSelector end
 
-abstract type MarkdownFormat <: FormatSelector end
-abstract type LaTeXFormat    <: FormatSelector end
-abstract type HTMLFormat     <: FormatSelector end
+struct MarkdownFormat <: FormatSelector end
+struct LaTeXFormat    <: FormatSelector end
+struct HTMLFormat     <: FormatSelector end
 
 Selectors.order(::Type{MarkdownFormat}) = 1.0
 Selectors.order(::Type{LaTeXFormat})    = 2.0

--- a/test/examples/src/man/tutorial.md
+++ b/test/examples/src/man/tutorial.md
@@ -546,3 +546,46 @@ LaTeXEquation("\\[\\left[\\begin{array}{rr} x & 2x \\\\ \n y & y \\end{array}\\r
 ```@example showablelatex
 LaTeXEquation("\$\$\\begin{bmatrix} 1 & 2 \\\\ \n 3 & 4 \\end{bmatrix}\$\$")
 ```
+---
+
+Extra tests that code-like blocks are recursively expanded in nested Markdown contexts
+([#1747](https://github.com/JuliaDocs/Documenter.jl/pull/1747)).
+
+- Recurse into lists:
+
+  ```@repl recurse
+  list_one = 1
+  ```
+
+  1. More than single layer of nesting as well:
+
+     ```@repl recurse
+     list_two = 2
+     ```
+
+- `@raw` outputs are code-like:
+
+  ```@raw html
+  <pre>raw code output</pre>
+  ```
+
+!!! note
+
+    Admonitions and blockquotes contain blocks Markdown elements as well.
+
+    ```@setup recurse
+    setup = true
+    ```
+
+    ```@example recurse
+    if setup # assigned in @setup block
+        print(join(["running", "example", "block"], " "))
+    end
+    ```
+
+    The following quote will print a result:
+
+    > Evaling code:
+    > ```@eval
+    > evaled = sqrt(2.0)
+    > ```

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -94,6 +94,21 @@ end
             documenterjs = String(read(joinpath(build_dir, "assets", "documenter.js")))
             @test occursin("languages/julia.min", documenterjs)
             @test occursin("languages/julia-repl.min", documenterjs)
+
+            # PR1747
+            @test isfile(joinpath(build_dir, "man", "tutorial.html"))
+            tutorialhtml = read(joinpath(build_dir, "man", "tutorial.html"), String)
+            @test occursin("julia&gt; list_one = 1", tutorialhtml)
+            @test occursin("julia&gt; list_two = 2", tutorialhtml)
+            @test !occursin("&lt;pre&gt;raw code output&lt;/pre&gt;", tutorialhtml)
+            @test !occursin("RawNode(:html", tutorialhtml)
+            @test occursin("<pre>raw code output</pre>", tutorialhtml)
+            @test !occursin("setup = true", tutorialhtml)
+            @test occursin("print(join([", tutorialhtml)
+            @test occursin("running example block", tutorialhtml)
+            @test !occursin("evaled = sqrt(2.0)", tutorialhtml)
+            @test !occursin("EvalNode(", tutorialhtml)
+            @test occursin("1.414213562", tutorialhtml)
         end
     end
 


### PR DESCRIPTION
In some recent documentation I've been writing, I discovered that ` ```@repl ... ``` ` blocks would not expand if contained within a Markdown list. The first commit in this PR is (essentially) the definition I came up with to solve my immediate problem (i.e. as type/method definitions at the top of my `docs/make.jl` file).

I then discovered #1637 was a proposal for a very similar feature improvement, but it has a couple of unresolved review comments. The second commit takes comments from that other PR and updates this implementation to only recursively expand code-like expanders within nested contexts. It leverages an intermediate abstract type to partition the expanders which should be recursively expanded from those that should not.

I'd consider the third commit to be optional and can be dropped if the change is too disruptive. The idea is that the second commit requires defining "dummy" implementations of `Selectors.order` and `Selectors.matcher` for the intermediate abstract type. The third commit (IMHO) cleans up the abstraction by differentiating between concrete (singleton) subtypes which correspond to runnable actions and abstract types which can be used to build a type hierarchy.

- [x] Needs tests if/when the design approach and names are agreed upon.

Fixes #491

---

**Example**

````md
...multiple transformations are made...

- **Strings**

  As complex data themselves...

  - _Unicode_

    ... combining characters ...
    ```@repl
    acute_a = "\u00E1" # Latin Small Letter A with Acute
    a_combineaccute = "a\u0301" # "a" + Combining Acute Accent
    acute_a == a_combineaccute
    ```
````

**Before:**
> ![screenshot_before](https://user-images.githubusercontent.com/2965436/149040931-2ea0b7e6-31a9-427f-ab26-36daef9a77ef.png)


**After:**
> ![screenshot_after](https://user-images.githubusercontent.com/2965436/149040784-5d91f043-ec68-41fd-8a32-8c60d5217949.png)

