### PR TITLE
[tex] Adjusting the TOC style

### DIFF
--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -221,14 +221,17 @@ function writeheader(io::IO, doc::Documents.Document)
         \\usepackage{./documenter}
         \\usepackage{./custom}
 
-        \\settocdepth{section}
-
         \\title{
             {\\HUGE $(doc.user.sitename)}\\\\
             {\\Large $(get(ENV, "TRAVIS_TAG", ""))}
         }
         \\author{$(doc.user.authors)}
 
+        %% TOC settings
+        % -- TOC depth
+        %   value: [part, chapter, section, subsection,
+        %           subsubsection, paragraph, subparagraph]
+        \\settocdepth{section}  % show "part+chapter+section" in TOC
         \\begin{document}
 
         \\frontmatter

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -242,6 +242,8 @@ function writeheader(io::IO, doc::Documents.Document)
         \\setlength{\\cftbeforepartskip}{1.5em \\@plus \\p@}
         % {chaper} to {chaper}
         \\setlength{\\cftbeforechapterskip}{0.0em \\@plus \\p@}
+        % Chapter num to chapter title spacing (Figure 9.2@memman)
+        \\setlength{\\cftchapternumwidth}{2.5em}
         \\makeatother
 
         \\begin{document}

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -221,6 +221,7 @@ function writeheader(io::IO, doc::Documents.Document)
         \\usepackage{./documenter}
         \\usepackage{./custom}
 
+        %% Title Page
         \\title{
             {\\HUGE $(doc.user.sitename)}\\\\
             {\\Large $(get(ENV, "TRAVIS_TAG", ""))}
@@ -246,6 +247,7 @@ function writeheader(io::IO, doc::Documents.Document)
         \\setlength{\\cftchapternumwidth}{2.5em}
         \\makeatother
 
+        %% Main document begin
         \\begin{document}
 
         \\frontmatter

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -244,7 +244,9 @@ function writeheader(io::IO, doc::Documents.Document)
         % {chaper} to {chaper}
         \\setlength{\\cftbeforechapterskip}{0.0em \\@plus \\p@}
         % Chapter num to chapter title spacing (Figure 9.2@memman)
-        \\setlength{\\cftchapternumwidth}{2.5em}
+        \\setlength{\\cftchapternumwidth}{2.5em \\@plus \\p@}
+        % indent before section number
+        \\setlength{\\cftsectionindent}{2.5em \\@plus \\p@}
         \\makeatother
 
         %% Main document begin

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -232,6 +232,18 @@ function writeheader(io::IO, doc::Documents.Document)
         %   value: [part, chapter, section, subsection,
         %           subsubsection, paragraph, subparagraph]
         \\settocdepth{section}  % show "part+chapter+section" in TOC
+        % -- TOC spacing
+        %   ref: https://tex.stackexchange.com/questions/60317/toc-spacing-in-memoir
+        %   doc: memoir/memman.pdf
+        %       - Figure 9.2: Layout of a ToC
+        %       - Table 9.3: Value of K in macros for styling entries
+        \\makeatletter
+        % {part} to {chaper}
+        \\setlength{\\cftbeforepartskip}{1.5em \\@plus \\p@}
+        % {chaper} to {chaper}
+        \\setlength{\\cftbeforechapterskip}{0.0em \\@plus \\p@}
+        \\makeatother
+
         \\begin{document}
 
         \\frontmatter


### PR DESCRIPTION
xref: JuliaLang/julia#43698

1. Use compact line spacing in TOC: `\cftbeforepartskip`, `\cftbeforechapterskip`
2. Increase the spacing between chapter numbers and chapter names: `\cftchapternumwidth`
3. Increase indent before section number: `\cftsectionindent`

![image](https://user-images.githubusercontent.com/5158738/149526726-aa5d014f-eec0-4095-9330-455de5df8b15.png)


output: [DocumenterLaTeX-toc#1750.pdf](https://drive.google.com/file/d/1-BRhgatXAjw9EAze45jRWrcSVaBPlbF8/view?usp=sharing) v.s. [DocumenterLaTeX-master+7beb208b3.pdf](https://drive.google.com/file/d/1JzP55M8XSPg-58BTXxcLWJjIqCE7zhL8/view?usp=sharing)