### PR TITLE
allow deploy docs on schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Documenter.jl changelog
 
 ## Unreleased
-* ![Enhancement][badge-enhancement] Documenter now deploys documentation from scheduled jobs (`schedule` on GitHub actions). ([#1772][github-1554], [#1773][github-1752])
+* ![Enhancement][badge-enhancement] Documenter now deploys documentation from scheduled jobs (`schedule` on GitHub actions). ([#1772][github-1772], [#1773][github-1773])
 
 ## Version `v0.27.14`
 
@@ -979,6 +979,8 @@
 [github-1762]: https://github.com/JuliaDocs/Documenter.jl/pull/1762
 [github-1770]: https://github.com/JuliaDocs/Documenter.jl/issues/1770
 [github-1771]: https://github.com/JuliaDocs/Documenter.jl/pull/1771
+[github-1772]: https://github.com/JuliaDocs/Documenter.jl/issues/1772
+[github-1773]: https://github.com/JuliaDocs/Documenter.jl/pull/1773
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 [julia-39841]: https://github.com/JuliaLang/julia/pull/39841

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Documenter.jl changelog
 
 ## Unreleased
+* ![Enhancement][badge-enhancement] Documenter now deploys documentation from scheduled jobs (`schedule` on GitHub actions). ([#1772][github-1554], [#1773][github-1752])
 
 ## Version `v0.27.14`
 

--- a/src/deployconfig.jl
+++ b/src/deployconfig.jl
@@ -274,7 +274,7 @@ Implementation of `DeployConfig` for deploying from GitHub Actions.
 The following environment variables influences the build
 when using the `GitHubActions` configuration:
 
- - `GITHUB_EVENT_NAME`: must be set to `push` or `workflow_dispatch`.
+ - `GITHUB_EVENT_NAME`: must be set to `push`, `workflow_dispatch`, or `schedule`.
    This avoids deployment on pull request builds.
 
  - `GITHUB_REPOSITORY`: must match the value of the `repo` keyword to [`deploydocs`](@ref).
@@ -327,9 +327,9 @@ function deploy_folder(cfg::GitHubActions;
     println(io, "- $(marker(repo_ok)) ENV[\"GITHUB_REPOSITORY\"]=\"$(cfg.github_repository)\" occurs in repo=\"$(repo)\"")
     if build_type === :release
         ## Do not deploy for PRs
-        event_ok = cfg.github_event_name == "push" || cfg.github_event_name == "workflow_dispatch"
+        event_ok = in(cfg.github_event_name, ["push", "workflow_dispatch", "schedule"])
         all_ok &= event_ok
-        println(io, "- $(marker(event_ok)) ENV[\"GITHUB_EVENT_NAME\"]=\"$(cfg.github_event_name)\" is \"push\" or \"workflow_dispatch\"")
+        println(io, "- $(marker(event_ok)) ENV[\"GITHUB_EVENT_NAME\"]=\"$(cfg.github_event_name)\" is \"push\", \"workflow_dispatch\" or \"schedule\"")
         ## If a tag exist it should be a valid VersionNumber
         m = match(r"^refs\/tags\/(.*)$", cfg.github_ref)
         tag_nobuild = version_tag_strip_build(m.captures[1])
@@ -343,9 +343,9 @@ function deploy_folder(cfg::GitHubActions;
         subfolder = m === nothing ? nothing : tag_nobuild
     elseif build_type === :devbranch
         ## Do not deploy for PRs
-        event_ok = cfg.github_event_name == "push" || cfg.github_event_name == "workflow_dispatch"
+        event_ok = in(cfg.github_event_name, ["push", "workflow_dispatch", "schedule"])
         all_ok &= event_ok
-        println(io, "- $(marker(event_ok)) ENV[\"GITHUB_EVENT_NAME\"]=\"$(cfg.github_event_name)\" is \"push\" or \"workflow_dispatch\"")
+        println(io, "- $(marker(event_ok)) ENV[\"GITHUB_EVENT_NAME\"]=\"$(cfg.github_event_name)\" is \"push\", \"workflow_dispatch\" or \"schedule\"")
         ## deploydocs' devbranch should match the current branch
         m = match(r"^refs\/heads\/(.*)$", cfg.github_ref)
         branch_ok = m === nothing ? false : String(m.captures[1]) == devbranch

--- a/test/deployconfig.jl
+++ b/test/deployconfig.jl
@@ -381,6 +381,24 @@ end end
                                      devbranch="master", devurl="hello-world", push_preview=false)
         @test !d.all_ok
     end
+    # Build on `schedule` jobs
+    withenv("GITHUB_EVENT_NAME" => "schedule",
+            "GITHUB_REPOSITORY" => "JuliaDocs/Documenter.jl",
+            "GITHUB_REF" => "refs/tags/v1.2.3",
+            "GITHUB_ACTOR" => "github-actions",
+            "GITHUB_TOKEN" => "SGVsbG8sIHdvcmxkLg==",
+            "DOCUMENTER_KEY" => nothing,
+        ) do
+        cfg = Documenter.GitHubActions()
+        d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
+                                     devbranch="master", devurl="dev", push_preview=true)
+        @test d.all_ok
+        @test d.subfolder == "v1.2.3"
+        @test d.repo == "github.com/JuliaDocs/Documenter.jl.git"
+        @test d.branch == "gh-pages"
+        @test Documenter.authentication_method(cfg) === Documenter.HTTPS
+        @test Documenter.authenticated_repo_url(cfg) === "https://github-actions:SGVsbG8sIHdvcmxkLg==@github.com/JuliaDocs/Documenter.jl.git"
+    end
 end end
 
 @testset "Buildkite CI deploy configuration" begin; with_logger(NullLogger()) do


### PR DESCRIPTION
This PR adds the `deploy_on_schedule` kwarg to [`deploydocs`](https://github.com/JuliaDocs/Documenter.jl/blob/master/src/Documenter.jl#L481) and  [`deploy_folder`](https://github.com/JuliaDocs/Documenter.jl/blob/master/src/deployconfig.jl#L304). This lets the user deploy documentation from scheduled github actions. 


I'm added some tests to check that the kwarg works as expected for `deploy_folder`. I couldn't see where the tests were for `deploydocs` but if tests exist for that function then I should probably add to them.

Also I think this a feature bump? unsure, any advice is appreciated.

closes #1772.

