### PR TITLE
Added QuizQuestion to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Other third-party packages that can be combined with Documenter include:
 * [DocumenterCitations.jl](https://github.com/ali-ramadhan/DocumenterCitations.jl)
 * [Literate.jl](https://github.com/fredrikekre/Literate.jl)
 * [LiveServer.jl](https://github.com/tlienart/LiveServer.jl)
+* [QuizQuestions](https://github.com/jverzani/QuizQuestions.jl)
 
 Finally, there are also a few other packages in the Julia ecosystem that are similar to Documenter, but fill a slightly different niche:
 


### PR DESCRIPTION
Added QuizQuestions.jl to "Other third-party packages that can be combined with Documenter".
QuizQuestions allows embedding simple interactive quizzes in the Markdown source page that is then converted to HTML by Documenter.