### PR TITLE
Fix JuliaMono CSS to support all weights/variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* ![Enhancement][badge-enhancement] Update CSS source file for JuliaMono, so that all font variations are included (not just `JuliaMono Regular`). ([#1780][github-1780], [#1784][github-1784])
+* ![Enhancement][badge-enhancement] Update CSS source file for JuliaMono, so that all font variations are included (not just `JuliaMono Regular`) and that the latest version (0.039 -> 0.044) of the font would be used. ([#1780][github-1780], [#1784][github-1784])
 * ![Bugfix][badge-bugfix] Fix `strict` mode to properly print errors, not just a warnings. ([#1756][github-1756], [#1776][github-1776])
 
 ## Version `v0.27.15`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * ![Bugfix][badge-bugfix] Fix `strict` mode to properly print errors, not just a warnings. ([#1756][github-1756], [#1776][github-1776])
+* ![Bugfix][badge-bugfix] Update CSS source file for JuliaMono, so that all font variations are included (not just `JuliaMono Regular`). ([#1780][github-1780])
 
 ## Version `v0.27.15`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
+* ![Enhancement][badge-enhancement] Update CSS source file for JuliaMono, so that all font variations are included (not just `JuliaMono Regular`). ([#1780][github-1780], [#1784][github-1784])
 * ![Bugfix][badge-bugfix] Fix `strict` mode to properly print errors, not just a warnings. ([#1756][github-1756], [#1776][github-1776])
-* ![Bugfix][badge-bugfix] Update CSS source file for JuliaMono, so that all font variations are included (not just `JuliaMono Regular`). ([#1780][github-1780])
 
 ## Version `v0.27.15`
 
@@ -993,6 +993,8 @@
 [github-1773]: https://github.com/JuliaDocs/Documenter.jl/pull/1773
 [github-1774]: https://github.com/JuliaDocs/Documenter.jl/pull/1774
 [github-1776]: https://github.com/JuliaDocs/Documenter.jl/pull/1776
+[github-1780]: https://github.com/JuliaDocs/Documenter.jl/issues/1780
+[github-1784]: https://github.com/JuliaDocs/Documenter.jl/pull/1784
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 [julia-39841]: https://github.com/JuliaLang/julia/pull/39841

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -522,7 +522,7 @@ module RD
 
     const requirejs_cdn = "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"
     const lato = "https://cdnjs.cloudflare.com/ajax/libs/lato-font/3.0.0/css/lato-font.min.css"
-    const juliamono = "https://cdnjs.cloudflare.com/ajax/libs/juliamono/0.039/juliamono-regular.css"
+    const juliamono = "https://cdnjs.cloudflare.com/ajax/libs/juliamono/0.044/juliamono.css"
     const fontawesome_version = "5.15.3"
     const fontawesome_css = [
         "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/$(fontawesome_version)/css/fontawesome.min.css",


### PR DESCRIPTION
Fixes https://github.com/JuliaDocs/Documenter.jl/issues/1780. Previous CSS file only supported JuliaMono Regular, which could create some spacings issues (see https://github.com/FedeClaudi/Term.jl/issues/46, for example). Now light/bold/italic font variations should use the proper font files, instead of faux-bolding/italicizing. Also updates JuliaMono source to v0.044 (up from v0.039). Tested on MacOS with Safari, and all font weights/variants worked correctly ☺️