### PR TITLE
Fix outdated GitHub Docs links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * ![Enhancement][badge-enhancement] The preamble of the LaTeX source of the PDF build can now be customized by the user. ([#1746][github-1746], [#1788][github-1788])
 * ![Bugfix][badge-bugfix] Fix `strict` mode to properly print errors, not just a warnings. ([#1756][github-1756], [#1776][github-1776])
 * ![Bugfix][badge-bugfix] Disable git terminal prompt when detecting remote HEAD branch. ([#1797][github-1797])
+* ![Bugfix][badge-bugfix] When linkchecking HTTP and HTTPS URLs, Documenter now passes a realistic browser (Chrome) `User-Agent` header along with the request, in order to work around servers that try to use the `User-Agent` to block non-browser requests. ([#1796][github-1796])
 
 ## Version `v0.27.15`
 
@@ -1002,6 +1003,7 @@
 [github-1784]: https://github.com/JuliaDocs/Documenter.jl/pull/1784
 [github-1785]: https://github.com/JuliaDocs/Documenter.jl/pull/1785
 [github-1788]: https://github.com/JuliaDocs/Documenter.jl/pull/1788
+[github-1796]: https://github.com/JuliaDocs/Documenter.jl/pull/1796
 [github-1797]: https://github.com/JuliaDocs/Documenter.jl/pull/1797
 <!-- end of issue link definitions -->
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -26,8 +26,6 @@ makedocs(
     authors = "Michael Hatherly, Morten Piibeleht, and contributors.",
     linkcheck = "linkcheck" in ARGS,
     linkcheck_ignore = [
-        # timelessrepo.com seems to 404 on any CURL request...
-        "http://timelessrepo.com/json-isnt-a-javascript-subset",
         # We'll ignore links that point to GitHub's edit pages, as they redirect to the
         # login screen and cause a warning:
         r"https://github.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/edit(.*)",

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -17,7 +17,7 @@ Feel free to nominate commits that should be backported by opening an issue. Req
 
 ### `release-*` branches
 
-  * Each new minor version `x.y.0` gets a branch called `release-x.y` (a [protected branch](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches)).
+  * Each new minor version `x.y.0` gets a branch called `release-x.y` (a [protected branch](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches)).
   * New versions are usually tagged only from the `release-x.y` branches.
   * For patch releases, changes get backported to the `release-x.y` branch via a single PR with the standard name "Backports for x.y.z" and label ["Type: Backport"](https://github.com/JuliaDocs/Documenter.jl/pulls?q=label%3A%22Type%3A+Backport%22). The PR message links to all the PRs that are providing commits to the backport. The PR gets merged as a merge commit (i.e. not squashed).
   * The old `release-*` branches may be removed once they have outlived their usefulness.

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -249,7 +249,7 @@ see the previous section.
 
 When running from GitHub Actions it is possible to authenticate using
 [the GitHub Actions authentication token
-(`GITHUB_TOKEN`)]( https://docs.github.com/en/actions/security-guides/automatic-token-authentication). This is done by adding
+(`GITHUB_TOKEN`)](https://docs.github.com/en/actions/security-guides/automatic-token-authentication). This is done by adding
 
 ```yaml
 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -15,7 +15,7 @@ the docs you're currently reading.
     documentation locally with Documenter.
 
     This guide assumes that you already have [GitHub](https://github.com/) and
-    [Travis](https://travis-ci.com/) accounts setup. If not then go set those up first and
+    [Travis](https://www.travis-ci.com/) accounts setup. If not then go set those up first and
     then return here.
 
     It is possible to deploy from other systems than Travis CI or GitHub Actions,
@@ -207,7 +207,7 @@ jobs:
 This will install Julia, checkout the correct commit of your repository, and run the
 build of the documentation. The `julia-version:`, `julia-arch:` and `os:` entries decide
 the environment from which the docs are built and deployed. The example above builds and deploys
-the documentation from an Ubuntu worker running Julia 1.6. 
+the documentation from an Ubuntu worker running Julia 1.6.
 
 !!! tip
     The example above is a basic workflow that should suit most projects. For more information on
@@ -249,7 +249,7 @@ see the previous section.
 
 When running from GitHub Actions it is possible to authenticate using
 [the GitHub Actions authentication token
-(`GITHUB_TOKEN`)](https://docs.github.com/en/actions/reference/authentication-in-a-workflow). This is done by adding
+(`GITHUB_TOKEN`)]( https://docs.github.com/en/actions/security-guides/automatic-token-authentication). This is done by adding
 
 ```yaml
 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -276,7 +276,7 @@ DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
 
 to the configuration file, as showed in the [previous section](@ref GitHub-Actions).
 See GitHub's manual for
-[Encrypted secrets](https://docs.github.com/en/actions/reference/encrypted-secrets)
+[Encrypted secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
 for more information.
 
 ### Add code coverage from documentation builds

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -194,7 +194,16 @@ function linkcheck(link::Markdown.Link, doc::Documents.Document; method::Symbol=
     if !haskey(doc.internal.locallinks, link)
         timeout = doc.user.linkcheck_timeout
         null_file = @static Sys.iswindows() ? "nul" : "/dev/null"
-        cmd = `curl $(method === :HEAD ? "-sI" : "-s") --proto =http,https,ftp,ftps $(link.url) --max-time $timeout -o $null_file --write-out "%{http_code} %{url_effective} %{redirect_url}"`
+        # In some cases, web servers (e.g. docs.github.com as of 2022) will reject requests
+        # that declare a non-browser user agent (curl specifically passes 'curl/X.Y'). In
+        # case of docs.github.com, the server returns a 403 with a page saying "The request
+        # is blocked". However, spoofing a realistic browser User-Agent string is enough to
+        # get around this, and so here we simply pass the example Chrome UA string from the
+        # Mozilla developer docs, but only is it's a HTTP(S) request.
+        #
+        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent#chrome_ua_string
+        useragent  = startswith(uppercase(link.url), "HTTP") ? ["--user-agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36"] : ""
+        cmd = `curl $(method === :HEAD ? "-sI" : "-s") --proto =http,https,ftp,ftps $(useragent) $(link.url) --max-time $timeout -o $null_file --write-out "%{http_code} %{url_effective} %{redirect_url}"`
 
         local result
         try

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -216,13 +216,13 @@ function linkcheck(link::Markdown.Link, doc::Documents.Document; method::Symbol=
             if (protocol === :HTTP && (status < 300 || status == 302)) ||
                 (protocol === :FTP && (200 <= status < 300 || status == 350))
                 if location !== nothing
-                    @debug "linkcheck '$(link.url)' status: $(status), redirects to $(location)."
+                    @debug "linkcheck '$(link.url)' status: $(status), redirects to '$(location)'"
                 else
                     @debug "linkcheck '$(link.url)' status: $(status)."
                 end
             elseif protocol === :HTTP && status < 400
                 if location !== nothing
-                    @warn "linkcheck '$(link.url)' status: $(status), redirects to $(location)."
+                    @warn "linkcheck '$(link.url)' status: $(status), redirects to '$(location)'"
                 else
                     @warn "linkcheck '$(link.url)' status: $(status)."
                 end

--- a/src/Utilities/JSDependencies.jl
+++ b/src/Utilities/JSDependencies.jl
@@ -325,7 +325,7 @@ end
     json_jsescape(args...)
 
 Call `JSON.json(args...)` to generate a `String` of JSON, but then also escape two Unicode
-characters to get valid JS (since [JSON is not a JS subset](http://timelessrepo.com/json-isnt-a-javascript-subset)).
+characters to get valid JS (since [JSON is not a JS subset](https://web.archive.org/web/20200111135746/http://timelessrepo.com/json-isnt-a-javascript-subset)).
 
 !!! note
     Technically, starting with ECMAScript® 2019 (10th edition), this is no longer necessary.

--- a/src/deployconfig.jl
+++ b/src/deployconfig.jl
@@ -286,7 +286,7 @@ when using the `GitHubActions` configuration:
    see the manual section for [GitHub Actions](@ref) for more information.
 
 The `GITHUB_*` variables are set automatically on GitHub Actions, see the
-[documentation](https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables).
+[documentation](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables).
 """
 struct GitHubActions <: DeployConfig
     github_repository::String


### PR DESCRIPTION
They have been [throwing 301s](https://github.com/JuliaDocs/Documenter.jl/runs/5965277331?check_suite_focus=true). Should hopefully fix linkcheck.