### PR TITLE
Added preprocess [default to  (page,path) -> page] option

### DIFF
--- a/src/Builder.jl
+++ b/src/Builder.jl
@@ -90,6 +90,7 @@ function Selectors.runner(::Type{SetupBuildDirectory}, doc::Documents.Document)
     build  = doc.user.build
     source = doc.user.source
     workdir = doc.user.workdir
+    preprocess = doc.user.preprocess
 
 
     # The .user.source directory must exist.
@@ -128,7 +129,7 @@ function Selectors.runner(::Type{SetupBuildDirectory}, doc::Documents.Document)
 
             if endswith(file, ".md")
                 push!(mdpages, Utilities.srcpath(source, root, file))
-                Documents.addpage!(doc, src, dst, wd)
+                Documents.addpage!(doc, src, dst, wd, preprocess)
             else
                 cp(src, dst; force = true)
             end

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -221,6 +221,10 @@ ignored.
 **`linkcheck_timeout`** configures how long `curl` waits (in seconds) for a link request to
 return a response before giving up. The default is 10 seconds.
 
+**`preprocess`** allows to specify a function to preprocess the String read from file before
+it is parsed as a Markdown page. The custom function should have the page content as the
+first argument, the page full path as the second one and return a String.
+
 **`strict`** -- if set to `true`, [`makedocs`](@ref) fails the build right before rendering
 if it encountered any errors with the document in the previous build phases. The keyword
 `strict` can also be set to a `Symbol` or `Vector{Symbol}` to specify which kind of error


### PR DESCRIPTION
The preprocess function is called after having read the String from
file and before it is parsed as a Markdown page.