### PR TITLE
Add a CI job to verify CHANGELOG

### DIFF
--- a/.github/workflows/repochecks.yml
+++ b/.github/workflows/repochecks.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Test scripts/changelog.jl
         run: |
           # Run the unit tests of the changelog.jl script:
-          julia --color=yes --project=scripts/ scripts/changelog.jl test
+          julia --color=yes --code-coverage --project=scripts/ scripts/changelog.jl test
           # Run changelog.jl with a small, but known good CHANGELOG file and make sure it passes:
-          julia --color=yes --project=scripts/ scripts/changelog.jl --file=scripts/changelog-valid.md
+          julia --color=yes --code-coverage --project=scripts/ scripts/changelog.jl --file=scripts/changelog-valid.md
           # Run changelog.jl with a known _bad_ CHANGELOG file, which should exit with a non-zero code:
-          ! julia --color=yes --project=scripts/ scripts/changelog.jl --file=scripts/changelog-invalid.md
+          ! julia --color=yes --code-coverage --project=scripts/ scripts/changelog.jl --file=scripts/changelog-invalid.md
       - name: Check CHANGELOG.md
-        run: julia --color=yes --project=scripts/ scripts/changelog.jl --github
+        run: julia --color=yes --code-coverage --project=scripts/ scripts/changelog.jl --github
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/repochecks.yml
+++ b/.github/workflows/repochecks.yml
@@ -19,8 +19,11 @@ jobs:
         run: julia --color=yes --project=scripts/ -e 'using Pkg; Pkg.instantiate()'
       - name: Test scripts/changelog.jl
         run: |
+          # Run the unit tests of the changelog.jl script:
           julia --color=yes --project=scripts/ scripts/changelog.jl test
+          # Run changelog.jl with a small, but known good CHANGELOG file and make sure it passes:
           julia --color=yes --project=scripts/ scripts/changelog.jl --file=scripts/changelog-valid.md
+          # Run changelog.jl with a known _bad_ CHANGELOG file, which should exit with a non-zero code:
           ! julia --color=yes --project=scripts/ scripts/changelog.jl --file=scripts/changelog-invalid.md
       - name: Check CHANGELOG.md
         run: julia --color=yes --project=scripts/ scripts/changelog.jl --github

--- a/.github/workflows/repochecks.yml
+++ b/.github/workflows/repochecks.yml
@@ -1,0 +1,30 @@
+name: Repo checks
+
+on:
+  push:
+    branches: '*'
+    tags: '*'
+  pull_request:
+
+jobs:
+  changelog:
+    name: Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: '1.6'
+      - name: Install dependencies
+        run: julia --color=yes --project=scripts/ -e 'using Pkg; Pkg.instantiate()'
+      - name: Test scripts/changelog.jl
+        run: |
+          julia --color=yes --project=scripts/ scripts/changelog.jl test
+          julia --color=yes --project=scripts/ scripts/changelog.jl --file=scripts/changelog-valid.md
+          ! julia --color=yes --project=scripts/ scripts/changelog.jl --file=scripts/changelog-invalid.md
+      - name: Check CHANGELOG.md
+        run: julia --color=yes --project=scripts/ scripts/changelog.jl --github
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info

--- a/.github/workflows/repochecks.yml
+++ b/.github/workflows/repochecks.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Check CHANGELOG.md
         run: julia --color=yes --code-coverage --project=scripts/ scripts/changelog.jl --github
       - uses: julia-actions/julia-processcoverage@v1
+        with:
+          directories: src,scripts
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info

--- a/scripts/Manifest.toml
+++ b/scripts/Manifest.toml
@@ -1,0 +1,193 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.6.6"
+manifest_format = "2.0"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.CommonMark]]
+deps = ["Crayons", "JSON", "URIs"]
+git-tree-sha1 = "8c4858e44024bae3e521c77e132e1bbd56e0ad55"
+repo-rev = "mp/reference-links"
+repo-url = "https://github.com/mortenpi/CommonMark.jl"
+uuid = "a80b9123-70ca-4bc0-993e-6e3bcb318db6"
+version = "0.8.6"
+
+[[deps.Crayons]]
+git-tree-sha1 = "249fe38abf76d48563e2f4556bebd215aa317e15"
+uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
+version = "4.1.1"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[deps.GitHub]]
+deps = ["Base64", "Dates", "HTTP", "JSON", "MbedTLS", "Sockets", "SodiumSeal", "URIs"]
+git-tree-sha1 = "056781ae7b953289778408b136f8708a46837979"
+uuid = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
+version = "5.7.2"
+
+[[deps.HTTP]]
+deps = ["Base64", "Dates", "IniFile", "Logging", "MbedTLS", "NetworkOptions", "Sockets", "URIs"]
+git-tree-sha1 = "0fa77022fe4b511826b39c894c90daf5fce3334a"
+uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+version = "0.9.17"
+
+[[deps.IniFile]]
+git-tree-sha1 = "f550e6e32074c939295eb5ea6de31849ac2c9625"
+uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
+version = "0.5.1"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.JLLWrappers]]
+deps = ["Preferences"]
+git-tree-sha1 = "abc9885a7ca2052a736a600f7fa66209f96506e1"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.4.1"
+
+[[deps.JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "3c837543ddb02250ef42f4738347454f95079d4e"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.3"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+
+[[deps.LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.MbedTLS]]
+deps = ["Dates", "MbedTLS_jll", "Random", "Sockets"]
+git-tree-sha1 = "1c38e51c3d08ef2278062ebceade0e46cefc96fe"
+uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
+version = "1.0.3"
+
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[deps.Parsers]]
+deps = ["Dates"]
+git-tree-sha1 = "621f4f3b4977325b9128d5fae7a8b4829a0c2222"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.2.4"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "d3538e7f8a790dc8903519090857ef8e1283eecd"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.2.5"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[deps.SodiumSeal]]
+deps = ["Base64", "Libdl", "libsodium_jll"]
+git-tree-sha1 = "80cef67d2953e33935b41c6ab0a178b9987b1c99"
+uuid = "2133526b-2bfb-4018-ac12-889fb3908a75"
+version = "0.1.1"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+
+[[deps.URIs]]
+git-tree-sha1 = "97bbe755a53fe859669cd907f2d96aee8d2c1355"
+uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
+version = "1.3.0"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[deps.libsodium_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "848ab3d00fe39d6fbc2a8641048f8f272af1c51e"
+uuid = "a9144af2-ca23-56d9-984f-0d03f7b5ccf8"
+version = "1.0.20+0"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/scripts/Project.toml
+++ b/scripts/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+CommonMark = "a80b9123-70ca-4bc0-993e-6e3bcb318db6"
+GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"

--- a/scripts/changelog-invalid.md
+++ b/scripts/changelog-invalid.md
@@ -1,0 +1,18 @@
+Foo [#1234][githb-1234] bar [#4321][github-1234] baz [foobar][github-1234].
+
+Missing link reference definition: [#1000][githb-1000]
+
+Bad brackets: [#1000](github-1000)
+
+[#200][github-200]
+
+<!-- issue link definitions -->
+[github-1234]: https://github.com/JuliaDocs/Documenter.jl/issues/1234
+[github-500]: https://github.com/JuliaDocs/Documenter.jl/tracker/1234
+[github-501]: https://github.com/JuliaDocs/Documenter.jl/issues/500
+[github-200]: https://github.com/JuliaDocs/Documenter.jl/issues/200
+[github-200]: https://github.com/JuliaDocs/Documenter.jl/issues/200
+[github-200]: https://github.com/JuliaDocs/Documenter.jl/issues/201
+<!-- end of issue lnk definitions -->
+
+[non-abs-url]: foo

--- a/scripts/changelog-valid.md
+++ b/scripts/changelog-valid.md
@@ -1,0 +1,9 @@
+[Experimental badge link][badge-experimental]
+
+Foo [#1234][github-1234] bar.
+
+<!-- issue link definitions -->
+[github-1234]: https://github.com/JuliaDocs/Documenter.jl/issues/1234
+<!-- end of issue link definitions -->
+
+[badge-experimental]: https://img.shields.io/badge/experimental-lightgrey.svg

--- a/scripts/changelog.jl
+++ b/scripts/changelog.jl
@@ -1,0 +1,527 @@
+using Dates
+using Test
+using GitHub
+# Note: currently requires a modified version of CommonMark:
+# https://github.com/mortenpi/CommonMark.jl/tree/mp/reference-links
+using CommonMark
+
+# Configuration:
+
+const LINKREF_EXCEPTIONS = [
+    "json-jl", "juliamono", "documenterlatex", "documentermarkdown",
+    r"^julia-([0-9]+)$",
+    r"^julialangorg-([0-9]+)$",
+    r"^badge-([a-z]+)$",
+]
+const ISSUE_LIST_START = "<!-- issue link definitions -->"
+const ISSUE_LIST_END = "<!-- end of issue link definitions -->"
+const CHANGELOG = joinpath(@__DIR__, "..", "CHANGELOG.md")
+
+# Functions:
+
+"""
+    isabsurl(url)
+Checks whether `url` is an absolute URL (as opposed to a relative one).
+"""
+isabsurl(url) = occursin(ABSURL_REGEX, url)
+const ABSURL_REGEX = r"^[[:alpha:]+-.]+://"
+
+function findnodes(T, ast)
+    nodes = CommonMark.Node[]
+    for (node, entering) in ast
+        entering || continue
+        node.t isa T && push!(nodes, node)
+    end
+    return nodes
+end
+
+function children(n::CommonMark.Node)
+    n, nodes = n.first_child, CommonMark.Node[]
+    while n != CommonMark.NULL_NODE
+        push!(nodes, n)
+        n = n.nxt
+    end
+    return nodes
+end
+
+function fetch_github_issues(; minratelimit = 30, auth_token = nothing, issues_list_cache = Ref{Vector{Issue}}())
+    if isassigned(issues_list_cache)
+        @debug "Using cached issues list" length(issues_list_cache[])
+    else
+        auth = isnothing(auth_token) ? GitHub.AnonymousAuth() : authenticate(auth_token)
+
+        ratelimit = rate_limit(auth = auth)
+        if ratelimit["rate"]["remaining"] < minratelimit
+            reset = unix2datetime(ratelimit["rate"]["reset"])
+            @warn """
+            Failed to fetch issues from GitHub.
+            Rate-limited: too few requests remaining ($(ratelimit["rate"]["remaining"]); less than $(minratelimit))
+            Reset at $(reset) UTC (unix: $(ratelimit["rate"]["reset"]))
+            Likely due to GITHUB_TOKEN not having been set.
+            """ rate_limit = ratelimit
+            return
+        end
+
+        @debug "rate_limit" ratelimit["rate"]["remaining"] reset = unix2datetime(ratelimit["rate"]["reset"]) rate_limit = ratelimit
+        issues_list_cache[], _ = issues(
+            "JuliaDocs/Documenter.jl",
+            auth = auth,
+            params = Dict(:state => "all", :per_page => 100)
+        )
+    end
+    issues_dict = Dict(issue.number => issue for issue in issues_list_cache[])
+    # sanity check, to make sure there are no duplicate issue numbers
+    @assert length(issues_list_cache[]) == length(issues_dict)
+    return issues_dict
+end
+
+function parse_changelog_into_ast(io::IO)
+    p = Parser()
+    bad_reflabels = String[]
+    p.inline_parser.reflink_callback = reflabel -> begin
+        push!(bad_reflabels, reflabel)
+    end
+    changelog = read(io, String)
+    ast = p(changelog)
+    if !isempty(bad_reflabels)
+        # If we found any bad reference labels, we'll add them to the .refmap manually
+        # and re-parse the CHANGELOG file
+        refmap = Dict{String, Tuple{String, String}}(
+            reflabel => ("#MISSING#", "")
+            for reflabel in bad_reflabels
+        )
+        return p(changelog, refmap = refmap)
+    else
+        return ast
+    end
+end
+parse_changelog_into_ast(filename::AbstractString) = open(parse_changelog_into_ast, filename)
+
+function print_nonref_links(ast::CommonMark.Node)
+    println("Following non-ref links found in AST:", "")
+    for link in findnodes(CommonMark.Link, ast)
+        println(" - ", term(link), " (", link.t.destination, ")")
+    end
+end
+
+"""
+Check that all the standard (non-reference) links in the AST are absolute URLs.
+"""
+function check_links_not_absolute(ast::CommonMark.Node)
+    badlinks = String[]
+    for link in findnodes(CommonMark.Link, ast)
+        isabsurl(link.t.destination) && continue
+        push!(badlinks, string(" - ", term(link), " (", link.t.destination, ")"))
+    end
+    isempty(badlinks) && return true
+    @error """Non-absolute links detected in text.
+    This is likely due to wrong brackets for reference links ('()' vs '[]').
+    $(join(badlinks, "\n"))
+    """
+    return false
+end
+
+"""
+Check that all the link reference definitions in the AST are absolute URLs.
+"""
+function check_linkrefs_not_absolute(ast::CommonMark.Node)
+    badlinks = String[]
+    for link in findnodes(CommonMark.LinkReferenceDefinition, ast)
+        isabsurl(link.t.destination) && continue
+        push!(badlinks, string(" - [", link.t.label, "]: ", link.t.destination))
+    end
+    isempty(badlinks) && return true
+    @error """Non-absolute link references detected.
+    $(join(badlinks, "\n"))
+    """
+    return false
+end
+
+"""
+Returns a tuple of information if the text in a link is `#[0-9]+`, and `nothing`
+if it is not.
+"""
+function parse_documenter_linktext(node::CommonMark.Node)
+    cs = children(node)
+    length(cs) == 1 || return
+    cs[1].t isa CommonMark.Text || return
+    m = match(r"^#([0-9]+)$", cs[1].literal)
+    isnothing(m) && return
+    return (number = parse(Int, m[1]), text = cs[1].literal, node = node)
+end
+
+function check_reflinks(ast::CommonMark.Node)
+    badlinks = String[]
+    for reflink in findnodes(CommonMark.ReferenceLink, ast)
+        if any(occursin(exception, reflink.t.label) for exception in LINKREF_EXCEPTIONS)
+            @debug "Ignoring ref link: '$(reflink.t.label)'"
+            continue
+        end
+        # First, make sure that the reference link label is 'github-NNN'
+        m = match(r"^github-([0-9]+)$", reflink.t.label)
+        if isnothing(m)
+            push!(badlinks, string(" - ", term(reflink), " [", reflink.t.label, "]"))
+            continue
+        end
+        # If the link text is '#NNN', then we make sure that the issue numbers match
+        link_issunumber = parse(Int, m[1])
+        linktext = parse_documenter_linktext(reflink)
+        if !isnothing(linktext)
+            if linktext.number != link_issunumber
+                push!(badlinks, string(" - ", term(reflink), " [", reflink.t.label, "]"))
+            end
+        else
+            # If we didn't manage to determine the issue number from the text, we also
+            # consider it to be a bad link. However, this may need to be relaxed in the
+            # future, as it is not necessarily an error to have a link using the `github-N`
+            # labels even if they are not an issue link.
+            push!(badlinks, string(" - ", term(reflink), " [", reflink.t.label, "]"))
+        end
+    end
+    isempty(badlinks) && return true
+    @error """Invalid reference links:
+    $(join(badlinks, "\n"))
+    """
+    return false
+end
+
+function parse_documenter_url(destination)
+    m = match(r"^https://github.com/JuliaDocs/Documenter.jl/(pull|issues)/([0-9]+)$", destination)
+    isnothing(m) && return
+    (type = m[1], number = parse(Int, m[2]), url = destination)
+end
+
+"""
+Make sure that all `github-NNN` link reference definitions point to Documenter.
+"""
+function check_linkrefs_github_url(ast::CommonMark.Node; ghissues::Union{Dict{Int,Issue},Nothing} = nothing)
+    badlinks = String[]
+    for link in findnodes(CommonMark.LinkReferenceDefinition, ast)
+        # Only keep labels that are in the 'github-NNN' format
+        m = match(r"^github-([0-9]+)$", link.t.label)
+        isnothing(m) && continue
+        urlinfo = parse_documenter_url(link.t.destination)
+        if isnothing(urlinfo)
+            push!(badlinks, string(" - [", link.t.label, "]: ", link.t.destination, " (bad URL)"))
+            continue
+        end
+        # If the URL is sane, we'll check that the issue number matches:
+        if urlinfo.number != parse(Int, m[1])
+            push!(badlinks, string(" - [", link.t.label, "]: ", link.t.destination, " (issue number mismatch)"))
+            continue
+        end
+        # If ghissues was passed, we will check to make sure that the issue type is correct
+        isnothing(ghissues) && continue
+        if !haskey(ghissues, urlinfo.number)
+            push!(badlinks, string(" - [", link.t.label, "]: ", link.t.destination, " (bad GH issue number)"))
+            continue
+        end
+        gh_url = ghissues[urlinfo.number].html_url
+        if string(gh_url) != urlinfo.url
+            push!(badlinks, string(" - [", link.t.label, "]: ", link.t.destination, " (bad URL for issue, should be: '$(gh_url)')"))
+            continue
+        end
+    end
+    isempty(badlinks) && return true
+    @error """Invalid GitHub link references detected.
+    $(join(badlinks, "\n"))
+    """
+    return false
+end
+
+function check_issue_list_delimiters(io::IO)
+    errors = String[]
+    changelog = readlines(io)
+    linkdef_start = findfirst(contains(ISSUE_LIST_START), changelog)
+    linkdef_end = findfirst(contains(ISSUE_LIST_END), changelog)
+    # Check that the delimiters are present
+    isnothing(linkdef_start) && push!(errors, " - '$(ISSUE_LIST_START)'")
+    isnothing(linkdef_end) && push!(errors, " - '$(ISSUE_LIST_END)'")
+    # Make sure that the issue delimiters are in the right order
+    if !isnothing(linkdef_start) && !isnothing(linkdef_end)
+        (linkdef_end - linkdef_start) >= 1 || push!(errors, " - Issue list delimiters in wrong order")
+    end
+    isempty(errors) && return true
+    @error """Missing issue list delimiters:
+    $(join(errors, "\n"))
+    """
+    return false
+end
+check_issue_list_delimiters(filename::AbstractString) = open(check_issue_list_delimiters, filename)
+
+function find_github_links(ast::CommonMark.Node)
+    links, linkdefs = [], []
+    for node in findnodes(CommonMark.ReferenceLink, ast)
+        m = match(r"^github-([0-9]+)$", node.t.label)
+        isnothing(m) && continue
+        push!(links, (
+            label = node.t.label,
+            number = parse(Int, m[1]),
+            node = node,
+        ))
+    end
+    for node in findnodes(CommonMark.LinkReferenceDefinition, ast)
+        m = match(r"^github-([0-9]+)$", node.t.label)
+        isnothing(m) && continue
+        push!(linkdefs, (
+            label = node.t.label,
+            url = node.t.destination,
+            number = parse(Int, m[1]),
+            node = node,
+        ))
+    end
+    return (; links, linkdefs)
+end
+
+function check_missing_links(ast)
+    errors = String[]
+    links, linkdefs = find_github_links(ast)
+    link_numbers = sort(unique(link.number for link in links))
+    linkdef_numbers = sort(unique(link.number for link in linkdefs))
+    if linkdef_numbers != unique(link.number for link in linkdefs)
+        push!(errors, " - Link definitions not sorted")
+    end
+    for n in linkdef_numbers
+        # Check that there are not duplicate link definitions
+        counts = count(isequal(n), link.number for link in linkdefs)
+        (counts == 1) || push!(errors, " - Duplicate link definition: github-$(n) (x$(counts))")
+        # Make sure that each linkdef has a corresponding link:
+        idx = findfirst(isequal(n), link_numbers)
+        isnothing(idx) && push!(errors, " - Missing link for link definition: github-$(n)")
+    end
+    for n in link_numbers
+        # Make sure that each link has a corresponding link definition:
+        idx = findfirst(isequal(n), linkdef_numbers)
+        isnothing(idx) && push!(errors, " - Missing link definition for link: [github-$(n)]")
+    end
+    isempty(errors) && return true
+    @error """Missing or duplicate github-NNN links.
+    $(join(errors, "\n"))
+    """
+    return false
+end
+
+function fix_changelog_issue_list(filename; ofile=filename, ghissues::Union{Dict{Int,Issue},Nothing} = nothing)
+    # Find the link definition list in the CHANGELOG
+    changelog = readlines(filename)
+    linkdef_start = findfirst(contains(ISSUE_LIST_START), changelog)
+    linkdef_end = findfirst(contains(ISSUE_LIST_END), changelog)
+    @assert !isnothing(linkdef_start)
+    @assert !isnothing(linkdef_end)
+    @assert (linkdef_end - linkdef_start) >= 1
+    # Generate the correct link reference definition list
+    ast = parse_changelog_into_ast(filename)
+    links, linkdefs = find_github_links(ast)
+
+    linkdef_list = map(sort(unique(link.number for link in links))) do issuenumber
+        # If ghissues is passed, we'll determine the URL from there
+        url = if !isnothing(ghissues)
+            if haskey(ghissues, issuenumber)
+                string(ghissues[issuenumber].html_url)
+            else
+                @warn "Invalid issue: github-$(issuenumber) missing from GH issue list"
+                nothing
+            end
+        end
+        # If that did not success (no ghissues, or issue missing), then we'll fall back to
+        # the URL in the existing link reference definition
+        if isnothing(url)
+            idx = findfirst(linkdef -> linkdef.number == issuenumber, linkdefs)
+            if isnothing(idx)
+                @warn "Issue missing from link reference definitions, assuming '/issues/': github-$(issuenumber)"
+                url = "https://github.com/JuliaDocs/Documenter.jl/issues/$(issuenumber)"
+            else
+                url = linkdefs[idx].url
+            end
+        end
+        return "[github-$(issuenumber)]: $(url)"
+    end
+    # Update the relevant lines and write the output file
+    changelog_updated = vcat(changelog[1:linkdef_start], linkdef_list, changelog[linkdef_end:end])
+    open(ofile, "w") do io
+        for line in changelog_updated
+            write(io, line, '\n')
+        end
+    end
+end
+
+macro interactive(expr)
+    @assert expr.head == :if
+    isinteractive() ? expr.args[2] : expr
+end
+
+function run_mode(args)
+    "test" in args && return :test
+    "fix" in args && return :fix
+    return :check
+end
+
+const PATH_OPTION_REGEX = r"^--file=(.+)$"
+function changelog_file_path(args)
+    idx = findlast(contains(PATH_OPTION_REGEX), args)
+    isnothing(idx) && return CHANGELOG
+    m = match(PATH_OPTION_REGEX, args[idx])
+    path = joinpath(pwd(), m[1])
+    @info "Reading CHANGELOG from $path"
+    return path
+end
+
+# Read ARGS and run the script.
+# The @interactive make it possible to run each of the blocks in e.g. VSCode without having
+# to set up the ARGS variable.
+
+github_issues_list = @interactive if "--github" in ARGS
+    @info "Attempting to fetch issue list from GitHub..."
+    issues = fetch_github_issues(auth_token = get(ENV, "GITHUB_TOKEN", nothing))
+    isnothing(issues) || @info "... fetched information on $(length(issues)) issues."
+    issues
+end
+
+@interactive if run_mode(ARGS) === :check
+    ast = parse_changelog_into_ast(changelog_file_path(ARGS))
+    # Just for information, we print out all the standard (i.e. not refererence) links found in
+    # the document. This can be manually checked every now and then to make sure that there are
+    # no unexpected entries there.
+    print_nonref_links(ast)
+    # Run all the checks and throw an error there are any problems:
+    noerrors = true
+    noerrors = noerrors & check_issue_list_delimiters(CHANGELOG)
+    noerrors = noerrors & check_reflinks(ast)
+    noerrors = noerrors & check_links_not_absolute(ast)
+    noerrors = noerrors & check_linkrefs_not_absolute(ast)
+    noerrors = noerrors & check_linkrefs_github_url(ast; ghissues = github_issues_list)
+    noerrors = noerrors & check_missing_links(ast)
+    if noerrors
+        @info "No errors detected in CHANGELOG.md"
+    else
+        error("Errors detected in CHANGELOG.md, see the log.")
+    end
+end
+
+@interactive if run_mode(ARGS) === :fix
+    @info "Updating CHANGELOG.md. This will overwrite the file."
+    @assert check_issue_list_delimiters(CHANGELOG)
+    fix_changelog_issue_list(CHANGELOG, ghissues = github_issues_list)
+end
+
+# Run with MD string
+rwmds(f, mds::AbstractString) = f(parse_changelog_into_ast(IOBuffer(mds)))
+
+@interactive if run_mode(ARGS) === :test
+    @info "Running changelog.jl tests"
+    valid_example = read(joinpath(@__DIR__, "changelog-valid.md"), String)
+    invalid_example = read(joinpath(@__DIR__, "changelog-invalid.md"), String)
+
+    @testset "changelog.jl" begin
+        @testset "check_issue_list_delimiters()" begin
+            @test check_issue_list_delimiters(IOBuffer(valid_example))
+            @test @test_logs (:error,) check_issue_list_delimiters(IOBuffer(invalid_example)) === false
+            @test @test_logs (:error,) check_issue_list_delimiters(IOBuffer("")) === false
+            @test @test_logs (:error,) check_issue_list_delimiters(IOBuffer("""
+            foo bar baz
+            """)) === false
+            @test @test_logs (:error,) check_issue_list_delimiters(IOBuffer("""
+            <!-- issue link definitions -->
+            """)) === false
+            @test @test_logs (:error,) check_issue_list_delimiters(IOBuffer("""
+            <!-- end of issue link definitions -->
+            """)) === false
+            @test @test_logs (:error,) check_issue_list_delimiters(IOBuffer("""
+            <!-- end of issue link definitions -->
+            <!-- issue link definitions -->
+            """)) === false
+            @test check_issue_list_delimiters(IOBuffer("""
+            <!-- issue link definitions -->
+            <!-- end of issue link definitions -->
+            """))
+            @test check_issue_list_delimiters(IOBuffer("""
+            foo
+            <!-- issue link definitions -->
+            bar
+            <!-- end of issue link definitions -->
+            """))
+        end
+
+        @testset "check_reflinks()" begin
+            @test rwmds(check_reflinks, "")
+            @test rwmds(check_reflinks, valid_example)
+            @test @test_logs (:error,) rwmds(check_reflinks, invalid_example) === false
+            @test rwmds(check_reflinks, """
+            Reference link: [#1234][github-1234]
+
+            [github-1234]: https://github.com/JuliaDocs/Documenter.jl/issues/1234
+            """)
+            @test @test_logs (:error,) rwmds(check_reflinks, """
+            Bad reference link label: [#1234][githb-1234]
+
+            [github-1234]: https://github.com/JuliaDocs/Documenter.jl/issues/1234
+            """) === false
+            @test @test_logs (:error,) rwmds(check_reflinks, """
+            Mismatching issue numbers: [#4321][github-1234]
+
+            [github-1234]: https://github.com/JuliaDocs/Documenter.jl/issues/1234
+            """) === false
+            @test @test_logs (:error,) rwmds(check_reflinks, """
+            Link label not '#NNNN': [1234][github-1234]
+
+            [github-1234]: https://github.com/JuliaDocs/Documenter.jl/issues/1234
+            """) === false
+            @test @test_logs (:error,) rwmds(check_reflinks, """
+            Link label not '#NNNN': [foobar][github-1234]
+
+            [github-1234]: https://github.com/JuliaDocs/Documenter.jl/issues/1234
+            """) === false
+        end
+
+        @testset "check_links_not_absolute()" begin
+            @test rwmds(check_links_not_absolute, "")
+            @test rwmds(check_links_not_absolute, valid_example)
+            @test @test_logs (:error,) rwmds(check_links_not_absolute, invalid_example) === false
+            @test @test_logs (:error,) rwmds(check_links_not_absolute, """
+            Non-absolute URL: [foobar](github-1234).
+            """) === false
+            @test rwmds(check_links_not_absolute, """
+            Absolute URL: [foobar](https://example.org/).
+            """)
+        end
+
+        @testset "check_linkrefs_not_absolute()" begin
+            @test rwmds(check_linkrefs_not_absolute, "")
+            @test rwmds(check_linkrefs_not_absolute, valid_example)
+            @test @test_logs (:error,) rwmds(check_linkrefs_not_absolute, invalid_example) === false
+        end
+
+        @testset "check_linkrefs_github_url()" begin
+            @test rwmds(check_linkrefs_github_url, "")
+            @test rwmds(check_linkrefs_github_url, valid_example)
+            @test @test_logs (:error,) rwmds(check_linkrefs_github_url, invalid_example) === false
+            @test @test_logs (:error,) rwmds(check_linkrefs_github_url, """
+            [github-1234]: https://githb.com/JuliaDocs/Documenter.jl/issues/1234
+            """) === false
+            @test @test_logs (:error,) rwmds(check_linkrefs_github_url, """
+            [github-1234]: https://github.com/JuliaDocs/Documenter.jl/issues/1235
+            """) === false
+            @test rwmds(check_linkrefs_github_url, """
+            [github-1234]: https://github.com/JuliaDocs/Documenter.jl/issues/1234
+            """)
+        end
+
+        @testset "check_missing_links()" begin
+            @test rwmds(check_missing_links, "")
+            @test rwmds(check_missing_links, valid_example)
+            @test @test_logs (:error,) rwmds(check_missing_links, invalid_example) === false
+            @test @test_logs (:error,) rwmds(check_missing_links, """
+            [#1234][github-1234]
+
+            [github-1234]: https://github.com/JuliaDocs/Documenter.jl/issues/1234
+            [github-1234]: https://github.com/JuliaDocs/Documenter.jl/issues/1234
+            """) === false
+            @test @test_logs (:error,)  rwmds(check_missing_links, """
+            [#1234][github-1234]
+            """) === false
+            @test @test_logs (:error,)  rwmds(check_missing_links, """
+            [github-1234]: https://github.com/JuliaDocs/Documenter.jl/issues/1234
+            """) === false
+        end
+    end
+end


### PR DESCRIPTION
Following up on #1787. This should catch various errors (missings links etc.) that get introduced into the CHANGELOG sometimes.

It depends on an [experimental branch of CommonMark.jl](https://github.com/mortenpi/CommonMark.jl/tree/mp/reference-links), as CommonMark does not fully support reference links right now (MichaelHatherly/CommonMark.jl#40). Once those changes get into CommonMark, the code here should be updated and then the `Manifest.toml` can be removed.