### PR TITLE
LaTeX: add `tectonic`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,7 +56,7 @@ jobs:
             using Pkg
             Pkg.instantiate()
             Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.add(["IOCapture", "DocumenterMarkdown"])'
+            Pkg.add(["IOCapture", "DocumenterMarkdown", "tectonic_jll"])'
       - run: julia --project=test/examples --code-coverage test/examples/tests_latex.jl
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Documenter.jl changelog
 
+## Unreleased
+
+* ![Enhancement][badge-enhancement] PDF/LaTeX output can now be compiled with the [Tectonic](https://tectonic-typesetting.github.io) LaTeX engine. ([#1802][github-1802], [#1803][github-1803])
+
 ## Version `v0.27.16`
 
 * ![Enhancement][badge-enhancement] Update CSS source file for JuliaMono, so that all font variations are included (not just `JuliaMono Regular`) and that the latest version (0.039 -> 0.044) of the font would be used. ([#1780][github-1780], [#1784][github-1784])
@@ -1007,6 +1011,8 @@
 [github-1795]: https://github.com/JuliaDocs/Documenter.jl/pull/1795
 [github-1796]: https://github.com/JuliaDocs/Documenter.jl/pull/1796
 [github-1797]: https://github.com/JuliaDocs/Documenter.jl/pull/1797
+[github-1802]: https://github.com/JuliaDocs/Documenter.jl/issues/1802
+[github-1803]: https://github.com/JuliaDocs/Documenter.jl/pull/1803
 <!-- end of issue link definitions -->
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079

--- a/docs/src/man/other-formats.md
+++ b/docs/src/man/other-formats.md
@@ -33,6 +33,27 @@ The following is required to build the documentation:
   highlighter [Pygments](https://pygments.org/) installed.
 * You need the [_DejaVu Sans_ and _DejaVu Sans Mono_](https://dejavu-fonts.github.io/) fonts installed.
 
+### Compiling using Tectonic 
+
+The documentation can be also built using the
+[Tectonic](https://tectonic-typesetting.github.io) typesetting system. It is required to have a `tectonic`
+executable present in `PATH`, or to provide it using the `tectonic` keyword:
+
+```
+using Documenter
+
+# Executable `tectonic` is present in `PATH`
+makedocs(
+    format = Documenter.LaTeX(platform="tectonic"), 
+    ...)
+
+# The path to `tectonic` is provided by the JLL
+import tectonic_jll: tectonic
+makedocs(
+    format = Documenter.LaTeX(platform="tectonic", tectonic=tectonic()), 
+    ...)
+```
+
 ### Compiling using docker image
 
 It is also possible to use a prebuilt [docker image](https://hub.docker.com/r/juliadocs/documenter-latex/)

--- a/docs/src/man/other-formats.md
+++ b/docs/src/man/other-formats.md
@@ -36,8 +36,8 @@ The following is required to build the documentation:
 ### Compiling using Tectonic 
 
 The documentation can be also built using the
-[Tectonic](https://tectonic-typesetting.github.io) typesetting system. It is required to have a `tectonic`
-executable present in `PATH`, or to provide it using the `tectonic` keyword:
+[Tectonic](https://tectonic-typesetting.github.io) LaTeX engine. It is required to have a `tectonic`
+available in `PATH`, or to provide a path to the binary using the `tectonic` keyword:
 
 ```
 using Documenter
@@ -47,8 +47,8 @@ makedocs(
     format = Documenter.LaTeX(platform="tectonic"), 
     ...)
 
-# The path to `tectonic` is provided by the JLL
-import tectonic_jll: tectonic
+# The path to `tectonic` is provided by the tectonic_jll package
+using tectonic_jll: tectonic
 makedocs(
     format = Documenter.LaTeX(platform="tectonic", tectonic=tectonic()), 
     ...)

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -441,6 +441,26 @@ else
     nothing
 end
 
+examples_latex_simple_tectonic_doc = if "latex_simple_tectonic" in EXAMPLE_BUILDS
+    @info("Building mock package docs: LaTeXWriter/latex_simple_tectonic")
+    using tectonic_jll: tectonic
+    @quietly makedocs(
+        format = Documenter.LaTeX(platform="tectonic", version = v"1.2.3", tectonic=tectonic()),
+        sitename = "Documenter LaTeX Simple Tectonic",
+        root  = examples_root,
+        build = "builds/latex_simple_tectonic",
+        source = "src.latex_simple",
+        pages = ["Main section" => ["index.md"]],
+        doctest = false,
+        debug = true,
+    )
+else
+    @info "Skipping build: LaTeXWriter/latex_simple_tectonic"
+    @debug "Controlling variables:" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
+    nothing
+end
+
+
 examples_latex_texonly_doc = if "latex_texonly" in EXAMPLE_BUILDS
     @info("Building mock package docs: LaTeXWriter/latex_texonly")
     @quietly makedocs(

--- a/test/examples/tests_latex.jl
+++ b/test/examples/tests_latex.jl
@@ -3,7 +3,8 @@ using Test
 # DOCUMENTER_TEST_EXAMPLES can be used to control which builds are performed in
 # make.jl, and we need to set it to the relevant LaTeX builds.
 ENV["DOCUMENTER_TEST_EXAMPLES"] =
-    "latex latex_simple latex_texonly latex_cover_page latex_toc_style"
+    "latex latex_simple latex_texonly latex_cover_page latex_toc_style " *
+    "latex_simple_tectonic"
 
 # When the file is run separately we need to include make.jl which actually builds
 # the docs and defines a few modules that are referred to in the docs. The make.jl
@@ -64,6 +65,14 @@ end
         @test isa(doc, Documenter.Documents.Document)
         let build_dir = joinpath(examples_root, "builds", "latex_toc_style")
             @test joinpath(build_dir, "DocumenterLaTeX$(tagsuffix).pdf") |> isfile
+        end
+    end
+
+    @testset "PDF/LaTeX: tectonic" begin
+        doc = Main.examples_latex_simple_tectonic_doc
+        @test isa(doc, Documenter.Documents.Document)
+        let build_dir = joinpath(examples_root, "builds", "latex_simple_tectonic")
+            @test joinpath(build_dir, "DocumenterLaTeXSimpleTectonic-1.2.3.pdf") |> isfile
         end
     end
 end

--- a/test/examples/tests_latex.jl
+++ b/test/examples/tests_latex.jl
@@ -3,8 +3,7 @@ using Test
 # DOCUMENTER_TEST_EXAMPLES can be used to control which builds are performed in
 # make.jl, and we need to set it to the relevant LaTeX builds.
 ENV["DOCUMENTER_TEST_EXAMPLES"] =
-    "latex latex_simple latex_texonly latex_cover_page latex_toc_style " *
-    "latex_simple_tectonic"
+    "latex latex_simple latex_texonly latex_cover_page latex_toc_style latex_simple_tectonic"
 
 # When the file is run separately we need to include make.jl which actually builds
 # the docs and defines a few modules that are referred to in the docs. The make.jl


### PR DESCRIPTION
Adds another option, "tectonic", to the `platform` argument of Latex writer. The option makes Latex writer use the tectonic binary to compile the tex files. If this is the way to go, I will adjust the documentation accordingly. 

I am not sure where to add a test case for this. I would appreciate help.

Closes #1802 

(cc @fredrikekre)