### PR TITLE
Fix linkcheck (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * ![Enhancement][badge-enhancement] PDF/LaTeX output can now be compiled with the [Tectonic](https://tectonic-typesetting.github.io) LaTeX engine. ([#1802][github-1802], [#1803][github-1803])
+* ![Bugfix][badge-bugfix] When linkchecking HTTP and HTTPS URLs, Documenter now also passes a realistic `accept-encoding` header along with the request, in order to work around servers that try to block non-browser requests. ([#1807][github-1807])
 
 ## Version `v0.27.16`
 
@@ -1013,6 +1014,7 @@
 [github-1797]: https://github.com/JuliaDocs/Documenter.jl/pull/1797
 [github-1802]: https://github.com/JuliaDocs/Documenter.jl/issues/1802
 [github-1803]: https://github.com/JuliaDocs/Documenter.jl/pull/1803
+[github-1807]: https://github.com/JuliaDocs/Documenter.jl/pull/1807
 <!-- end of issue link definitions -->
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -202,8 +202,13 @@ function linkcheck(link::Markdown.Link, doc::Documents.Document; method::Symbol=
         # Mozilla developer docs, but only is it's a HTTP(S) request.
         #
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent#chrome_ua_string
-        useragent  = startswith(uppercase(link.url), "HTTP") ? ["--user-agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36"] : ""
-        cmd = `curl $(method === :HEAD ? "-sI" : "-s") --proto =http,https,ftp,ftps $(useragent) $(link.url) --max-time $timeout -o $null_file --write-out "%{http_code} %{url_effective} %{redirect_url}"`
+        fakebrowser  = startswith(uppercase(link.url), "HTTP") ? [
+            "--user-agent",
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
+            "-H",
+            "accept-encoding: gzip, deflate, br",
+        ] : ""
+        cmd = `curl $(method === :HEAD ? "-sI" : "-s") --proto =http,https,ftp,ftps $(fakebrowser) $(link.url) --max-time $timeout -o $null_file --write-out "%{http_code} %{url_effective} %{redirect_url}"`
 
         local result
         try


### PR DESCRIPTION
Following up on #1796, it looks like GitHub has started blocking the requests even if there is a valid-ish user agent. But adding an `accept-encoding` header seems to get around this again. Might be becoming a game of whac-a-mole though...