### PR TITLE
Handle bad doc metadata better in at-autodocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 * ![Enhancement][badge-enhancement] PDF/LaTeX output can now be compiled with the [Tectonic](https://tectonic-typesetting.github.io) LaTeX engine. ([#1802][github-1802], [#1803][github-1803])
 * ![Enhancement][badge-enhancement] The phrasing of the outdated version warning in the HTML output has been improved. ([#1805][github-1805])
+* ![Enhancement][badge-enhancement] Documenter now provides the `Documenter.except` function which can be used to "invert" the list of errors that are passed to `makedocs` via the `strict` keyword. ([#1811][github-1811])
 * ![Bugfix][badge-bugfix] When linkchecking HTTP and HTTPS URLs, Documenter now also passes a realistic `accept-encoding` header along with the request, in order to work around servers that try to block non-browser requests. ([#1807][github-1807])
 * ![Bugfix][badge-bugfix] LaTeX build logs are now properly outputted to the `LaTeXWriter.{stdout,stderr}` files when using the Docker build option. ([#1806][github-1806])
+* ![Bugfix][badge-bugfix] `makedocs` no longer fails with an `UndefVarError` if it encounters a specific kind of bad docsystem state related to docstrings attached to the call syntax, but issues an `@autodocs` error/warning instead. ([JuliaLang/julia#45174][julia-45174], [#1192][github-1192], [#1810][github-1810], [#1811][github-1811])
 
 ## Version `v0.27.16`
 
@@ -840,6 +842,7 @@
 [github-1184]: https://github.com/JuliaDocs/Documenter.jl/issues/1184
 [github-1186]: https://github.com/JuliaDocs/Documenter.jl/pull/1186
 [github-1189]: https://github.com/JuliaDocs/Documenter.jl/pull/1189
+[github-1192]: https://github.com/JuliaDocs/Documenter.jl/issues/1192
 [github-1194]: https://github.com/JuliaDocs/Documenter.jl/pull/1194
 [github-1195]: https://github.com/JuliaDocs/Documenter.jl/pull/1195
 [github-1200]: https://github.com/JuliaDocs/Documenter.jl/issues/1200
@@ -1019,10 +1022,13 @@
 [github-1805]: https://github.com/JuliaDocs/Documenter.jl/pull/1805
 [github-1806]: https://github.com/JuliaDocs/Documenter.jl/pull/1806
 [github-1807]: https://github.com/JuliaDocs/Documenter.jl/pull/1807
+[github-1810]: https://github.com/JuliaDocs/Documenter.jl/issues/1810
+[github-1811]: https://github.com/JuliaDocs/Documenter.jl/pull/1811
 <!-- end of issue link definitions -->
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 [julia-39841]: https://github.com/JuliaLang/julia/pull/39841
+[julia-45174]: https://github.com/JuliaLang/julia/issues/45174
 [julialangorg-1272]: https://github.com/JuliaLang/www.julialang.org/issues/1272
 
 [documenterlatex]: https://github.com/JuliaDocs/DocumenterLaTeX.jl

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -21,6 +21,7 @@ Pages = ["public.md"]
 ```@docs
 Documenter
 makedocs
+Documenter.except
 hide
 asset
 deploydocs

--- a/src/Builder.jl
+++ b/src/Builder.jl
@@ -252,7 +252,9 @@ function Selectors.runner(::Type{RenderDocument}, doc::Documents.Document)
     # How many fatal errors
     c = count(is_strict(doc.user.strict), doc.internal.errors)
     if c > 0
-        error("`makedocs` encountered $(c > 1 ? "errors" : "an error"). Terminating build")
+        error("`makedocs` encountered $(c > 1 ? "errors" : "an error") ("
+        * join(Ref(":") .* string.(doc.internal.errors), ", ")
+        * "). Terminating build before rendering.")
     else
         @info "RenderDocument: rendering document."
         Documenter.Writers.render(doc)

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -28,7 +28,7 @@ end
 # Names of possible internal errors
 const ERROR_NAMES = [:autodocs_block, :cross_references, :docs_block, :doctest,
                      :eval_block, :example_block, :footnote, :linkcheck, :meta_block,
-                     :missing_docs, :parse_error, :setup_block]
+                     :missing_docs, :parse_error, :setup_block, :autodocs_docmeta]
 
 """
     abstract type Plugin end

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -28,7 +28,7 @@ end
 # Names of possible internal errors
 const ERROR_NAMES = [:autodocs_block, :cross_references, :docs_block, :doctest,
                      :eval_block, :example_block, :footnote, :linkcheck, :meta_block,
-                     :missing_docs, :parse_error, :setup_block, :autodocs_docmeta]
+                     :missing_docs, :parse_error, :setup_block]
 
 """
     abstract type Plugin end

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -225,6 +225,7 @@ return a response before giving up. The default is 10 seconds.
 if it encountered any errors with the document in the previous build phases. The keyword
 `strict` can also be set to a `Symbol` or `Vector{Symbol}` to specify which kind of error
 (or errors) should be fatal. Options are: $(join(Ref("`:") .* string.(ERROR_NAMES) .* Ref("`"), ", ", ", and ")).
+Use [`Documenter.except`](@ref) to explicitly set non-fatal errors.
 
 **`workdir`** determines the working directory where `@example` and `@repl` code blocks are
 executed. It can be either a path or the special value `:build` (default).
@@ -266,6 +267,35 @@ function makedocs(components...; debug = false, format = HTML(), kwargs...)
         Selectors.dispatch(Builder.DocumentPipeline, document)
     end
     debug ? document : nothing
+end
+
+"""
+    Documenter.except(errors...)
+
+Returns the list of all valid error classes that can be passed as the `strict` argument to
+[`makedocs`](@ref), except for the ones specified in the `errors` argument. Each error class
+must be a `Symbol` and passed as a separate argument.
+
+Can be used to easily disable the strict checking of specific error classes while making
+sure that all other error types still lead to the Documenter build failing. E.g. to stop
+Documenter failing on footnote and linkcheck errors, one can set `strict` as
+
+```julia
+makedocs(...,
+    strict = Documenter.except(:linkcheck, :footnote),
+)
+```
+
+Possible valid `Symbol` values are:
+$(join(Ref("`:") .* string.(ERROR_NAMES) .* Ref("`"), ", ", ", and ")).
+"""
+function except(errors::Symbol...)
+    invalid_errors = setdiff(errors, ERROR_NAMES)
+    isempty(invalid_errors) || throw(DomainError(
+        tuple(invalid_errors...),
+        "Invalid error classes passed to Documenter.except. Valid error classes are: $(ERROR_NAMES)"
+    ))
+    setdiff(ERROR_NAMES, errors)
 end
 
 """

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -412,13 +412,23 @@ function Selectors.runner(::Type{AutoDocsBlocks}, x, page, doc)
                     Documenter.DocSystem.category(binding)
                 catch err
                     isa(err, UndefVarError) || rethrow(err)
-                    @docerror(doc, :autodocs_block,
+                    @docerror(doc, :autodocs_docmeta,
                     """
                     @autodocs ($(Utilities.locrepr(page.source, lines))) encountered a bad docstring binding '$(binding)'
                     ```$(x.language)
                     $(x.code)
                     ```
-                    This is likely due to a bug in the Julia docsystem.
+                    This is likely due to a bug in the Julia docsystem relating to the handling of
+                    docstrings attached to methods of callable objects. See:
+
+                      https://github.com/JuliaLang/julia/issues/45174
+
+                    You can ignore this error by disabling strict checking for :autodocs_docmeta
+                    in the makedocs call with e.g.
+
+                      strict = Documenter.except(:autodocs_docmeta)
+
+                    However, the relevant docstrings will not be included by the @autodocs block.
                     """, exception = err)
                     continue # skip this docstring
                 end

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -420,6 +420,7 @@ function Selectors.runner(::Type{AutoDocsBlocks}, x, page, doc)
                     ```
                     This is likely due to a bug in the Julia docsystem.
                     """, exception = err)
+                    continue # skip this docstring
                 end
                 if category in order && included
                     # filter the elements after category/order has been evaluated

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -412,7 +412,7 @@ function Selectors.runner(::Type{AutoDocsBlocks}, x, page, doc)
                     Documenter.DocSystem.category(binding)
                 catch err
                     isa(err, UndefVarError) || rethrow(err)
-                    @docerror(doc, :autodocs_docmeta,
+                    @docerror(doc, :autodocs_block,
                     """
                     @autodocs ($(Utilities.locrepr(page.source, lines))) encountered a bad docstring binding '$(binding)'
                     ```$(x.language)
@@ -423,12 +423,13 @@ function Selectors.runner(::Type{AutoDocsBlocks}, x, page, doc)
 
                       https://github.com/JuliaLang/julia/issues/45174
 
-                    You can ignore this error by disabling strict checking for :autodocs_docmeta
-                    in the makedocs call with e.g.
+                    As a workaround, the docstrings for the functor methods could be included in the docstring
+                    of the type definition. This error can also be ignored by disabling strict checking for
+                    :autodocs_block in the makedocs call with e.g.
 
-                      strict = Documenter.except(:autodocs_docmeta)
+                      strict = Documenter.except(:autodocs_block)
 
-                    However, the relevant docstrings will not be included by the @autodocs block.
+                    However, the relevant docstrings will then not be included by the @autodocs block.
                     """, exception = err)
                     continue # skip this docstring
                 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,0 @@
-[deps]
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/test/errors/make.jl
+++ b/test/errors/make.jl
@@ -14,10 +14,52 @@ func(x) = x
 
 end
 
-using Documenter
+using Documenter, Test
 
 makedocs(sitename="-", modules = [ErrorsModule])
 
 for strict in (true, :doctest, [:doctest])
     @test_throws ErrorException makedocs(modules = [ErrorsModule], strict = strict)
 end
+
+# The following tests check that we can somewhat handle bad docsystem metadata. Issues:
+#
+#  - https://github.com/JuliaDocs/Documenter.jl/issues/1192
+#  - https://github.com/JuliaDocs/Documenter.jl/issues/1810
+#  - https://github.com/JuliaDocs/Documenter.jl/pull/1811
+#  - https://github.com/JuliaLang/julia/issues/45174
+#
+module BadDocmetaModule
+struct TestStruct1 end
+struct TestStruct2 end
+struct TestStruct3 end
+
+"standard"
+(baz::TestStruct1)(a::Int) = 0
+
+"parametric"
+(foo::TestStruct2)(a::T) where T = 0
+
+"return"
+(bar::TestStruct3)(a::Int, b::Int) :: Int = 0
+end
+
+@test makedocs(
+    strict = Documenter.except(:autodocs_block),
+    source = "src.docmeta", modules = [BadDocmetaModule], sitename="-", checkdocs = :exports,
+) === nothing
+@test makedocs(
+    strict=false,
+    source = "src.docmeta", modules = [BadDocmetaModule], sitename="-", checkdocs = :exports,
+) === nothing
+# The two following tests should start failing once the underlying bug in Base.Docs is fixed,
+# at which point these tests should be removed (or replaced with ones testing against some
+# manually crafted Docs.meta).
+@test_throws ErrorException makedocs(
+    strict = true,
+    source = "src.docmeta", modules = [BadDocmetaModule], sitename="-", checkdocs = :exports,
+)
+@test_throws ErrorException makedocs(
+    strict = :autodocs_block,
+    source = "src.docmeta", modules = [BadDocmetaModule], sitename="-", checkdocs = :exports,
+)

--- a/test/errors/src.docmeta/index.md
+++ b/test/errors/src.docmeta/index.md
@@ -1,0 +1,4 @@
+```@autodocs
+Modules = [BadDocmetaModule]
+Order   = [:function, :type]
+```

--- a/test/except.jl
+++ b/test/except.jl
@@ -1,0 +1,13 @@
+module ExceptTests
+using Test
+using Documenter: except, ERROR_NAMES
+
+@testset "Documenter.except" begin
+    @test_throws DomainError except(:foobar)
+    @test_throws MethodError except([:linkcheck])
+    @test sort(except()) == sort(ERROR_NAMES)
+    @test sort(except(:linkcheck)) == sort(filter(!isequal(:linkcheck), ERROR_NAMES))
+    @test isempty(except(ERROR_NAMES...))
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ include("TestUtilities.jl"); using .TestUtilities
     @quietly include("errors/make.jl")
 
     # Unit tests for module internals.
+    include("except.jl")
     include("utilities.jl")
     include("markdown2.jl")
 


### PR DESCRIPTION
When running into the call syntax issue in #1810 or #1192, at-autodocs will now issue a standard documenter error/warning:

```
┌ Error: @autodocs (src/index.md:1-4) encountered a bad docstring binding 'Docerr.foo'
│ ```@autodocs
│ Modules = [Docerr]
│ Order   = [:function, :type]
│ ```
│ This is likely due to a bug in the Julia docsystem relating to the handling of
│ docstrings attached to methods of callable objects. See:
│ 
│   https://github.com/JuliaLang/julia/issues/45174
│ 
│ As a workaround, the docstrings for the functor methods could be included in the docstring
│ of the type definition. This error can also be ignored by disabling strict checking for
│ :autodocs_block in the makedocs call with e.g.
│ 
│   strict = Documenter.except(:autodocs_block)
│ 
│ However, the relevant docstrings will then not be included by the @autodocs block.
│   exception = UndefVarError: foo not defined
└ @ Documenter.Expanders ~/Julia/JuliaDocs/Documenter/src/Utilities/Utilities.jl:32
```

If strict error checking is disabled, then these docstrings will simply get omitted from the at-autodocs block. This will close #1810 and close #1192 on Documenter's end, but the upstream issue https://github.com/JuliaLang/julia/issues/45174 still needs to be addressed.

In addition, this add the `Documenter.except` function to easily disable strict checking on some error types (as opposed to having to list all, except a few manually):

```julia
makedocs(...,
    strict = Documenter.except(:linkcheck, :footnote),
)
```

And we also now print the error classes that cause `makedocs` to terminate, so that it would be easier to figure out which error classes to `except`, if that is something the user wants / needs to do.