### PR TITLE
Reduce padding in some container elements

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         version:
           - '1.0'
+          - '1.6'
           - '1'
           - 'nightly'
         os:

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.5'
+          version: '1.6'
       - name: Run online linkcheck tests
         run: julia --color=yes test/run_docchecks.jl
   manual_linkcheck:
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.5'
+          version: '1.6'
       - name: Install dependencies
         run: julia --color=yes --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and check documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* ![Enhancement][badge-enhancement] The padding of the various container elements in the HTML style has been reduced, to improve the look of the generated HTML pages. ([#1814][github-1814], [#1818][github-1818])
 * ![Bugfix][badge-bugfix] Build failures now only show fatal errors, rather than all errors. ([#1816][github-1816])
 
 ## Version `v0.27.17`
@@ -1028,7 +1029,9 @@
 [github-1807]: https://github.com/JuliaDocs/Documenter.jl/pull/1807
 [github-1810]: https://github.com/JuliaDocs/Documenter.jl/issues/1810
 [github-1811]: https://github.com/JuliaDocs/Documenter.jl/pull/1811
+[github-1814]: https://github.com/JuliaDocs/Documenter.jl/issues/1814
 [github-1816]: https://github.com/JuliaDocs/Documenter.jl/pull/1816
+[github-1818]: https://github.com/JuliaDocs/Documenter.jl/pull/1818
 <!-- end of issue link definitions -->
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079

--- a/assets/html/scss/documenter/_elements.scss
+++ b/assets/html/scss/documenter/_elements.scss
@@ -39,17 +39,17 @@ pre {
   overflow: hidden;
 
   code, code.hljs {
-    padding: 0 0.5rem !important;
+    padding: 0 $documenter-container-left-padding !important;
     overflow: auto;
     display: block;
   }
 
   code:first-of-type, code.hljs:first-of-type {
-    padding-top: 0.7rem !important;
+    padding-top: 0.5rem !important;
   }
 
   code:last-of-type, code.hljs:last-of-type {
-    padding-bottom: 0.7rem !important;
+    padding-bottom: 0.5rem !important;
   }
 
   .copy-button {

--- a/assets/html/scss/documenter/_variables.scss
+++ b/assets/html/scss/documenter/_variables.scss
@@ -87,5 +87,5 @@ $documenter-admonition-header-padding: 0.5rem $documenter-container-left-padding
 $documenter-admonition-body-padding: 0.5rem $documenter-container-left-padding;
 $documenter-docstring-header-padding: 0.5rem $documenter-container-left-padding;
 $documenter-docstring-body-padding-h: $documenter-container-left-padding;
-$documenter-docstring-body-padding-v: 1rem;
+$documenter-docstring-body-padding-v: 0.75rem;
 $documenter-docstring-body-padding: $documenter-docstring-body-padding-v $documenter-docstring-body-padding-h;

--- a/assets/html/scss/documenter/_variables.scss
+++ b/assets/html/scss/documenter/_variables.scss
@@ -79,10 +79,13 @@ $documenter-main-padding: 1rem !default;
 // to be in px, hence the unit conversion.
 $desktop: round($body-size * ($documenter-max-width + $documenter-sidebar-width + $documenter-sidebar-main-gap + $documenter-main-padding-right - 5rem)/1rem) !default;
 
-// Admonitions
-$message-header-padding: 0.75em;
-$message-body-padding: 1em 1.25em;
-// Docstrings
-$card-content-padding-v: 1rem;
-$card-content-padding-h: 1.25rem;
-$card-content-padding: $card-content-padding-v $card-content-padding-h;
+// Padding for admonitions and docstrings.
+// We'll try to keep the left padding consistent between the various container
+// elements:
+$documenter-container-left-padding: 0.75rem;
+$documenter-admonition-header-padding: 0.5rem $documenter-container-left-padding;
+$documenter-admonition-body-padding: 0.5rem $documenter-container-left-padding;
+$documenter-docstring-header-padding: 0.5rem $documenter-container-left-padding;
+$documenter-docstring-body-padding-h: $documenter-container-left-padding;
+$documenter-docstring-body-padding-v: 1rem;
+$documenter-docstring-body-padding: $documenter-docstring-body-padding-v $documenter-docstring-body-padding-h;

--- a/assets/html/scss/documenter/components/_admonition.scss
+++ b/assets/html/scss/documenter/components/_admonition.scss
@@ -81,19 +81,19 @@ $admonition-header-color: () !default;
   font-weight: $message-header-weight;
   justify-content: space-between;
   line-height: 1.25;
-  padding: $message-header-padding;
+  padding: $documenter-admonition-header-padding;
   position: relative;
 
   &:before {
     @include font-awesome;
-    margin-right: $message-header-padding;
+    margin-right: $documenter-container-left-padding;
     content: "\f06a";
   }
 }
 
 .admonition-body {
   color: $message-body-color;
-  padding: $message-body-padding;
+  padding: $documenter-admonition-body-padding;
 
   pre {
     background-color: $pre-background;

--- a/assets/html/scss/documenter/components/_docstring.scss
+++ b/assets/html/scss/documenter/components/_docstring.scss
@@ -10,7 +10,7 @@
     display: flex;
     flex-grow: 1;
     align-items: stretch;
-    padding: $card-header-padding;
+    padding: $documenter-docstring-header-padding;
 
     background-color: $documenter-docstring-header-background;
     box-shadow: $card-header-shadow;
@@ -31,7 +31,7 @@
 
   > section {
     position: relative;
-    padding: $card-content-padding;
+    padding: $documenter-docstring-body-padding;
 
     border-bottom: 1px solid $border;
     &:last-child {
@@ -42,8 +42,8 @@
       transition: opacity 0.3s;
       opacity: 0;
       position: absolute;
-      right: $card-content-padding-h / 2;
-      bottom: $card-content-padding-v / 2;
+      right: $documenter-docstring-body-padding-h / 2;
+      bottom: $documenter-docstring-body-padding-v / 2;
       @extend .tag;
       @extend .is-primary;
       @extend .is-size-7;

--- a/assets/html/themes/documenter-dark.css
+++ b/assets/html/themes/documenter-dark.css
@@ -7212,7 +7212,7 @@ html.theme--documenter-dark {
         margin-left: 0.3em; }
     html.theme--documenter-dark .docstring > section {
       position: relative;
-      padding: 1rem 0.75rem;
+      padding: 0.75rem 0.75rem;
       border-bottom: 1px solid #5e6d6f; }
       html.theme--documenter-dark .docstring > section:last-child {
         border-bottom: none; }
@@ -7221,7 +7221,7 @@ html.theme--documenter-dark {
         opacity: 0;
         position: absolute;
         right: 0.375rem;
-        bottom: 0.5rem; }
+        bottom: 0.375rem; }
         html.theme--documenter-dark .docstring > section > a.docs-sourcelink:focus {
           opacity: 1 !important; }
     html.theme--documenter-dark .docstring:hover > section > a.docs-sourcelink {

--- a/assets/html/themes/documenter-dark.css
+++ b/assets/html/themes/documenter-dark.css
@@ -3598,7 +3598,7 @@ html.theme--documenter-dark {
     position: relative; }
   html.theme--documenter-dark .card-content {
     background-color: transparent;
-    padding: 1rem 1.25rem; }
+    padding: 1.5rem; }
   html.theme--documenter-dark .card-footer {
     background-color: transparent;
     border-top: 1px solid #5e6d6f;
@@ -3938,7 +3938,7 @@ html.theme--documenter-dark {
     font-weight: 700;
     justify-content: space-between;
     line-height: 1.25;
-    padding: 0.75em;
+    padding: 0.75em 1em;
     position: relative; }
     html.theme--documenter-dark .message-header .delete {
       flex-grow: 0;
@@ -3954,7 +3954,7 @@ html.theme--documenter-dark {
     border-style: solid;
     border-width: 0 0 0 4px;
     color: #fff;
-    padding: 1em 1.25em; }
+    padding: 1.25em 1.5em; }
     html.theme--documenter-dark .message-body code,
     html.theme--documenter-dark .message-body pre {
       background-color: white; }
@@ -7090,13 +7090,13 @@ html.theme--documenter-dark {
     position: relative;
     overflow: hidden; }
     html.theme--documenter-dark pre code, html.theme--documenter-dark pre code.hljs {
-      padding: 0 0.5rem !important;
+      padding: 0 0.75rem !important;
       overflow: auto;
       display: block; }
     html.theme--documenter-dark pre code:first-of-type, html.theme--documenter-dark pre code.hljs:first-of-type {
-      padding-top: 0.7rem !important; }
+      padding-top: 0.5rem !important; }
     html.theme--documenter-dark pre code:last-of-type, html.theme--documenter-dark pre code.hljs:last-of-type {
-      padding-bottom: 0.7rem !important; }
+      padding-bottom: 0.5rem !important; }
     html.theme--documenter-dark pre .copy-button {
       opacity: 0.2;
       transition: opacity 0.2s;
@@ -7175,16 +7175,16 @@ html.theme--documenter-dark {
     font-weight: 700;
     justify-content: space-between;
     line-height: 1.25;
-    padding: 0.75em;
+    padding: 0.5rem 0.75rem;
     position: relative; }
     html.theme--documenter-dark .admonition-header:before {
       font-family: "Font Awesome 5 Free";
       font-weight: 900;
-      margin-right: 0.75em;
+      margin-right: 0.75rem;
       content: "\f06a"; }
   html.theme--documenter-dark .admonition-body {
     color: #fff;
-    padding: 1em 1.25em; }
+    padding: 0.5rem 0.75rem; }
     html.theme--documenter-dark .admonition-body pre {
       background-color: #282f2f; }
     html.theme--documenter-dark .admonition-body code {
@@ -7199,7 +7199,7 @@ html.theme--documenter-dark {
       display: flex;
       flex-grow: 1;
       align-items: stretch;
-      padding: 0.75rem;
+      padding: 0.5rem 0.75rem;
       background-color: #282f2f;
       box-shadow: 0 1px 2px rgba(10, 10, 10, 0.1);
       box-shadow: none;
@@ -7212,7 +7212,7 @@ html.theme--documenter-dark {
         margin-left: 0.3em; }
     html.theme--documenter-dark .docstring > section {
       position: relative;
-      padding: 1rem 1.25rem;
+      padding: 1rem 0.75rem;
       border-bottom: 1px solid #5e6d6f; }
       html.theme--documenter-dark .docstring > section:last-child {
         border-bottom: none; }
@@ -7220,7 +7220,7 @@ html.theme--documenter-dark {
         transition: opacity 0.3s;
         opacity: 0;
         position: absolute;
-        right: 0.625rem;
+        right: 0.375rem;
         bottom: 0.5rem; }
         html.theme--documenter-dark .docstring > section > a.docs-sourcelink:focus {
           opacity: 1 !important; }

--- a/assets/html/themes/documenter-light.css
+++ b/assets/html/themes/documenter-light.css
@@ -3666,7 +3666,7 @@ a.tag:hover, .docstring > section > a.docs-sourcelink:hover {
 
 .card-content {
   background-color: transparent;
-  padding: 1rem 1.25rem; }
+  padding: 1.5rem; }
 
 .card-footer {
   background-color: transparent;
@@ -4029,7 +4029,7 @@ a.list-item {
   font-weight: 700;
   justify-content: space-between;
   line-height: 1.25;
-  padding: 0.75em;
+  padding: 0.75em 1em;
   position: relative; }
   .message-header .delete {
     flex-grow: 0;
@@ -4046,7 +4046,7 @@ a.list-item {
   border-style: solid;
   border-width: 0 0 0 4px;
   color: #222222;
-  padding: 1em 1.25em; }
+  padding: 1.25em 1.5em; }
   .message-body code,
   .message-body pre {
     background-color: white; }
@@ -7004,13 +7004,13 @@ pre {
   position: relative;
   overflow: hidden; }
   pre code, pre code.hljs {
-    padding: 0 0.5rem !important;
+    padding: 0 0.75rem !important;
     overflow: auto;
     display: block; }
   pre code:first-of-type, pre code.hljs:first-of-type {
-    padding-top: 0.7rem !important; }
+    padding-top: 0.5rem !important; }
   pre code:last-of-type, pre code.hljs:last-of-type {
-    padding-bottom: 0.7rem !important; }
+    padding-bottom: 0.5rem !important; }
   pre .copy-button {
     opacity: 0.2;
     transition: opacity 0.2s;
@@ -7110,17 +7110,17 @@ pre {
   font-weight: 700;
   justify-content: space-between;
   line-height: 1.25;
-  padding: 0.75em;
+  padding: 0.5rem 0.75rem;
   position: relative; }
   .admonition-header:before {
     font-family: "Font Awesome 5 Free";
     font-weight: 900;
-    margin-right: 0.75em;
+    margin-right: 0.75rem;
     content: "\f06a"; }
 
 .admonition-body {
   color: #222222;
-  padding: 1em 1.25em; }
+  padding: 0.5rem 0.75rem; }
   .admonition-body pre {
     background-color: whitesmoke; }
   .admonition-body code {
@@ -7136,7 +7136,7 @@ pre {
     display: flex;
     flex-grow: 1;
     align-items: stretch;
-    padding: 0.75rem;
+    padding: 0.5rem 0.75rem;
     background-color: whitesmoke;
     box-shadow: 0 1px 2px rgba(10, 10, 10, 0.1);
     box-shadow: none;
@@ -7149,7 +7149,7 @@ pre {
       margin-left: 0.3em; }
   .docstring > section {
     position: relative;
-    padding: 1rem 1.25rem;
+    padding: 1rem 0.75rem;
     border-bottom: 1px solid #dbdbdb; }
     .docstring > section:last-child {
       border-bottom: none; }
@@ -7157,7 +7157,7 @@ pre {
       transition: opacity 0.3s;
       opacity: 0;
       position: absolute;
-      right: 0.625rem;
+      right: 0.375rem;
       bottom: 0.5rem; }
       .docstring > section > a.docs-sourcelink:focus {
         opacity: 1 !important; }

--- a/assets/html/themes/documenter-light.css
+++ b/assets/html/themes/documenter-light.css
@@ -7149,7 +7149,7 @@ pre {
       margin-left: 0.3em; }
   .docstring > section {
     position: relative;
-    padding: 1rem 0.75rem;
+    padding: 0.75rem 0.75rem;
     border-bottom: 1px solid #dbdbdb; }
     .docstring > section:last-child {
       border-bottom: none; }
@@ -7158,7 +7158,7 @@ pre {
       opacity: 0;
       position: absolute;
       right: 0.375rem;
-      bottom: 0.5rem; }
+      bottom: 0.375rem; }
       .docstring > section > a.docs-sourcelink:focus {
         opacity: 1 !important; }
   .docstring:hover > section > a.docs-sourcelink {

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"
 
 [compat]
-DocumenterTools = "=0.1.12"
+DocumenterTools = "=0.1.14"


### PR DESCRIPTION
Reduces and makes the padding more consistent between various container elements. For admonitions, it changes as follows:

![padding-admonition-old](https://user-images.githubusercontent.com/147757/167765708-276bf6b9-e90d-4fd9-85eb-b38942c100f3.png)
![padding-admonition-new](https://user-images.githubusercontent.com/147757/167765710-4e756276-0867-4f89-a068-bd953427959c.png)

It also makes the padding in the docstrings consistent with the admonitions, although I left the content vertical padding a little higher, since docstrings often start with a code block, and `0.5rem` looked a little too narrow then:

![padding-docstrings-old](https://user-images.githubusercontent.com/147757/167765727-b679edea-fe1a-42ac-9435-7f341718537a.png)
![padding-docstrings-new](https://user-images.githubusercontent.com/147757/167765730-c0413016-da61-455d-a4e6-544ee66cad61.png)

For code blocks, the vertical padding is slightly reduced, but left padding actually increases (to be consistent with admonitions and docstrings):

![padding-code-old](https://user-images.githubusercontent.com/147757/167765735-f04c0e4e-4b4b-4220-b748-a3d2f296eb6e.png)
![padding-code-new](https://user-images.githubusercontent.com/147757/167765740-3c2f7d53-261c-4cd1-8632-b571191334e0.png)


@KristofferC: what do you think? Not quite as narrow as you suggested, but perhaps a good compromise? Close #1814.