### PR TITLE
Set `permissions: write-all` in `hosting.md`

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -195,7 +195,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1' # Latest stable Julia release.
+          version: '1.6'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -189,12 +189,13 @@ on:
 
 jobs:
   build:
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.6'
+          version: '1' # Latest stable Julia release.
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy


### PR DESCRIPTION
GitHub seems to have changed the permissions for the `secrets.GITHUB_TOKEN`. It does not allow writing by default anymore. I've now had two new repositories where I copy-pasted some workflow and got the following back
```
[docs cdb3219] build based on 2be61e3
 12 files changed, 16162 insertions(+)
 create mode 100644 dev/assets/documenter.js
 create mode 100644 dev/assets/search.js
 create mode 100644 dev/assets/themes/documenter-dark.css
 create mode 100644 dev/assets/themes/documenter-light.css
 create mode 100644 dev/assets/themeswap.js
 create mode 100644 dev/assets/warner.js
 create mode 100644 dev/index.html
 create mode 100644 dev/search/index.html
 create mode 100644 dev/search_index.js
 create mode 100644 dev/siteinfo.js
 create mode 100644 index.html
 create mode 100644 versions.js
remote: Write access to repository not granted.
fatal: unable to access 'https://github.com/rikhuijzer/MyProject.jl.git/': The requested URL returned error: 403
```
Explicitly setting
```
permissions: write-all
```
fixed it.

More information about the permissions for the `GITHUB_TOKEN` can be found at https://docs.github.com/en/actions/security-guides/automatic-token-authentication. I haven't yet found related release notes.