### PR TITLE
Add documentation for LaTeX macros and mathengine

### DIFF
--- a/docs/src/man/latex.md
+++ b/docs/src/man/latex.md
@@ -145,7 +145,7 @@ LaTeXEquation(raw"""
 
 ## Set math engine and define macros for LaTeX
 
-Add the `mathengine` argument to [`Documenter.Writers.HTMLWriter.HTML`](@ref) which allows the math rendering engine to be specified and support both MathJax and KaTeX (the latter is the default).
+The `mathengine` argument to [`Documenter.Writers.HTMLWriter.HTML`](@ref) allows the math rendering engine to be specified, supporting both MathJax and KaTeX (with the latter being the default).
 
 Furthermore, you can also pass custom configuration to the rendering engine. E.g. to add global LaTeX command definitions, you can set `mathengine` to:
 ```julia

--- a/docs/src/man/latex.md
+++ b/docs/src/man/latex.md
@@ -144,6 +144,7 @@ LaTeXEquation(raw"""
 ```
 
 ## Set math engine and define macros for LaTeX
+
 Add the `mathengine` argument to [`Documenter.Writers.HTMLWriter.HTML`](@ref) which allows the math rendering engine to be specified and support both MathJax and KaTeX (the latter is the default).
 
 Furthermore, you can also pass custom configuration to the rendering engine. E.g. to add global LaTeX command definitions, you can set `mathengine` to:

--- a/docs/src/man/latex.md
+++ b/docs/src/man/latex.md
@@ -157,9 +157,7 @@ mathengine = Documenter.MathJax(Dict(:TeX => Dict(
     ),
 )))
 ```
-Or on MathJax v3, the
-[physics package](http://mirrors.ibiblio.org/CTAN/macros/latex/contrib/physics/physics.pdf)
-can be loaded:
+Or with MathJax v3, the [physics package](http://mirrors.ibiblio.org/CTAN/macros/latex/contrib/physics/physics.pdf) can be loaded:
 ```julia
 mathengine = MathJax3(Dict(
     :loader => Dict("load" => ["[tex]/physics"]),

--- a/docs/src/man/latex.md
+++ b/docs/src/man/latex.md
@@ -142,3 +142,31 @@ LaTeXEquation(raw"""
     \end{array}\right]
 """)
 ```
+
+## Set math engine and define macros for LaTeX
+Add the `mathengine` argument to [`Documenter.Writers.HTMLWriter.HTML`](@ref) which allows the math rendering engine to be specified and support both MathJax and KaTeX (the latter is the default).
+
+Furthermore, you can also pass custom configuration to the rendering engine. E.g. to add global LaTeX command definitions, you can set `mathengine` to:
+```julia
+mathengine = Documenter.MathJax(Dict(:TeX => Dict(
+    :equationNumbers => Dict(:autoNumber => "AMS"),
+    :Macros => Dict(
+        :ket => ["|#1\\rangle", 1],
+        :bra => ["\\langle#1|", 1],
+    ),
+)))
+```
+Or on MathJax v3, the
+[physics package](http://mirrors.ibiblio.org/CTAN/macros/latex/contrib/physics/physics.pdf)
+can be loaded:
+```julia
+mathengine = MathJax3(Dict(
+    :loader => Dict("load" => ["[tex]/physics"]),
+    :tex => Dict(
+        "inlineMath" => [["\$","\$"], ["\\(","\\)"]],
+        "tags" => "ams",
+        "packages" => ["base", "ams", "autoload", "physics"],
+    ),
+)),
+```
+`MathJax2`, `MathJax3` and `KaTeX` are available types for `mathengine`.

--- a/docs/src/man/latex.md
+++ b/docs/src/man/latex.md
@@ -168,4 +168,4 @@ mathengine = MathJax3(Dict(
     ),
 )),
 ```
-`MathJax2`, `MathJax3` and `KaTeX` are available types for `mathengine`.
+[`MathJax2`](@ref), [`MathJax3`](@ref) and [`KaTeX`](@ref) are available types for `mathengine`.


### PR DESCRIPTION
This PR adds documentation for LaTeX macros and `mathengine`.

Most of sentences were carried from the original PR (#1097) and [`test/examples/src/man/tutorial.md`](https://github.com/JuliaDocs/Documenter.jl/blob/master/test/examples/src/man/tutorial.md).