### PR TITLE
Fully disable version selector on unversioned docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * ![Enhancement][badge-enhancement] The padding of the various container elements in the HTML style has been reduced, to improve the look of the generated HTML pages. ([#1814][github-1814], [#1818][github-1818])
+* ![Bugfix][badge-bugfix] When deploying unversioned docs, Documenter now generates a `siteinfo.js` file that disables the version selector, even if a `../versions.js` happens to exists. ([#1667][github-1667], [#1825][github-1825])
 * ![Bugfix][badge-bugfix] Build failures now only show fatal errors, rather than all errors. ([#1816][github-1816])
 * ![Bugfix][badge-bugfix] Disable git terminal prompt when detecting remote HEAD branch for ssh remotes, and allow ssh-agent authentication (by appending rather than overriding ENV). ([#1821][github-1821])
 
@@ -985,6 +986,7 @@
 [github-1658]: https://github.com/JuliaDocs/Documenter.jl/pull/1658
 [github-1661]: https://github.com/JuliaDocs/Documenter.jl/pull/1661
 [github-1665]: https://github.com/JuliaDocs/Documenter.jl/pull/1665
+[github-1667]: https://github.com/JuliaDocs/Documenter.jl/issues/1667
 [github-1673]: https://github.com/JuliaDocs/Documenter.jl/pull/1673
 [github-1687]: https://github.com/JuliaDocs/Documenter.jl/pull/1687
 [github-1689]: https://github.com/JuliaDocs/Documenter.jl/pull/1689
@@ -1034,6 +1036,7 @@
 [github-1816]: https://github.com/JuliaDocs/Documenter.jl/pull/1816
 [github-1818]: https://github.com/JuliaDocs/Documenter.jl/pull/1818
 [github-1821]: https://github.com/JuliaDocs/Documenter.jl/pull/1821
+[github-1825]: https://github.com/JuliaDocs/Documenter.jl/pull/1825
 <!-- end of issue link definitions -->
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079

--- a/assets/html/js/versions.js
+++ b/assets/html/js/versions.js
@@ -3,6 +3,12 @@
 
 // update the version selector with info from the siteinfo.js and ../versions.js files
 $(document).ready(function() {
+  // If the version selector is disabled with DOCUMENTER_VERSION_SELECTOR_DISABLED in the
+  // siteinfo.js file, we just return immediately and not display the version selector.
+  if (typeof DOCUMENTER_VERSION_SELECTOR_DISABLED === 'boolean' && DOCUMENTER_VERSION_SELECTOR_DISABLED) {
+    return;
+  }
+
   var version_selector = $("#documenter .docs-version-selector");
   var version_selector_select = $("#documenter .docs-version-selector select");
 

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -672,7 +672,11 @@ function git_push(
         deploy_dir = subfolder === nothing ? dirname : joinpath(dirname, subfolder)
         gitrm_copy(target_dir, deploy_dir)
 
-        if versions !== nothing
+        if versions === nothing
+            # If the documentation is unversioned and deployed to root, we generate a
+            # siteinfo.js file that would disable the version selector in the docs
+            Writers.HTMLWriter.generate_siteinfo_file(deploy_dir, nothing)
+        else
             # Generate siteinfo-file with DOCUMENTER_CURRENT_VERSION
             Writers.HTMLWriter.generate_siteinfo_file(deploy_dir, subfolder)
 

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -1428,9 +1428,13 @@ function generate_redirect_file(redirectfile::AbstractString, entries)
     end
 end
 
-function generate_siteinfo_file(dir::AbstractString, version::AbstractString)
+function generate_siteinfo_file(dir::AbstractString, version::Union{AbstractString,Nothing})
     open(joinpath(dir, "siteinfo.js"), "w") do buf
-        println(buf, "var DOCUMENTER_CURRENT_VERSION = \"$(version)\";")
+        if version !== nothing
+            println(buf, "var DOCUMENTER_CURRENT_VERSION = \"$(version)\";")
+        else
+            println(buf, "var DOCUMENTER_VERSION_SELECTOR_DISABLED = true;")
+        end
     end
 end
 


### PR DESCRIPTION
Since we generated `siteinfo.js` in `deploydocs`, we don't actually need to add any options to `makedocs`, and can just "communicate" with `makedocs` about this via the `siteinfo.js` file. Fix #1667.