### PR TITLE
Set `permissions: content: write` in `hosting.md`

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -189,7 +189,8 @@ on:
 
 jobs:
   build:
-    permissions: write-all
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Fix for the too permissive setting in https://github.com/JuliaDocs/Documenter.jl/pull/1819.

Thanks to @SaschaMann for noting that

> This is not a good practice. Instead, only the minimal permissions that are needed to make the workflow work should be given to the token.

See https://github.com/julia-actions/julia-docdeploy/pull/21 for details.

