### PR TITLE
Cache search objects in localStorage for faster search loading

### DIFF
--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -535,6 +535,7 @@ module RD
     const jqueryui = RemoteLibrary("jqueryui", "https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js")
     const lunr = RemoteLibrary("lunr", "https://cdnjs.cloudflare.com/ajax/libs/lunr.js/2.3.9/lunr.min.js")
     const lodash = RemoteLibrary("lodash", "https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js")
+    const lzstring = RemoteLibrary("lzstring", "https://cdnjs.cloudflare.com/ajax/libs/lz-string/1.4.4/lz-string.min.js")
 
     # headroom
     const headroom_version = "0.12.0"
@@ -751,7 +752,7 @@ function render(doc::Documents.Document, settings::HTML=HTML())
     if isfile(joinpath(doc.user.source, "assets", "search.js"))
         @warn "not creating 'search.js', provided by the user."
     else
-        r = JSDependencies.RequireJS([RD.jquery, RD.lunr, RD.lodash])
+        r = JSDependencies.RequireJS([RD.jquery, RD.lunr, RD.lodash, RD.lzstring])
         push!(r, JSDependencies.parse_snippet(joinpath(ASSETS, "search.js")))
         JSDependencies.verify(r; verbose=true) || error("RequireJS declaration is invalid")
         JSDependencies.writejs(joinpath(doc.user.build, "assets", "search.js"), r)


### PR DESCRIPTION
I'm hoping to speed up the displaying of search results after a page reload. It's nice and fast when updating thee search box, but the building of the search dictionaries is really slow, especially on Base docs.

I see a few paths to do this:
1. Use a server-side search phrase -> results service - Can't be hosted by github pages etc. Won't work offline
2. Rework the docs pages to be within a long-lasting page and use frames to serve content so that the search dictionaries can be retained - Seems like a good idea but a lot of work. Will still be slow first load
3. Generate the dictionaries during mkdocs and deserialize them - Likely to be fast, but given users can provide custom search.js files (as Base does), it would likely be hard to make this work universally?
4. Store the `index` and `store` in browser local storage, which is per-origin, so that following page loads can use the cached versions

This PR is a demo of the last option.

Unfortunately, it's slower on first load and only slightly faster on following loads because of the need for compression due to the storage limit (on chrome at least) being 5MB, which the index of Base docs exceeds.

Perhaps the string size could be queried to see if compression is needed, but you'd need to know whether it was compressed at load time, so there would need to be an additional flag stored.


Anyway, I'm not sure this is a good idea, but I thought I'd share given it "works"

@mortenpi I recall we talked about some of this before