### PR TITLE
Disable enter key page refresh on search page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * ![Enhancement][badge-enhancement] The `ansicolor` keyword to `HTML()` now defaults to true, meaning that executed outputs from `@example`- and `@repl`-blocks are now by default colored (if they emit colored output). ([#1828][github-1828])
 
+## Version `v0.27.19`
+
+* ![Enhancement][badge-enhancement] On the HTML search page, pressing enter no longer causes the page to refresh (and therefore does not trigger the slow search index rebuild). ([#1728][github-1728], [#1833][github-1833])
+
 ## Version `v0.27.18`
 
 * ![Enhancement][badge-enhancement] The padding of the various container elements in the HTML style has been reduced, to improve the look of the generated HTML pages. ([#1814][github-1814], [#1818][github-1818])
@@ -1004,6 +1008,7 @@
 [github-1709]: https://github.com/JuliaDocs/Documenter.jl/pull/1709
 [github-1716]: https://github.com/JuliaDocs/Documenter.jl/pull/1716
 [github-1727]: https://github.com/JuliaDocs/Documenter.jl/pull/1727
+[github-1728]: https://github.com/JuliaDocs/Documenter.jl/issues/1728
 [github-1743]: https://github.com/JuliaDocs/Documenter.jl/pull/1743
 [github-1746]: https://github.com/JuliaDocs/Documenter.jl/issues/1746
 [github-1748]: https://github.com/JuliaDocs/Documenter.jl/pull/1748
@@ -1042,6 +1047,7 @@
 [github-1821]: https://github.com/JuliaDocs/Documenter.jl/pull/1821
 [github-1825]: https://github.com/JuliaDocs/Documenter.jl/pull/1825
 [github-1828]: https://github.com/JuliaDocs/Documenter.jl/pull/1828
+[github-1833]: https://github.com/JuliaDocs/Documenter.jl/pull/1833
 <!-- end of issue link definitions -->
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079

--- a/assets/html/search.js
+++ b/assets/html/search.js
@@ -231,6 +231,17 @@ $(document).ready(function() {
     searchbox.keyup(_.debounce(update_search_box, 250))
     searchbox.change(update_search_box)
 
+    // Disable enter-key form submission for the searchbox on the search page
+    // and just re-run search rather than refresh the whole page.
+    $(".docs-search").keypress(
+      function(event){
+        if (event.which == '13') {
+          update_search_box();
+          event.preventDefault();
+        }
+      }
+    );
+
     search_query_uri = parseUri(window.location).queryKey["q"]
     if(search_query_uri !== undefined) {
       search_query = decodeURIComponent(search_query_uri.replace(/\+/g, '%20'))

--- a/assets/html/search.js
+++ b/assets/html/search.js
@@ -180,6 +180,7 @@ $(document).ready(function() {
     searchresults = $('#documenter-search-results');
     searchinfo = $('#documenter-search-info');
     searchbox = $('#documenter-search-query');
+    searchform = $('.docs-search');
     function update_search(querystring) {
       tokens = lunr.tokenizer(querystring)
       results = index.query(function (q) {
@@ -233,7 +234,7 @@ $(document).ready(function() {
 
     // Disable enter-key form submission for the searchbox on the search page
     // and just re-run search rather than refresh the whole page.
-    $(".docs-search").keypress(
+    searchform.keypress(
       function(event){
         if (event.which == '13') {
           update_search_box();


### PR DESCRIPTION
As discussed https://github.com/JuliaDocs/Documenter.jl/pull/1831#issuecomment-1140581369

> One gripe I have is that I often instinctively press return after entering text in the search box, which, if you're on the search page already makes you needlessly hit the slow search load, given 1) the search results are likely already shown due to the text box update 2) the reload makes you hit the regeneration of the search dicts

> Perhaps the return-key form entry could be disabled on the search page itself?

I injected this js code locally and it worked, but I've not tried a full build. 
I guess there's a preview on the PR?

@mortenpi 

---

_Edit by @mortenpi: close #1728._