### PR TITLE
Update JS dependencies to latest non-breaking version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@
 
 ## Version `v0.27.20`
 
-* ![Enhancement][badge-enhancement] MathJax 3 has been updated to `v3.2.2` (minor version bump). ([#1844][github-1844])
+* ![Enhancement][badge-enhancement] The various JS and font dependencies of the HTML backend have been updated to the latest non-breaking versions. ([#1844][github-1844], [#1846][github-1846])
+
+  - MathJax 3 has been updated from `v3.2.0` to `v3.2.2`.
+  - JuliaMono has been updated from `v0.044` to `v0.045`.
+  - Font Awesome has been updated from `v5.15.3` to `v5.15.4`.
+  - highlight.js has been updated from `v11.0.1` to `v11.5.1`.
+  - KaTeX has been updated from `v0.13.11` to `v0.13.24`.
 
 ## Version `v0.27.19`
 
@@ -1064,6 +1070,7 @@
 [github-1838]: https://github.com/JuliaDocs/Documenter.jl/pull/1838
 [github-1841]: https://github.com/JuliaDocs/Documenter.jl/pull/1841
 [github-1844]: https://github.com/JuliaDocs/Documenter.jl/pull/1844
+[github-1844]: https://github.com/JuliaDocs/Documenter.jl/pull/1846
 <!-- end of issue link definitions -->
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1070,7 +1070,7 @@
 [github-1838]: https://github.com/JuliaDocs/Documenter.jl/pull/1838
 [github-1841]: https://github.com/JuliaDocs/Documenter.jl/pull/1841
 [github-1844]: https://github.com/JuliaDocs/Documenter.jl/pull/1844
-[github-1844]: https://github.com/JuliaDocs/Documenter.jl/pull/1846
+[github-1846]: https://github.com/JuliaDocs/Documenter.jl/pull/1846
 <!-- end of issue link definitions -->
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -523,8 +523,8 @@ module RD
 
     const requirejs_cdn = "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"
     const lato = "https://cdnjs.cloudflare.com/ajax/libs/lato-font/3.0.0/css/lato-font.min.css"
-    const juliamono = "https://cdnjs.cloudflare.com/ajax/libs/juliamono/0.044/juliamono.css"
-    const fontawesome_version = "5.15.3"
+    const juliamono = "https://cdnjs.cloudflare.com/ajax/libs/juliamono/0.045/juliamono.min.css"
+    const fontawesome_version = "5.15.4"
     const fontawesome_css = [
         "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/$(fontawesome_version)/css/fontawesome.min.css",
         "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/$(fontawesome_version)/css/solid.min.css",
@@ -551,7 +551,7 @@ module RD
         # NOTE: the CSS themes for hightlightjs are compiled into the Documenter CSS
         # When updating this dependency, it is also necessary to update the the CSS
         # files the CSS files in assets/html/scss/highlightjs
-        hljs_version = "11.0.1"
+        hljs_version = "11.5.1"
         push!(r, RemoteLibrary(
             "highlight",
             "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/$(hljs_version)/highlight.min.js"
@@ -577,7 +577,7 @@ module RD
     end
 
     # MathJax & KaTeX
-    const katex_version = "0.13.11"
+    const katex_version = "0.13.24"
     const katex_css = "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/$(katex_version)/katex.min.css"
     function mathengine!(r::RequireJS, engine::KaTeX)
         push!(r, RemoteLibrary(

--- a/test/prerender/prerender.jl
+++ b/test/prerender/prerender.jl
@@ -55,7 +55,7 @@ for _ in 1:2 # test with and without highlightjs file given
     @test !occursin("<code class=\"language-julia-repl hljs\">julia&gt; function f()", index)
     @test !occursin("<code class=\"language-llvm hljs\">;  @ int.jl:87 within", index)
     @test occursin("<code class=\"language-julia hljs\"><span class=\"hljs-keyword\">function</span> f()", index)
-    @test occursin("<code class=\"language-julia-repl hljs\"><span class=\"hljs-meta\">julia&gt;</span>", index)
+    @test occursin("<code class=\"language-julia-repl hljs\"><span class=\"hljs-meta prompt_\">julia&gt;</span>", index)
     @test occursin("<code class=\"language-llvm hljs\"><span class=\"hljs-comment\">;  @ int.jl:87", index)
     @test length(HLJSFILES) == 1
 end
@@ -82,7 +82,7 @@ index = read_index()
 @test !occursin("<code class=\"language-julia-repl hljs\">julia&gt; function f()", index)
 @test occursin("<code class=\"language-llvm hljs\">;  @ int.jl:87 within", index)
 @test occursin("<code class=\"language-julia hljs\"><span class=\"hljs-keyword\">function</span> f()", index)
-@test occursin("<code class=\"language-julia-repl hljs\"><span class=\"hljs-meta\">julia&gt;</span>", index)
+@test occursin("<code class=\"language-julia-repl hljs\"><span class=\"hljs-meta prompt_\">julia&gt;</span>", index)
 @test !occursin("<code class=\"language-llvm hljs\"><span class=\"hljs-comment\">;  @ int.jl:87", index)
 
 @test length(HLJSFILES) == 2


### PR DESCRIPTION
(Hopefully) non-breaking bumps for Font Awesome, KaTeX, HIghlightJS, in the same vein as #1844. I also assume that the JuliaMono bump is non-breaking.

For 0.28, we should bump these versions to the actual latest ones (e.g. for KaTeX), but no point in changing the versions until we're close to the actual release.