### PR TITLE
Move `draft` keyword documentation out of the `expandfirst`

### DIFF
--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -189,16 +189,16 @@ is enabled by default.
 before the others. Documenter normally evaluates the files in the alphabetic order of their
 file paths relative to `src`, but `expandfirst` allows some pages to be prioritized.
 
-**`draft`** can be set to `true` to build a draft version of the document. In draft mode
-some potentially time-consuming steps are skipped (e.g. running `@example` blocks), which is
-useful when iterating on the documentation. This setting can also be configured per-page
-by setting `Draft = true` in an `@meta` block.
-
 For example, if you have `foo.md` and `bar.md`, `bar.md` would normally be evaluated before
 `foo.md`. But with `expandfirst = ["foo.md"]`, you can force `foo.md` to be evaluated first.
 
 Evaluation order among the `expandfirst` pages is according to the order they appear in the
 argument.
+
+**`draft`** can be set to `true` to build a draft version of the document. In draft mode
+some potentially time-consuming steps are skipped (e.g. running `@example` blocks), which is
+useful when iterating on the documentation. This setting can also be configured per-page
+by setting `Draft = true` in an `@meta` block.
 
 # Experimental keywords
 


### PR DESCRIPTION
The documentation for the `draft` keyword to `makedocs` breaks up the explanation of the `expandfirst` keyword. This moves the former slightly down to fix this.