### PR TITLE
Fix nightly test failures

### DIFF
--- a/test/doctests/src/working.md
+++ b/test/doctests/src/working.md
@@ -36,6 +36,14 @@ xyz
 
 Original issue:
 
+```@meta
+DocTestSetup = quote
+    methods(args...) = println("""
+    # 1 method for generic function "f":
+    [1] f() in Main at none:1
+    """)
+end
+```
 ```jldoctest
 julia> f()=0
 f (generic function with 1 method)
@@ -43,6 +51,9 @@ f (generic function with 1 method)
 julia> methods(f)
 # 1 method for generic function "f":
 [1] f() in Main at none:1
+```
+```@meta
+DocTestSetup = nothing
 ```
 
 Comments at the start:

--- a/test/doctests/src/working.md
+++ b/test/doctests/src/working.md
@@ -38,7 +38,7 @@ Original issue:
 
 ```@meta
 DocTestSetup = quote
-    methods(args...) = println("""
+    methods(args...) = Text("""
     # 1 method for generic function "f":
     [1] f() in Main at none:1
     """)


### PR DESCRIPTION
It seems that the printing of `methods()` has changed and our doctest tests relied on that.