### PR TITLE
GHA setup: add statuses write permissions

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -191,6 +191,7 @@ jobs:
   build:
     permissions:
       contents: write
+      statuses: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
X-ref: https://github.com/JuliaDocs/Documenter.jl/pull/1829#issuecomment-1139136673. Based on some testing in https://github.com/mortenpi/Example.jl/pull/2, `statuses: write` is necessary and sufficient to make the deploy check appear.