### PR TITLE
Handle missing Git in git_remote_head_branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 * ![Enhancement][badge-enhancement] The `ansicolor` keyword to `HTML()` now defaults to true, meaning that executed outputs from `@example`- and `@repl`-blocks are now by default colored (if they emit colored output). ([#1828][github-1828])
 
+## Version `v0.27.21`
+
+* ![Bugfix][badge-bugfix] Fix a regression where Documenter throws an error on systems that do not have Git available. ([#1870][github-1870], [#1871][github-1871])
+
 ## Version `v0.27.20`
 
 * ![Enhancement][badge-enhancement] The various JS and font dependencies of the HTML backend have been updated to the latest non-breaking versions. ([#1844][github-1844], [#1846][github-1846])
@@ -1087,6 +1091,8 @@
 [github-1861]: https://github.com/JuliaDocs/Documenter.jl/pull/1861
 [github-1862]: https://github.com/JuliaDocs/Documenter.jl/pull/1862
 [github-1865]: https://github.com/JuliaDocs/Documenter.jl/pull/1865
+[github-1870]: https://github.com/JuliaDocs/Documenter.jl/issues/1870
+[github-1871]: https://github.com/JuliaDocs/Documenter.jl/pull/1871
 <!-- end of issue link definitions -->
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -790,10 +790,19 @@ it out automatically.
 to construct the warning messages.
 """
 function git_remote_head_branch(varname, root; remotename = "origin", fallback = "master")
+    gitcmd = git(nothrow = true)
+    if gitcmd === nothing
+        @warn """
+        Unable to determine $(varname) from remote HEAD branch, defaulting to "$(fallback)".
+        Unable to find the `git` binary. Unless this is due to a configuration error, the
+        relevant variable should be set explicitly.
+        """
+        return fallback
+    end
     # We need to do addenv() here to merge the new variables with the environment set by
     # Git_jll and the git() function.
     cmd = addenv(
-        setenv(`$(git()) remote show $(remotename)`, dir=root),
+        setenv(`$gitcmd remote show $(remotename)`, dir=root),
         "GIT_TERMINAL_PROMPT" => "0",
         "GIT_SSH_COMMAND" => get(ENV, "GIT_SSH_COMMAND", "ssh -o \"BatchMode yes\""),
     )
@@ -849,9 +858,11 @@ dropheaders(h::Markdown.Header) = Markdown.Paragraph([Markdown.Bold(h.text)])
 dropheaders(v::Vector) = map(dropheaders, v)
 dropheaders(other) = other
 
-function git(; kwargs...)
+function git(; nothrow = false, kwargs...)
     system_git_path = Sys.which("git")
-    isnothing(system_git_path) && error("Unable to find `git`")
+    if system_git_path === nothing
+        return nothrow ? nothing : error("Unable to find `git`")
+    end
     # According to the Git man page, the default GIT_TEMPLATE_DIR is at /usr/share/git-core/templates
     # We need to set this to something so that Git wouldn't pick up the user
     # templates (e.g. from init.templateDir config).


### PR DESCRIPTION
~This is currently against `release-0.27` since I wrote this on top of the 0.27.20 tag, and needs to be brought up to date with with `master`.~

Fix #1870.