### PR TITLE
Add Documenter version to footer

### DIFF
--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -428,7 +428,7 @@ struct HTML <: Documenter.Writer
             sidebar_sitename :: Bool = true,
             highlights    :: Vector{String} = String[],
             mathengine    :: Union{MathEngine,Nothing} = KaTeX(),
-            footer        :: Union{String, Nothing} = "Powered by [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl) v$DOCUMENTER_VERSION and the [Julia Programming Language](https://julialang.org/).",
+            footer        :: Union{String, Nothing} = "Powered by [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl) v$(Documenter.DOCUMENTER_VERSION) and the [Julia Programming Language](https://julialang.org/).",
             ansicolor     :: Bool = true,
             lang          :: String = "en",
             warn_outdated :: Bool = true,

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -344,7 +344,7 @@ passing an instance of [`KaTeX`](@ref), [`MathJax2`](@ref), or
 passing options to the [`KaTeX`](@ref) or [`MathJax2`](@ref)/[`MathJax3`](@ref) constructors.
 
 **`footer`** can be a valid single-line markdown `String` or `nothing` and is displayed below
-the page navigation. Defaults to `"Powered by [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl)
+the page navigation. Defaults to `"Powered by [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl) {version}
 and the [Julia Programming Language](https://julialang.org/)."`.
 
 **`ansicolor`** can be used to globally disable colored output from `@repl` and `@example`
@@ -428,7 +428,7 @@ struct HTML <: Documenter.Writer
             sidebar_sitename :: Bool = true,
             highlights    :: Vector{String} = String[],
             mathengine    :: Union{MathEngine,Nothing} = KaTeX(),
-            footer        :: Union{String, Nothing} = "Powered by [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl) and the [Julia Programming Language](https://julialang.org/).",
+            footer        :: Union{String, Nothing} = "Powered by [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl) v$DOCUMENTER_VERSION and the [Julia Programming Language](https://julialang.org/).",
             ansicolor     :: Bool = true,
             lang          :: String = "en",
             warn_outdated :: Bool = true,


### PR DESCRIPTION
I think this is helpful for development. At least, I was hoping to see it to figure out if Base docs have been deployed with the new version yet