### PR TITLE
Fix nightly tests

### DIFF
--- a/test/errors/make.jl
+++ b/test/errors/make.jl
@@ -52,14 +52,24 @@ end
     strict=false,
     source = "src.docmeta", modules = [BadDocmetaModule], sitename="-", checkdocs = :exports,
 ) === nothing
-# The two following tests should start failing once the underlying bug in Base.Docs is fixed,
-# at which point these tests should be removed (or replaced with ones testing against some
-# manually crafted Docs.meta).
-@test_throws ErrorException makedocs(
-    strict = true,
-    source = "src.docmeta", modules = [BadDocmetaModule], sitename="-", checkdocs = :exports,
-)
-@test_throws ErrorException makedocs(
-    strict = :autodocs_block,
-    source = "src.docmeta", modules = [BadDocmetaModule], sitename="-", checkdocs = :exports,
-)
+if VERSION >= v"1.9.0-DEV.954"
+    # The docsystem metadata for the following tests was fixed in
+    #   https://github.com/JuliaLang/julia/pull/45529
+    @test ErrorException makedocs(
+        strict = true,
+        source = "src.docmeta", modules = [BadDocmetaModule], sitename="-", checkdocs = :exports,
+    ) === nothing
+    @test ErrorException makedocs(
+        strict = :autodocs_block,
+        source = "src.docmeta", modules = [BadDocmetaModule], sitename="-", checkdocs = :exports,
+    ) === nothing
+else
+    @test_throws ErrorException makedocs(
+        strict = true,
+        source = "src.docmeta", modules = [BadDocmetaModule], sitename="-", checkdocs = :exports,
+    )
+    @test_throws ErrorException makedocs(
+        strict = :autodocs_block,
+        source = "src.docmeta", modules = [BadDocmetaModule], sitename="-", checkdocs = :exports,
+    )
+end

--- a/test/errors/make.jl
+++ b/test/errors/make.jl
@@ -55,11 +55,11 @@ end
 if VERSION >= v"1.9.0-DEV.954"
     # The docsystem metadata for the following tests was fixed in
     #   https://github.com/JuliaLang/julia/pull/45529
-    @test ErrorException makedocs(
+    @test makedocs(
         strict = true,
         source = "src.docmeta", modules = [BadDocmetaModule], sitename="-", checkdocs = :exports,
     ) === nothing
-    @test ErrorException makedocs(
+    @test makedocs(
         strict = :autodocs_block,
         source = "src.docmeta", modules = [BadDocmetaModule], sitename="-", checkdocs = :exports,
     ) === nothing


### PR DESCRIPTION
The docsystem metadata for these tests was fixed in https://github.com/JuliaLang/julia/pull/45529.