### PR TITLE
Use DocumenterTools as a dev dep in docs/

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,12 +76,10 @@ jobs:
         with:
           version: '1'
       - uses: julia-actions/cache@v1
-      - run: |
-          julia --project=test/themes/ -e '
-            using Pkg
-            Pkg.instantiate()
-            Pkg.develop(PackageSpec(path=pwd()))'
-      - run: julia --project=test/themes test/themes/themes.jl
+      - name: Install dependencies
+        run: julia --color=yes --project=test/themes/ docs/instantiate.jl test/themes/
+      - name: Verify theme CSS files
+        run: julia --project=test/themes test/themes/themes.jl
 
   prerender:
     name: "NodeJS for prerender"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -118,11 +118,7 @@ jobs:
         with:
           version: '1'
       - uses: julia-actions/cache@v1
-      - run: |
-          julia --color=yes --project=docs/ -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()'
+      - run: julia --color=yes --project=docs/ docs/instantiate.jl
       - run: julia --color=yes --project=docs/ docs/make.jl ${{ matrix.format }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,7 +56,7 @@ jobs:
             using Pkg
             Pkg.instantiate()
             Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.add(["IOCapture", "DocumenterMarkdown", "tectonic_jll"])'
+            Pkg.add(["IOCapture", "tectonic_jll"])'
       - run: julia --project=test/examples --code-coverage test/examples/tests_latex.jl
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -118,8 +118,10 @@ jobs:
         with:
           version: '1'
       - uses: julia-actions/cache@v1
-      - run: julia --color=yes --project=docs/ docs/instantiate.jl
-      - run: julia --color=yes --project=docs/ docs/make.jl ${{ matrix.format }}
+      - name: Install dependencies
+        run: julia --color=yes --project=docs/ docs/instantiate.jl
+      - name: Build the manual
+        run: julia --color=yes --project=docs/ docs/make.jl ${{ matrix.format }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
@@ -150,7 +152,7 @@ jobs:
         with:
           version: '1.6'
       - name: Install dependencies
-        run: julia --color=yes --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        run: julia --color=yes --project=docs/ docs/instantiate.jl
       - name: Build and check documentation
         run: julia --color=yes --project=docs/ docs/make.jl linkcheck
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ test/nongit/build/
 test/errors/build/
 test/prerender/build/
 test/workdir/builds/
+docs/dev/
 docs/build/
 docs/build-pdf/
 docs/site/

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ test/missingdocs/build/
 test/nongit/build/
 test/errors/build/
 test/prerender/build/
+test/themes/dev/
 test/workdir/builds/
 docs/dev/
 docs/build/

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Documenter"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.27.18"
+version = "0.28.0-DEV"
 
 [deps]
 ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,3 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"
-
-[compat]
-DocumenterTools = "=0.1.14"

--- a/docs/instantiate.jl
+++ b/docs/instantiate.jl
@@ -1,14 +1,22 @@
 # This script can be used to quickly instantiate the docs/Project.toml enviroment.
 using Pkg
-cd(@__DIR__) do
-    Pkg.activate(@__DIR__)
-    # Install the documenter branch of DocumenterTools
+documenter_directory = joinpath(@__DIR__, "..")
+project_directory = isempty(ARGS) ? @__DIR__() : joinpath(pwd(), ARGS[1])
+cd(project_directory) do
+    Pkg.activate(project_directory)
+    # Install a DocumenterTools version that declares compatibility with Documenter 0.28,
+    # but from an unreleased tag.
+    # https://github.com/JuliaDocs/DocumenterTools.jl/releases/tag/documenter-v0.1.14%2B0.28.0-DEV
     if isdir("dev/DocumenterTools")
-        @info "DocumenterTools already cloned to docs/dev/DocumenterTools"
+        @info "DocumenterTools already cloned to dev/DocumenterTools"
+        run(`git -C dev/DocumenterTools fetch origin`)
     else
         run(`git clone -n https://github.com/JuliaDocs/DocumenterTools.jl.git dev/DocumenterTools`)
     end
-    run(`git -C dev/DocumenterTools checkout --detach 336e27eeaf56852838b192b1fc7c0cce129d2d9f`)
-    Pkg.develop([PackageSpec(path = "dev/DocumenterTools"), PackageSpec(path = "..")])
+    run(`git -C dev/DocumenterTools checkout documenter-v0.1.14+0.28.0-DEV`)
+    Pkg.develop([
+        PackageSpec(path = documenter_directory),
+        PackageSpec(path = "dev/DocumenterTools"),
+    ])
     Pkg.instantiate()
 end

--- a/docs/instantiate.jl
+++ b/docs/instantiate.jl
@@ -9,7 +9,6 @@ cd(@__DIR__) do
         run(`git clone -n https://github.com/JuliaDocs/DocumenterTools.jl.git dev/DocumenterTools`)
     end
     run(`git -C dev/DocumenterTools checkout --detach 336e27eeaf56852838b192b1fc7c0cce129d2d9f`)
-    Pkg.develop(path = "dev/DocumenterTools")
-    Pkg.develop(path = "..")
+    Pkg.develop([PackageSpec(path = "dev/DocumenterTools"), PackageSpec(path = "..")])
     Pkg.instantiate()
 end

--- a/docs/instantiate.jl
+++ b/docs/instantiate.jl
@@ -1,0 +1,15 @@
+# This script can be used to quickly instantiate the docs/Project.toml enviroment.
+using Pkg
+cd(@__DIR__) do
+    Pkg.activate(@__DIR__)
+    # Install the documenter branch of DocumenterTools
+    if isdir("dev/DocumenterTools")
+        @info "DocumenterTools already cloned to docs/dev/DocumenterTools"
+    else
+        run(`git clone -n https://github.com/JuliaDocs/DocumenterTools.jl.git dev/DocumenterTools`)
+    end
+    run(`git -C dev/DocumenterTools checkout --detach 336e27eeaf56852838b192b1fc7c0cce129d2d9f`)
+    Pkg.develop(path = "dev/DocumenterTools")
+    Pkg.develop(path = "..")
+    Pkg.instantiate()
+end

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -516,8 +516,7 @@ function getremote(dir::AbstractString)
     return get!(GIT_REMOTE_CACHE, dir) do
         remote = try
             readchomp(setenv(`$(git()) config --get remote.origin.url`; dir=dir))
-        catch e
-            @error "getremote failed" dir exception = (e, catch_backtrace())
+        catch
             ""
         end
         m = match(LibGit2.GITHUB_REGEX, remote)

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -516,7 +516,8 @@ function getremote(dir::AbstractString)
     return get!(GIT_REMOTE_CACHE, dir) do
         remote = try
             readchomp(setenv(`$(git()) config --get remote.origin.url`; dir=dir))
-        catch
+        catch e
+            @error "getremote failed" dir exception = (e, catch_backtrace())
             ""
         end
         m = match(LibGit2.GITHUB_REGEX, remote)

--- a/test/themes/Project.toml
+++ b/test/themes/Project.toml
@@ -4,5 +4,4 @@ DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"
 libsass_jll = "47bcb7c8-5119-555a-9eeb-0afcc36cd728"
 
 [compat]
-DocumenterTools = "=0.1.12"
 libsass_jll = "~3.6"


### PR DESCRIPTION
This does a few things:

1. The source links to the DocumenterTools docstrings do not work right now because we Pkg.add it, but we need the source files to be located in a Git repository for gitremote to determine the remote repository. We can work around that by making it a Pkg.develop dependency instead.

2. If we add it as a dev dependency, we can use unreleased branches which declare support for newer Documenter versions, and so we can use the `-DEV` versions in the Documenter repository now. However, this requires checking out a particular [commit](https://github.com/JuliaDocs/DocumenterTools.jl/tree/documenter-0.28-dev) (or tag) of DocumenterTools. Pkg.develop can not be used for this since it does not know how to check out specific branches, and will fail as it tries to check out master (which will not be compatible with e.g. `0.28.0-DEV`).

3. Since adding it as a local dev dependency is a slightly non-trivial, this creates a separate `docs/instantiate.jl` script which does the necessary cloning and Pkg environment manipulations, just to make life easier locally and in the CI config.

Handling a minor release will still be a little tricky. But what I reckon we can do is: (1) prepare the `master` branch of DocumenterTools, which declares compat with Documenter 0.28, (2) update `docs/instantiate.jl` here to that branch and tag Documenter, and (3) tag the previously prepared commit of DocumenterTools. This way we never have to register a package that depends on a future release of Documenter.

Rather than depending on a commit from a side branch, I think it would be better to push custom tags to DocumenterTools for this. That would ensure that the commit will stay around, even if branches get deleted, and so the `git checkout` here should never fail.

This will also function as a test case for #1808, since this is an uncommon edge case that we actually handle (including docstrings from a third package in the manual with working source links).