### PR TITLE
Improve how the at-quietly logs are handled in the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ test/errors/build/
 test/prerender/build/
 test/themes/dev/
 test/workdir/builds/
-test/quietly.log
+test/quietly-logs/
 docs/dev/
 docs/build/
 docs/build-pdf/

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ test/errors/build/
 test/prerender/build/
 test/themes/dev/
 test/workdir/builds/
+test/quietly.log
 docs/dev/
 docs/build/
 docs/build-pdf/

--- a/test/TestUtilities.jl
+++ b/test/TestUtilities.jl
@@ -1,4 +1,4 @@
-module TestUtilities
+isdefined(Main, :TestUtilities) || @eval Main module TestUtilities
 using Test
 import IOCapture
 

--- a/test/deploydocs.jl
+++ b/test/deploydocs.jl
@@ -1,7 +1,7 @@
-isdefined(@__MODULE__, :TestUtilities) || include("TestUtilities.jl")
 using Documenter: Documenter, deploydocs
 using Documenter.Utilities: git
-using Test, ..TestUtilities
+using Test
+include("TestUtilities.jl"); using Main.TestUtilities
 
 struct TestDeployConfig <: Documenter.DeployConfig
     repo_path :: String

--- a/test/doctests/fix/tests.jl
+++ b/test/doctests/fix/tests.jl
@@ -2,10 +2,9 @@
 #
 # DOCUMENTER_TEST_DEBUG= JULIA_DEBUG=all julia test/doctests/fix/tests.jl
 #
-isdefined(@__MODULE__, :TestUtilities) || (include("../../TestUtilities.jl"); using .TestUtilities)
 module DocTestFixTest
 using Documenter, Test
-using ..TestUtilities: @quietly
+include("../../TestUtilities.jl"); using Main.TestUtilities: @quietly
 
 # Type to reliably show() objects across Julia versions:
 @eval Main begin

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -1,3 +1,6 @@
+using Documenter
+include("../TestUtilities.jl"); using Main.TestUtilities
+
 # Defines the modules referred to in the example docs (under src/) and then builds them.
 # It can be called separately to build the examples/, or as part of the test suite.
 
@@ -159,8 +162,6 @@ function withassets(f, assets...)
 end
 
 # Build example docs
-using Documenter
-isdefined(@__MODULE__, :TestUtilities) || (include("../TestUtilities.jl"); using .TestUtilities)
 
 examples_root = @__DIR__
 builds_directory = joinpath(examples_root, "builds")

--- a/test/missingdocs/make.jl
+++ b/test/missingdocs/make.jl
@@ -1,7 +1,7 @@
-isdefined(@__MODULE__, :TestUtilities) || include("../TestUtilities.jl")
 module MissingDocsTests
-using Test, ..TestUtilities
+using Test
 using Documenter
+include("../TestUtilities.jl"); using Main.TestUtilities
 
 module MissingDocs
     export f

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Test
 import Documenter
-include("TestUtilities.jl"); using .TestUtilities
+include("TestUtilities.jl"); using Main.TestUtilities
 
 @testset "Documenter" begin
     # Build the example docs

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -1,9 +1,8 @@
 module UtilitiesTests
-
 using Test
 using Logging: Info
 import Base64: stringmime
-include("TestUtilities.jl"); using .TestUtilities
+include("TestUtilities.jl"); using Main.TestUtilities
 
 import Documenter
 using Documenter.Utilities: git


### PR DESCRIPTION
* [Change loading of TestUtilities](https://github.com/JuliaDocs/Documenter.jl/commit/5d25ce4c64d93d4572e2578b6d0c80bd13da31cc) 

  Create a more uniform pattern for loading the module to make sure that we
  do not accidentally load it several times as the tests runs, resetting
  the output log file, if that is enabled.

- [Store at-quietly logs in separate files](https://github.com/JuliaDocs/Documenter.jl/commit/e3dbe8a1fd241e9a218fd3962cea172eef6af1fe) 

  And also print the log ID in the test output if the logs are enabled, so
  that it would be easy to find the corresponding log.