### PR TITLE
Changed REPL.softscope! to REPL.softscope in Expanders and DocTests

### DIFF
--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -238,7 +238,7 @@ function eval_repl(block, sandbox, meta::Dict, doc::Documents.Document, page)
             result.hide = REPL.ends_with_semicolon(str)
             # Use the REPL softscope for REPL jldoctests,
             # see https://github.com/JuliaLang/julia/pull/33864
-            ex = REPL.softscope!(ex)
+            ex = REPL.softscope(ex)
             c = IOCapture.capture(rethrow = InterruptException) do
                 Core.eval(sandbox, ex)
             end

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -713,7 +713,7 @@ function Selectors.runner(::Type{REPLBlocks}, x, page, doc)
         input  = droplines(str)
         # Use the REPL softscope for REPLBlocks,
         # see https://github.com/JuliaLang/julia/pull/33864
-        ex = REPL.softscope!(ex)
+        ex = REPL.softscope(ex)
         c = IOCapture.capture(rethrow = InterruptException, color = ansicolor) do
             cd(page.workdir) do
                 Core.eval(mod, ex)


### PR DESCRIPTION
Changed REPL.softscope! to REPL.softscope in Expanders and DocTests

fixes #1894