### PR TITLE
Make at-ref links more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 * ![Enhancement][badge-enhancement] Woodpecker CI is now automatically supported for documentation deployment. ([#1880][github-1880])
 * ![Enhancement][badge-enhancement] The `@contents`-block now support `UnitRange`s for the `Depth` argument. This makes it possible to configure also the *minimal* header depth that should be displayed (`Depth = 2:3`, for example). This is supported by the HTML and the LaTeX/PDF backends. ([#245][github-245], [#1890][github-1890])
+* ![Enhancement][badge-enhancement] The at-ref links are now more flexible, allowing arbitrary links to point to both docstrings and section headings. ([#781][github-781], [#1900][github-1900])
 * ![Bugfix][badge-bugfix] Documenter now generates the correct source URLs for docstrings from other packages when the `repo` argument to `makedocs` is set (note: the source links to such docstrings only work if the external package is cloned from GitHub and added as a dev-dependency). However, this change **breaks** the case where the `repo` argument is used to override the main package/repository URL, assuming the repository is cloned from GitHub. ([#1808][github-1808])
 * ![Bugfix][badge-bugfix] Documenter no longer uses the `TRAVIS_REPO_SLUG` environment variable to determine the Git remote of non-main repositories (when inferring it from the Git repository configuration has failed), which could previously lead to bad source links. ([#1881][github-1881])
 
@@ -787,6 +788,7 @@
 [github-756]: https://github.com/JuliaDocs/Documenter.jl/issues/756
 [github-764]: https://github.com/JuliaDocs/Documenter.jl/pull/764
 [github-774]: https://github.com/JuliaDocs/Documenter.jl/pull/774
+[github-781]: https://github.com/JuliaDocs/Documenter.jl/issues/781
 [github-789]: https://github.com/JuliaDocs/Documenter.jl/pull/789
 [github-792]: https://github.com/JuliaDocs/Documenter.jl/pull/792
 [github-793]: https://github.com/JuliaDocs/Documenter.jl/issues/793
@@ -1117,6 +1119,7 @@
 [github-1885]: https://github.com/JuliaDocs/Documenter.jl/issues/1885
 [github-1886]: https://github.com/JuliaDocs/Documenter.jl/pull/1886
 [github-1890]: https://github.com/JuliaDocs/Documenter.jl/pull/1890
+[github-1900]: https://github.com/JuliaDocs/Documenter.jl/pull/1900
 <!-- end of issue link definitions -->
 
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -187,6 +187,38 @@ using the same syntax.
 Note that depending on what the `CurrentModule` is set to, a docstring `@ref` may need to
 be prefixed by the module which defines it.
 
+### Named `@ref`s
+
+It is also possible to override the destination of an `@ref`-link by adding the appropriate
+label to the link, such as a docstring reference or a page heading.
+
+```markdown
+Both of the following references point to `g` found in module `Main.Other`:
+
+* [`Main.Other.g`](@ref)
+* [the `g` function](@ref Main.Other.g)
+
+Both of the following point to the heading "On Something":
+
+* [On Something](@ref)
+* [The section about something.](@ref "On Something")
+```
+
+This can be useful to avoid having to write fully qualified names for references that
+are not imported into the current module, or when the text displayed in the link is
+used to add additional meaning to the surrounding text, such as
+
+```markdown
+Use [`for i = 1:10 ...`](@ref for) to loop over all the numbers from 1 to 10.
+```
+
+!!! note
+
+    Named doc `@ref`s should be used sparingly since writing unqualified names may, in some
+    cases, make it difficult to tell *which* function is being referred to in a particular
+    docstring if there happen to be several modules that provide definitions with the same
+    name.
+
 ### Duplicate Headers
 
 In some cases a document may contain multiple headers with the same name, but on different
@@ -210,40 +242,10 @@ to headers on different pages in the same way as unnamed ones do.
 Duplicate docstring references do not occur since splicing the same docstring into a
 document more than once is disallowed.
 
-### Named doc `@ref`s
+!!! note "Label precedence"
 
-Docstring `@ref`s can also be "named" in a similar way to headers as shown in the
-[Duplicate Headers](@ref) section above. For example
-
-```julia
-module Mod
-
-"""
-Both of the following references point to `g` found in module `Main.Other`:
-
-  * [`Main.Other.g`](@ref)
-  * [`g`](@ref Main.Other.g)
-
-"""
-f(args...) = # ...
-
-end
-```
-
-This can be useful to avoid having to write fully qualified names for references that
-are not imported into the current module, or when the text displayed in the link is
-used to add additional meaning to the surrounding text, such as
-
-```markdown
-Use [`for i = 1:10 ...`](@ref for) to loop over all the numbers from 1 to 10.
-```
-
-!!! note
-
-    Named doc `@ref`s should be used sparingly since writing unqualified names may, in some
-    cases, make it difficult to tell *which* function is being referred to in a particular
-    docstring if there happen to be several modules that provide definitions with the same
-    name.
+    Both user-defined and internally generated header reference labels take precedence over
+    docstring references, in case there is a conflict.
 
 ## `@meta` block
 
@@ -445,10 +447,10 @@ files into that directory. This allows the images to be easily referenced withou
 worry about relative paths.
 
 !!! info
-    If you use [Plots.jl](https://github.com/JuliaPlots/Plots.jl) with the default backend 
+    If you use [Plots.jl](https://github.com/JuliaPlots/Plots.jl) with the default backend
     [GR.jl](https://github.com/jheinen/GR.jl), you will likely see warnings like
     ```
-    qt.qpa.xcb: could not connect to display 
+    qt.qpa.xcb: could not connect to display
     qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
     ```
     To fix these, you need to set the environment variable `GKSwstype` to `100`. For example,

--- a/test/crossreferences.jl
+++ b/test/crossreferences.jl
@@ -1,0 +1,32 @@
+module CrossReferencesTests
+using Documenter: CrossReferences
+using Test
+
+@testset "CrossReferences" begin
+    @test CrossReferences.xrefname("") === nothing
+    @test CrossReferences.xrefname("@") === nothing
+    @test CrossReferences.xrefname("@re") === nothing
+    @test CrossReferences.xrefname("@refx") === nothing
+    @test CrossReferences.xrefname("@ref#") === nothing
+    @test CrossReferences.xrefname("@ref_") === nothing
+    # basic at-refs
+    @test CrossReferences.xrefname("@ref") == ""
+    @test CrossReferences.xrefname("@ref ") == ""
+    @test CrossReferences.xrefname("@ref     ") == ""
+    @test CrossReferences.xrefname("@ref\t") == ""
+    @test CrossReferences.xrefname("@ref\t  ") == ""
+    @test CrossReferences.xrefname("@ref \t") == ""
+    @test CrossReferences.xrefname(" @ref") == ""
+    @test CrossReferences.xrefname(" \t@ref") == ""
+    # named at-refs
+    @test CrossReferences.xrefname("@ref foo") == "foo"
+    @test CrossReferences.xrefname("@ref      foo") == "foo"
+    @test CrossReferences.xrefname("@ref  foo  ") == "foo"
+    @test CrossReferences.xrefname("@ref \t foo \t ") == "foo"
+    @test CrossReferences.xrefname("@ref\tfoo") == "foo"
+    @test CrossReferences.xrefname("@ref foo%bar") == "foo%bar"
+    @test CrossReferences.xrefname("@ref  foo bar  \t baz   ") == "foo bar  \t baz"
+    @test CrossReferences.xrefname(" \t@ref  foo") == "foo"
+end
+
+end

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -200,6 +200,7 @@ htmlbuild_pages = Any[
         "editurl/bad.md",
         "editurl/ugly.md",
     ],
+    "xrefs.md",
 ]
 
 function html_doc(build_directory, mathengine; htmlkwargs=(;), kwargs...)

--- a/test/examples/src/xrefs.md
+++ b/test/examples/src/xrefs.md
@@ -1,0 +1,16 @@
+# Cross-references
+
+Basic x-refs:
+
+* [X-ref target](@ref)
+* [`Mod.func`](@ref)
+
+Named x-refs:
+
+* [X-ref target with an ID](@ref xreftarget)
+* [docstring target](@ref Mod.func)
+* [string target](@ref "X-ref target")
+
+## X-ref target
+
+## [X-ref target with id](@id xreftarget)

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -104,4 +104,12 @@ end
         @test examples_html_repo_nothing_doc.user.remote === nothing
         @test examples_html_repo_error_doc.user.remote === nothing
     end
+
+    @testset "CrossReferences" begin
+        xref_file = joinpath(examples_root, "builds", "html", "xrefs", "index.html")
+        @test isfile(xref_file)
+        xref_file_html = read(xref_file, String)
+        # Make sure that all the cross-reference links were updated:
+        @test !occursin("@ref", xref_file_html)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,9 @@ include("TestUtilities.jl"); using Main.TestUtilities
     # DocSystem unit tests.
     include("docsystem.jl")
 
+    # CrossReferences
+    include("crossreferences.jl")
+
     # DocTest unit tests.
     @info "Running tests in doctests/"
     include("doctests/docmeta.jl")


### PR DESCRIPTION
Allows at-ref links of the form

```markdown
[the function `g`](@ref MyPackage.g)
[something-something](@ref "Section On Something")
```

which were previously not allowed. Previously you were only allowed to link either to an existing `id` (e.g. created by at-id, or by Documenter itself from a heading), or link to a docstring, but only if the whole label was code.

Fix #781, close #1767.