### PR TITLE
Normalize line endings in MD source before parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * ![Enhancement][badge-enhancement] The code copy buttons in HTML now have `title` and `aria-label` attributes. ([#1903][github-1903])
 * ![Bugfix][badge-bugfix] Documenter now generates the correct source URLs for docstrings from other packages when the `repo` argument to `makedocs` is set (note: the source links to such docstrings only work if the external package is cloned from GitHub and added as a dev-dependency). However, this change **breaks** the case where the `repo` argument is used to override the main package/repository URL, assuming the repository is cloned from GitHub. ([#1808][github-1808])
 * ![Bugfix][badge-bugfix] Documenter no longer uses the `TRAVIS_REPO_SLUG` environment variable to determine the Git remote of non-main repositories (when inferring it from the Git repository configuration has failed), which could previously lead to bad source links. ([#1881][github-1881])
+* ![Bugfix][badge-bugfix] Line endings in Markdown source files are now normalized to `LF` before parsing, to work around [a bug in the Julia Markdown parser][julia-29344] where parsing is sensitive to line endings, and can therefore cause platform-dependent behavior. ([#1906][github-1906])
 
 ## Version `v0.27.22`
 
@@ -1119,8 +1120,11 @@
 [github-1886]: https://github.com/JuliaDocs/Documenter.jl/pull/1886
 [github-1890]: https://github.com/JuliaDocs/Documenter.jl/pull/1890
 [github-1903]: https://github.com/JuliaDocs/Documenter.jl/pull/1903
+[github-1906]: https://github.com/JuliaDocs/Documenter.jl/pull/1906
+
 <!-- end of issue link definitions -->
 
+[julia-29344]: https://github.com/JuliaLang/julia/issues/29344
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 [julia-39841]: https://github.com/JuliaLang/julia/pull/39841
 [julia-45174]: https://github.com/JuliaLang/julia/issues/45174


### PR DESCRIPTION
Line endings in Markdown source files are now normalized to `LF` before parsing, to work around [a bug in the Julia Markdown parser][julia-29344] where parsing is sensitive to line endings, and can therefore cause platform-dependent behavior.

I wonder if this might cause problems with doctest fixing though..

[julia-29344]: https://github.com/JuliaLang/julia/issues/29344
