### PR TITLE
Various bugfixes and enhancements to LaTeXWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 * ![Bugfix][badge-bugfix] Documenter no longer uses the `TRAVIS_REPO_SLUG` environment variable to determine the Git remote of non-main repositories (when inferring it from the Git repository configuration has failed), which could previously lead to bad source links. ([#1881][github-1881])
 * ![Bugfix][badge-bugfix] Line endings in Markdown source files are now normalized to `LF` before parsing, to work around [a bug in the Julia Markdown parser][julia-29344] where parsing is sensitive to line endings, and can therefore cause platform-dependent behavior. ([#1906][github-1906])
 
+## Version `v0.27.23`
+
+* ![Enhancement][badge-enhancement] The `native` and `docker` PDF builds now run with the `-interaction=batchmode` (instead of `nonstopmode`) and `-halt-on-error` options to make the LaTeX error logs more readable and to fail the build early. ([#1908][github-1908])
+
 ## Version `v0.27.22`
 
 * ![Maintenance][badge-maintenance] Documenter is now compatible with DocStringExtensions v0.9. ([#1885][github-1885], [#1886][github-1886])
@@ -1121,7 +1125,7 @@
 [github-1890]: https://github.com/JuliaDocs/Documenter.jl/pull/1890
 [github-1903]: https://github.com/JuliaDocs/Documenter.jl/pull/1903
 [github-1906]: https://github.com/JuliaDocs/Documenter.jl/pull/1906
-
+[github-1908]: https://github.com/JuliaDocs/Documenter.jl/pull/1908
 <!-- end of issue link definitions -->
 
 [julia-29344]: https://github.com/JuliaLang/julia/issues/29344

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ## Version `v0.27.23`
 
 * ![Enhancement][badge-enhancement] The `native` and `docker` PDF builds now run with the `-interaction=batchmode` (instead of `nonstopmode`) and `-halt-on-error` options to make the LaTeX error logs more readable and to fail the build early. ([#1908][github-1908])
+* ![Bugfix][badge-bugfix] The PDF/LaTeX output now handles hard Markdown line breaks (i.e. `Markdown.LineBreak` nodes). ([#1908][github-1908])
 
 ## Version `v0.27.22`
 

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -701,6 +701,9 @@ function latexinline(io, hr::Markdown.HorizontalRule)
     _println(io, "\\rule{\\textwidth}{1pt}}")
 end
 
+function latexinline(io, hr::Markdown.LineBreak)
+    _println(io, "\\\\")
+end
 
 # Metadata Nodes get dropped from the final output for every format but are needed throughout
 # rest of the build and so we just leave them in place and print a blank line in their place.

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -171,7 +171,7 @@ function compile_tex(doc::Documents.Document, settings::LaTeX, fileprefix::Strin
         Sys.which("latexmk") === nothing && (@error "LaTeXWriter: latexmk command not found."; return false)
         @info "LaTeXWriter: using latexmk to compile tex."
         try
-            piperun(`latexmk -f -interaction=nonstopmode -view=none -lualatex -shell-escape $(fileprefix).tex`, clearlogs = true)
+            piperun(`latexmk -f -interaction=batchmode -halt-on-error -view=none -lualatex -shell-escape $(fileprefix).tex`, clearlogs = true)
             return true
         catch err
             logs = cp(pwd(), mktempdir(; cleanup=false); force=true)
@@ -199,7 +199,7 @@ function compile_tex(doc::Documents.Document, settings::LaTeX, fileprefix::Strin
             mkdir /home/zeptodoctor/build
             cd /home/zeptodoctor/build
             cp -r /mnt/. .
-            latexmk -f -interaction=nonstopmode -view=none -lualatex -shell-escape $(fileprefix).tex
+            latexmk -f -interaction=batchmode -halt-on-error -view=none -lualatex -shell-escape $(fileprefix).tex
             """
         try
             piperun(`docker run -itd -u zeptodoctor --name latex-container -v $(pwd()):/mnt/ --rm juliadocs/documenter-latex:$(DOCKER_IMAGE_TAG)`, clearlogs = true)

--- a/test/examples/src.latex_simple/index.md
+++ b/test/examples/src.latex_simple/index.md
@@ -121,3 +121,9 @@ LaTeXEquation2(raw"""
     \end{array}\right]
 """)
 ```
+
+## `LineBreak` node
+
+This sentence\
+should be over **multiple\
+lines**.


### PR DESCRIPTION
I think `-interaction=batchmode` is actually more appropriate than `nonstopmode`, since the latter includes "diagnostic messages" that are basically just noise. `-halt-on-error` should help in the cases where LaTeX doesn't clearly state that something was an error (like when you have missing fonts).

The full logs for the recent Julia 1.8.0 failure should just be

```
Latexmk: This is Latexmk, John Collins, 1 January 2015, version: 4.41.
Rule 'pdflatex': Rules & subrules not known to be previously run:
   pdflatex
Rule 'pdflatex': The following rules & subrules became out-of-date:
      'pdflatex'
------------
Run number 1 of rule 'pdflatex'
------------
Latexmk: applying rule 'pdflatex'...
------------
Running 'lualatex  -interaction=batchmode -halt-on-error -shell-escape -recorder  "TheJuliaLanguage.tex"'
------------
This is LuaTeX, Version 1.0.4 (TeX Live 2017/Debian)
 system commands enabled.
tput: No value for $TERM and no -T specified

luaotfload | main : initialization completed in 0.091 seconds
luaotfload | db : Reload initiated (formats: otf,ttf,ttc); reason: "Font phvb8t not found.".
luaotfload | resolve : sequence of 3 lookups yielded nothing appropriate.Failure to make 'TheJuliaLanguage.pdf'
Collected error summary (may duplicate other messages):
  pdflatex: Command for 'pdflatex' gave return code 256
Latexmk: Errors, in force_mode: so I tried finishing targets
```

which is far better than the 2MB of output we're getting now. And it fails only after a few seconds, rather than running for several minutes.

- https://tex.stackexchange.com/questions/258814/what-is-the-difference-between-interaction-nonstopmode-and-halt-on-error
- http://latexref.xyz/Command-line-options.html