### PR TITLE
attempt to fix broken PDF links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,12 @@
 * ![Bugfix][badge-bugfix] Documenter now generates the correct source URLs for docstrings from other packages when the `repo` argument to `makedocs` is set (note: the source links to such docstrings only work if the external package is cloned from GitHub and added as a dev-dependency). However, this change **breaks** the case where the `repo` argument is used to override the main package/repository URL, assuming the repository is cloned from GitHub. ([#1808][github-1808])
 * ![Bugfix][badge-bugfix] Documenter no longer uses the `TRAVIS_REPO_SLUG` environment variable to determine the Git remote of non-main repositories (when inferring it from the Git repository configuration has failed), which could previously lead to bad source links. ([#1881][github-1881])
 * ![Bugfix][badge-bugfix] Line endings in Markdown source files are now normalized to `LF` before parsing, to work around [a bug in the Julia Markdown parser][julia-29344] where parsing is sensitive to line endings, and can therefore cause platform-dependent behavior. ([#1906][github-1906])
-* ![Bugfix][badge-bugfix] Previously broken links within the PDF output are now fixed. (Julia issues: [pdf manual 1.5.2 links][julia-38054] and second part of [Dead links in pdf documentation][julia-43652])
 
 ## Version `v0.27.23`
 
 * ![Enhancement][badge-enhancement] The `native` and `docker` PDF builds now run with the `-interaction=batchmode` (instead of `nonstopmode`) and `-halt-on-error` options to make the LaTeX error logs more readable and to fail the build early. ([#1908][github-1908])
 * ![Bugfix][badge-bugfix] The PDF/LaTeX output now handles hard Markdown line breaks (i.e. `Markdown.LineBreak` nodes). ([#1908][github-1908])
+* ![Bugfix][badge-bugfix] Previously broken links within the PDF output are now fixed. ([JuliaLang/julia#38054][julia-38054], [JuliaLang/julia#43652][julia-43652], [#1909][github-1909])
 
 ## Version `v0.27.22`
 
@@ -1131,6 +1131,7 @@
 [github-1903]: https://github.com/JuliaDocs/Documenter.jl/pull/1903
 [github-1906]: https://github.com/JuliaDocs/Documenter.jl/pull/1906
 [github-1908]: https://github.com/JuliaDocs/Documenter.jl/pull/1908
+[github-1909]: https://github.com/JuliaDocs/Documenter.jl/pull/1909
 <!-- end of issue link definitions -->
 
 [julia-29344]: https://github.com/JuliaLang/julia/issues/29344

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * ![Bugfix][badge-bugfix] Documenter now generates the correct source URLs for docstrings from other packages when the `repo` argument to `makedocs` is set (note: the source links to such docstrings only work if the external package is cloned from GitHub and added as a dev-dependency). However, this change **breaks** the case where the `repo` argument is used to override the main package/repository URL, assuming the repository is cloned from GitHub. ([#1808][github-1808])
 * ![Bugfix][badge-bugfix] Documenter no longer uses the `TRAVIS_REPO_SLUG` environment variable to determine the Git remote of non-main repositories (when inferring it from the Git repository configuration has failed), which could previously lead to bad source links. ([#1881][github-1881])
 * ![Bugfix][badge-bugfix] Line endings in Markdown source files are now normalized to `LF` before parsing, to work around [a bug in the Julia Markdown parser][julia-29344] where parsing is sensitive to line endings, and can therefore cause platform-dependent behavior. ([#1906][github-1906])
+* ![Bugfix][badge-bugfix] Previously broken links within the PDF output are now fixed. (Julia issues: [pdf manual 1.5.2 links][julia-38054] and second part of [Dead links in pdf documentation][julia-43652])
 
 ## Version `v0.27.23`
 
@@ -1133,8 +1134,10 @@
 <!-- end of issue link definitions -->
 
 [julia-29344]: https://github.com/JuliaLang/julia/issues/29344
+[julia-38054]: https://github.com/JuliaLang/julia/issues/38054
 [julia-38079]: https://github.com/JuliaLang/julia/issues/38079
 [julia-39841]: https://github.com/JuliaLang/julia/pull/39841
+[julia-43652]: https://github.com/JuliaLang/julia/issues/43652
 [julia-45174]: https://github.com/JuliaLang/julia/issues/45174
 [julialangorg-1272]: https://github.com/JuliaLang/www.julialang.org/issues/1272
 

--- a/assets/latex/documenter.sty
+++ b/assets/latex/documenter.sty
@@ -85,3 +85,9 @@
 \usepackage{graphicx}
 \usepackage[export]{adjustbox}
 %
+
+% Some internal link targets are implemented with \label, some with \hypertarget,
+% but they require different links. This inserts a \hyperref if a corresponding label exists,
+% and \hyperlink if it doesn't.
+\def\hyperlinkref#1#2{\@ifundefined{r@#1}{\hyperlink{#1}{#2}}{\hyperref[#1]{#2}}}
+%

--- a/src/Anchors.jl
+++ b/src/Anchors.jl
@@ -125,13 +125,15 @@ function anchor(m::AnchorMap, id, file, n)
 end
 
 """
+Create a label from an anchor.
+"""
+label(a::Anchor) = (a.nth == 1) ? a.id : string(a.id, "-", a.nth)
+
+"""
 Create an HTML fragment from an anchor.
 """
 function fragment(a::Anchor)
-    frag = string("#", a.id)
-    if a.nth > 1
-        frag = string(frag, "-", a.nth)
-    end
+    frag = string("#", label(a))
     # TODO: Sanitize the fragment
     return frag
 end


### PR DESCRIPTION
This is supposed to address several issues regarding the PDF version of the Julia documentation, namely JuliaLang/julia#38054 and probably also the second comment in JuliaLang/julia#43652. This PR certainly needs improvements, but hopefully it gets the ball rolling. I find it annoying that the Julia documentation has so many broken links, and with this PR they all seem to disappear.

As far as I can tell, the main problem is that the field `anchor.nth` is used when creating a hypertarget in https://github.com/JuliaDocs/Documenter.jl/blob/6c92d59a19348b9ec4f1936bdce91d34511e4c18/src/Writers/LaTeXWriter.jl#L275-L279 but it is not used by hyperlinks. I don't know if this problem only happens for `anchor.nth == 1` or in general. In the case of the Julia documentation, the value seems to be always `1`, so I have omitted this field completely. I have noticed that in `HTMLWriter.jl` the case `anchor.nth == 1` receives special treatment.

A secondary problem is that the hypertarget is inserted before the text it refers to. Many targets are chapter or section headings, so there is a good chance that there will be a page break between the target and the text. On the other hand, if the target is moved behind the text, then the text is not visible when users follow the link. I've addressed this by using the LaTeX macro `\label` to create the target. Such labels then need to be referenced by `\hyperref` instead of `\hyperlink`. Since I don't know how to tell from within Julia which kind of target a link refers to, I have added a macro `\hyperlinkref` to `documenter.sty` which inserts either `\hyperref` or `\hyperlink`, depending on whether a corresponding label exists or not.

Other changes: In https://github.com/JuliaDocs/Documenter.jl/blob/6c92d59a19348b9ec4f1936bdce91d34511e4c18/src/Writers/LaTeXWriter.jl#L290-L294 a link is added to a target at the same spot. I have removed the link because it's unclear to me what the purpose of a link is that links to itself. (Theoretically, there could again be a page break between the target and the link.)

For the Julia documentation, the methods `latex(io::IO, index::Documents.IndexNode, page, doc)` and `latex(io::IO, contents::Documents.ContentsNode, page, doc)` are apparently never called, so changes in this code haven't been tested. In the latter function I have kept the `anchor.nth` when generating the link id, and I've moved the assignment `id =` to where it belongs.

I've also noticed that you use hashes of the anchor ids to get the target labels. Would it be a problem to simply use the ids themselves? For example. can they contain any characters that cause problems?