### PR TITLE
Remove the RawHTML document node

### DIFF
--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -167,10 +167,6 @@ struct EvalNode
     result :: Any
 end
 
-struct RawHTML
-    code::String
-end
-
 struct RawNode
     name::Symbol
     text::String
@@ -616,7 +612,6 @@ walk(f, meta, block::Markdown.Image)      = f(block) ? walk(f, meta, block.alt) 
 walk(f, meta, block::Markdown.Table)      = f(block) ? walk(f, meta, block.rows)    : nothing
 walk(f, meta, block::Markdown.List)       = f(block) ? walk(f, meta, block.items)   : nothing
 walk(f, meta, block::Markdown.Link)       = f(block) ? walk(f, meta, block.text)    : nothing
-walk(f, meta, block::RawHTML) = nothing
 walk(f, meta, block::DocsNodes) = walk(f, meta, block.nodes)
 walk(f, meta, block::DocsNode)  = walk(f, meta, block.docstr)
 walk(f, meta, block::EvalNode)  = walk(f, meta, block.result)

--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -2033,22 +2033,21 @@ function mdconvert(a::Markdown.Admonition, parent; kwargs...)
     )
 end
 
-mdconvert(html::Documents.RawHTML, parent; kwargs...) = Tag(Symbol("#RAW#"))(html.code)
-
 # Select the "best" representation for HTML output.
 mdconvert(mo::Documents.MultiOutput, parent; kwargs...) =
     Base.invokelatest(mdconvert, mo.content, parent; kwargs...)
 function mdconvert(d::Dict{MIME,Any}, parent; kwargs...)
-    if haskey(d, MIME"text/html"())
-        out = Documents.RawHTML(d[MIME"text/html"()])
+    rawhtml(code) = Tag(Symbol("#RAW#"))(code)
+    return if haskey(d, MIME"text/html"())
+        rawhtml(d[MIME"text/html"()])
     elseif haskey(d, MIME"image/svg+xml"())
         svg = d[MIME"image/svg+xml"()]
         svg_tag_match = match(r"<svg[^>]*>", svg)
         if svg_tag_match === nothing
             # There is no svg tag so we don't do any more advanced
-            # processing and just return the svg as RawHTML.
+            # processing and just return the svg as HTML.
             # The svg string should be invalid but that's not our concern here.
-            out = Documents.RawHTML(svg)
+            rawhtml(svg)
         else
             # The xmlns attribute has to be present for data:image/svg+xml
             # to work (https://stackoverflow.com/questions/18467982).
@@ -2082,17 +2081,17 @@ function mdconvert(d::Dict{MIME,Any}, parent; kwargs...)
                 sep = "'"
             end
 
-            out = Documents.RawHTML(string("<img src=", sep, "data:image/svg+xml;utf-8,", svg, sep, "/>"))
+            rawhtml(string("<img src=", sep, "data:image/svg+xml;utf-8,", svg, sep, "/>"))
         end
 
     elseif haskey(d, MIME"image/png"())
-        out = Documents.RawHTML(string("<img src=\"data:image/png;base64,", d[MIME"image/png"()], "\" />"))
+        rawhtml(string("<img src=\"data:image/png;base64,", d[MIME"image/png"()], "\" />"))
     elseif haskey(d, MIME"image/webp"())
-        out = Documents.RawHTML(string("<img src=\"data:image/webp;base64,", d[MIME"image/webp"()], "\" />"))
+        rawhtml(string("<img src=\"data:image/webp;base64,", d[MIME"image/webp"()], "\" />"))
     elseif haskey(d, MIME"image/gif"())
-        out = Documents.RawHTML(string("<img src=\"data:image/gif;base64,", d[MIME"image/gif"()], "\" />"))
+        rawhtml(string("<img src=\"data:image/gif;base64,", d[MIME"image/gif"()], "\" />"))
     elseif haskey(d, MIME"image/jpeg"())
-        out = Documents.RawHTML(string("<img src=\"data:image/jpeg;base64,", d[MIME"image/jpeg"()], "\" />"))
+        rawhtml(string("<img src=\"data:image/jpeg;base64,", d[MIME"image/jpeg"()], "\" />"))
     elseif haskey(d, MIME"text/latex"())
         # If the show(io, ::MIME"text/latex", x) output is already wrapped in \[ ... \] or $$ ... $$, we
         # unwrap it first, since when we output Markdown.LaTeX objects we put the correct
@@ -2101,13 +2100,15 @@ function mdconvert(d::Dict{MIME,Any}, parent; kwargs...)
         # Make sure to match multiline strings!
         m_bracket = match(r"\s*\\\[(.*)\\\]\s*"s, latex)
         m_dollars = match(r"\s*\$\$(.*)\$\$\s*"s, latex)
-        if m_bracket === nothing && m_dollars === nothing
-            out = Utilities.mdparse(latex; mode = :single)
+        out = if m_bracket === nothing && m_dollars === nothing
+            Utilities.mdparse(latex; mode = :single)
         else
-            out = Markdown.LaTeX(m_bracket !== nothing ? m_bracket[1] : m_dollars[1])
+            Markdown.LaTeX(m_bracket !== nothing ? m_bracket[1] : m_dollars[1])
         end
+        mdconvert(out, parent; kwargs...)
     elseif haskey(d, MIME"text/markdown"())
         out = Markdown.parse(d[MIME"text/markdown"()])
+        mdconvert(out, parent; kwargs...)
     elseif haskey(d, MIME"text/plain"())
         @tags pre
         text = d[MIME"text/plain"()]
@@ -2115,7 +2116,6 @@ function mdconvert(d::Dict{MIME,Any}, parent; kwargs...)
     else
         error("this should never happen.")
     end
-    return mdconvert(out, parent; kwargs...)
 end
 
 # Fallback
@@ -2199,8 +2199,5 @@ fixlinks!(ctx, navnode, t::Markdown.Table) = fixlinks!(ctx, navnode, t.rows)
 
 fixlinks!(ctx, navnode, mds::Vector) = map(md -> fixlinks!(ctx, navnode, md), mds)
 fixlinks!(ctx, navnode, md) = nothing
-
-# TODO: do some regex-magic in raw HTML blocks? Currently ignored.
-#fixlinks!(ctx, navnode, md::Documents.RawHTML) = ...
 
 end


### PR DESCRIPTION
It's not really a document node -- it's only used in one place in `HTMLWriter`, where it can easily be replaced with a simple function call.