### PR TITLE
Restrict the type of the last expression in at-eval blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
   **For upgrading:** To keep using the Markdown backend, refer to the [DocumenterMarkdown package][documentermarkdown]. That package might not immediately support the latest Documenter version, however.
 
+* ![BREAKING][badge-breaking] `@eval` blocks now require the last expression to be either `nothing` or of type `Markdown.MD`, with other cases now issuing a warning and falling back to a text representation in a code block. ([#1919][github-1919])
+
+  **For upgrading:** The cases where an `@eval` results in a object that is not `nothing` or `::Markdown.MD`, the returned object should be reviewed. In case the resulting object is of some `Markdown` node type (e.g. `Markdown.Paragraph` or `Markdown.Table`), it can simply be wrapped in `Markdown.MD([...])` for block nodes, or `Markdown.MD([Markdown.Paragraph([...])])` for inline nodes. In other cases Documenter was likely not handling the returned object in a correct way, but please open an issue if this change has broken a previously working use case.
+
 * ![Enhancement][badge-enhancement] The `ansicolor` keyword to `HTML()` now defaults to true, meaning that executed outputs from `@example`- and `@repl`-blocks are now by default colored (if they emit colored output). ([#1828][github-1828])
 * ![Enhancement][badge-enhancement] Documenter now shows a link to the root of the repository in the top navigation bar. The link is determined automatically from the remote repository, unless overridden or disabled via the `repolink` argument of `HTML`. ([#1254][github-1254])
 * ![Enhancement][badge-enhancement] A more general API is now available to configure the remote repository URLs via the `repo` argument of `makedocs` by passing objects that are subtypes of `Remotes.Remote` and implement its interface (e.g. `Remotes.GitHub`). Documenter will also try to determine `repo` automatically from the `GITHUB_REPOSITORY` environment variable if other fallbacks have failed. ([#1808][github-1808], [#1881][github-1881])
@@ -1134,6 +1138,7 @@
 [github-1906]: https://github.com/JuliaDocs/Documenter.jl/pull/1906
 [github-1908]: https://github.com/JuliaDocs/Documenter.jl/pull/1908
 [github-1909]: https://github.com/JuliaDocs/Documenter.jl/pull/1909
+[github-1919]: https://github.com/JuliaDocs/Documenter.jl/pull/1919
 <!-- end of issue link definitions -->
 
 [julia-29344]: https://github.com/JuliaLang/julia/issues/29344

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -650,7 +650,8 @@ println(iris)
 
 ## `@eval` block
 
-Evaluates the contents of the block and inserts the resulting value into the final document.
+Evaluates the contents of the block and inserts the resulting value into the final document,
+unless the last expression evaluates to `nothing`.
 
 In the following example we use the PyPlot package to generate a plot and display it in the
 final document.
@@ -671,6 +672,10 @@ nothing
 ![](plot.svg)
 ````
 
+Instead of returning `nothing` in the example above we could have returned a new
+`Markdown.MD` object through `Markdown.parse`. This can be more appropriate when the
+filename is not known until evaluation of the block itself.
+
 Another example is to generate markdown tables from machine readable data formats such as CSV or JSON.
 
 ````markdown
@@ -684,14 +689,14 @@ mdtable(df,latex=false)
 
 Which will generate a markdown version of the CSV file table.csv and render it in the output format.
 
+The final expression in an `@eval` block must be either `nothing` or a valid `Markdown.MD`
+object. Other objects will generate a warning and will be rendered in text form as a code block,
+but this behavior can change and should not be relied upon.
+
 Note that each `@eval` block evaluates its contents within a separate module. When
 evaluating each block the present working directory, `pwd`, is set to the directory in
 `build` where the file will be written to, and the paths in `include` calls are interpreted
 to be relative to `pwd`.
-
-Also, instead of returning `nothing` in the example above we could have returned a new
-`Markdown.MD` object through `Markdown.parse`. This can be more appropriate when the
-filename is not known until evaluation of the block itself.
 
 !!! note
 

--- a/src/Documents.jl
+++ b/src/Documents.jl
@@ -164,7 +164,7 @@ end
 
 struct EvalNode
     code   :: Markdown.Code
-    result :: Any
+    result :: Union{Markdown.MD, Nothing}
 end
 
 struct RawNode

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -549,6 +549,18 @@ function Selectors.runner(::Type{EvalBlocks}, x, page, doc)
                     """, exception = err)
             end
         end
+        result = if isa(result, Nothing) || isa(result, Markdown.MD)
+            result
+        else
+            # TODO: we could handle the cases where the user provides some of the Markdown library
+            # objects, like Paragraph.
+            @warn """Invalid type of object in @eval: $(typeof(result)). Should be one of:
+             - Nothing
+             - Markdown.MD
+            Falling back to code block representation.
+            """
+            Markdown.Code("", sprint(show, MIME"text/plain"(), result))
+        end
         page.mapping[x] = EvalNode(x, result)
     end
 end

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -567,7 +567,8 @@ function Selectors.runner(::Type{EvalBlocks}, x, page, doc)
             If you are seeing this warning after upgrading Documenter and this used to work,
             please open an issue on the Documenter issue tracker.
             """
-            Markdown.Code("", sprint(show, MIME"text/plain"(), result))
+            code = Markdown.Code("", sprint(show, MIME"text/plain"(), result))
+            Markdown.MD([code])
         end
         page.mapping[x] = EvalNode(x, result)
     end

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -554,10 +554,18 @@ function Selectors.runner(::Type{EvalBlocks}, x, page, doc)
         else
             # TODO: we could handle the cases where the user provides some of the Markdown library
             # objects, like Paragraph.
-            @warn """Invalid type of object in @eval: $(typeof(result)). Should be one of:
+            @warn """
+            Invalid type of object in @eval in $(Utilities.locrepr(page.source))
+            ```$(x.language)
+            $(x.code)
+            ```
+            Evaluate to `$(typeof(result))`, should be one of
              - Nothing
              - Markdown.MD
             Falling back to code block representation.
+
+            If you are seeing this warning after upgrading Documenter and this used to work,
+            please open an issue on the Documenter issue tracker.
             """
             Markdown.Code("", sprint(show, MIME"text/plain"(), result))
         end

--- a/test/examples/src/man/tutorial.md
+++ b/test/examples/src/man/tutorial.md
@@ -67,7 +67,11 @@ julia> a / b
 ```@eval
 import Markdown
 code = string(sprint(Base.banner), "julia>")
-Markdown.Code(code)
+Markdown.MD([Markdown.Code(code)])
+```
+
+```@eval
+rand(20, 20)
 ```
 
 ```jldoctest


### PR DESCRIPTION
Currently, you are generally allowed to have at-eval to return anything, and the resulting object will get spliced into the document somehow, but we do not really define how we treat arbitrary objects (HTML just `repr`s them and dumps the resulting string as text in the document).

In practice, and based on our docs, most of the time you're expected to either return `nothing` (so nothing gets displayed) or `Markdown.MD` (so you get properly rendered Markdown). This makes that requirement general and explicit, making it easier to support this block in the writers (that now know that it will always be either `nothing` or `Markdown.MD`, and don't have to deal with arbitrary types).

This can be breaking because it was possible to get somewhat reasonable output for some return types and it's possible that people are using it (in particular, I am concerned about cases where people might be returning various `Markdown.*` nodes without wrapping them in `Markdown.MD`). For that reason, this does not make that case quite an error, but instead you get a warning, and the resulting object is `show`ed into a text representation and displayed as a code block (so there is behavior change for users).