### PR TITLE
make binding support `->` function

### DIFF
--- a/src/DocSystem.jl
+++ b/src/DocSystem.jl
@@ -62,6 +62,7 @@ end
 binding(m::Module, x::Expr) =
     Meta.isexpr(x, :.) ? binding(getmod(m, x.args[1]), x.args[2].value) :
     Meta.isexpr(x, [:call, :macrocall, :curly]) ? binding(m, x.args[1]) :
+    Meta.isexpr(x, :->) ? binding(m, x.args[2].args[end]) :
     Meta.isexpr(x, :where) ? binding(m, x.args[1].args[1]) :
         error("`binding` cannot understand expression `$x`.")
 


### PR DESCRIPTION
So that it works for ``[`x -> sin(x)`](@ref)``,
As well as ``[`sin(_)`](@ref)`` if https://github.com/JuliaLang/julia/pull/46633 checked in