### PR TITLE
fix error in relpath_from_repo_root when file not exists

### DIFF
--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -420,6 +420,7 @@ Returns the path of `file`, relative to the root of the Git repository, or `noth
 file is not in a Git repository.
 """
 function relpath_from_repo_root(file)
+    isfile(file) || return nothing
     cd(dirname(file)) do
         root = repo_root(file)
         root !== nothing && startswith(file, root) ? relpath(file, root) : nothing
@@ -427,6 +428,7 @@ function relpath_from_repo_root(file)
 end
 
 function repo_commit(file)
+    isfile(file) || return nothing
     cd(dirname(file)) do
         readchomp(`$(git()) rev-parse HEAD`)
     end

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -420,7 +420,7 @@ Returns the path of `file`, relative to the root of the Git repository, or `noth
 file is not in a Git repository.
 """
 function relpath_from_repo_root(file)
-    isfile(file) || return nothing
+    isfile(file) || error("relpath_from_repo_root called with nonexistent file: $file")
     cd(dirname(file)) do
         root = repo_root(file)
         root !== nothing && startswith(file, root) ? relpath(file, root) : nothing
@@ -428,7 +428,7 @@ function relpath_from_repo_root(file)
 end
 
 function repo_commit(file)
-    isfile(file) || return nothing
+    isfile(file) || error("repo_commit called with nonexistent file: $file")
     cd(dirname(file)) do
         readchomp(`$(git()) rev-parse HEAD`)
     end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -191,8 +191,8 @@ end
             @test Documenter.Utilities.repo_root(filepath; dbdir=".svn") == nothing
             @test Documenter.Utilities.relpath_from_repo_root(filepath) == joinpath("src", "SourceFile.jl")
             # We assume that a temporary file is not in a repo
-            @test Documenter.Utilities.repo_root(tempname()) == nothing
-            @test Documenter.Utilities.relpath_from_repo_root(tempname()) == nothing
+            @test_throws ErrorException Documenter.Utilities.repo_root(tempname())
+            @test_throws ErrorException Documenter.Utilities.relpath_from_repo_root(tempname())
         end
 
         # Test worktree
@@ -213,8 +213,8 @@ end
             @test Documenter.Utilities.repo_root(filepath; dbdir=".svn") == nothing
             @test Documenter.Utilities.relpath_from_repo_root(filepath) == joinpath("src", "SourceFile.jl")
             # We assume that a temporary file is not in a repo
-            @test Documenter.Utilities.repo_root(tempname()) == nothing
-            @test Documenter.Utilities.relpath_from_repo_root(tempname()) == nothing
+            @test_throws ErrorException Documenter.Utilities.repo_root(tempname())
+            @test_throws ErrorException Documenter.Utilities.relpath_from_repo_root(tempname())
         end
 
         # Test submodule
@@ -248,8 +248,8 @@ end
             @test Documenter.Utilities.repo_root(filepath; dbdir=".svn") == nothing
             @test Documenter.Utilities.relpath_from_repo_root(filepath) == joinpath("src", "SourceFile.jl")
             # We assume that a temporary file is not in a repo
-            @test Documenter.Utilities.repo_root(tempname()) == nothing
-            @test Documenter.Utilities.relpath_from_repo_root(tempname()) == nothing
+            @test_throws ErrorException Documenter.Utilities.repo_root(tempname())
+            @test_throws ErrorException Documenter.Utilities.relpath_from_repo_root(tempname())
         end
 
         # This tests the case where the origin.url is some unrecognised Git hosting service, in which case we are unable

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -191,7 +191,7 @@ end
             @test Documenter.Utilities.repo_root(filepath; dbdir=".svn") == nothing
             @test Documenter.Utilities.relpath_from_repo_root(filepath) == joinpath("src", "SourceFile.jl")
             # We assume that a temporary file is not in a repo
-            @test_throws ErrorException Documenter.Utilities.repo_root(tempname())
+            @test Documenter.Utilities.repo_root(tempname()) == nothing
             @test_throws ErrorException Documenter.Utilities.relpath_from_repo_root(tempname())
         end
 
@@ -213,7 +213,7 @@ end
             @test Documenter.Utilities.repo_root(filepath; dbdir=".svn") == nothing
             @test Documenter.Utilities.relpath_from_repo_root(filepath) == joinpath("src", "SourceFile.jl")
             # We assume that a temporary file is not in a repo
-            @test_throws ErrorException Documenter.Utilities.repo_root(tempname())
+            @test Documenter.Utilities.repo_root(tempname()) == nothing
             @test_throws ErrorException Documenter.Utilities.relpath_from_repo_root(tempname())
         end
 
@@ -248,7 +248,7 @@ end
             @test Documenter.Utilities.repo_root(filepath; dbdir=".svn") == nothing
             @test Documenter.Utilities.relpath_from_repo_root(filepath) == joinpath("src", "SourceFile.jl")
             # We assume that a temporary file is not in a repo
-            @test_throws ErrorException Documenter.Utilities.repo_root(tempname())
+            @test Documenter.Utilities.repo_root(tempname()) == nothing
             @test_throws ErrorException Documenter.Utilities.relpath_from_repo_root(tempname())
         end
 


### PR DESCRIPTION
now `relpath_from_repo_root` would fail if file not exists

```
ERROR: LoadError: IOError: cd("/cache/build/default-amdci5-1/julialang/julia-master/usr/share/julia/stdlib/v1.9/CRC32c/src"): no such file or directory (ENOENT)
Stacktrace:
  [1] uv_error
    @ ./libuv.jl:100 [inlined]
  [2] cd(dir::String)
    @ Base.Filesystem ./file.jl:91
  [3] cd(f::Documenter.Utilities.var"#3#4"{String}, dir::String)
    @ Base.Filesystem ./file.jl:111
  [4] relpath_from_repo_root
    @ /cache/build/default-amdci4-6/julialang/julia-master/doc/deps/packages/Documenter/GS7EF/src/Utilities/Utilities.jl:423 [inlined]
  [5] source_url(repo::Documenter.Utilities.Remotes.GitHub, mod::Module, file::String, linerange::UnitRange{Int64})
    @ Documenter.Utilities /cache/build/default-amdci4-6/julialang/julia-master/doc/deps/packages/Documenter/GS7EF/src/Utilities/Utilities.jl:471
```