### PR TITLE
Change styling of code blocks in LaTeXWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
   **For upgrading:** The cases where an `@eval` results in a object that is not `nothing` or `::Markdown.MD`, the returned object should be reviewed. In case the resulting object is of some `Markdown` node type (e.g. `Markdown.Paragraph` or `Markdown.Table`), it can simply be wrapped in `Markdown.MD([...])` for block nodes, or `Markdown.MD([Markdown.Paragraph([...])])` for inline nodes. In other cases Documenter was likely not handling the returned object in a correct way, but please open an issue if this change has broken a previously working use case.
 
-* ![Enhancement][badge-enhancement] Changed the styling of code blocks in the LaTeXWriter. ([#1935][github-1935])
+* ![Enhancement][badge-enhancement] Improved the styling of code blocks in the LaTeXWriter. ([#1933][github-1933], [#1935][github-1935])
 * ![Enhancement][badge-enhancement] The `ansicolor` keyword to `HTML()` now defaults to true, meaning that executed outputs from `@example`- and `@repl`-blocks are now by default colored (if they emit colored output). ([#1828][github-1828])
 * ![Enhancement][badge-enhancement] Documenter now shows a link to the root of the repository in the top navigation bar. The link is determined automatically from the remote repository, unless overridden or disabled via the `repolink` argument of `HTML`. ([#1254][github-1254])
 * ![Enhancement][badge-enhancement] A more general API is now available to configure the remote repository URLs via the `repo` argument of `makedocs` by passing objects that are subtypes of `Remotes.Remote` and implement its interface (e.g. `Remotes.GitHub`). Documenter will also try to determine `repo` automatically from the `GITHUB_REPOSITORY` environment variable if other fallbacks have failed. ([#1808][github-1808], [#1881][github-1881])
@@ -1140,6 +1140,7 @@
 [github-1908]: https://github.com/JuliaDocs/Documenter.jl/pull/1908
 [github-1909]: https://github.com/JuliaDocs/Documenter.jl/pull/1909
 [github-1919]: https://github.com/JuliaDocs/Documenter.jl/pull/1919
+[github-1933]: https://github.com/JuliaDocs/Documenter.jl/issues/1933
 [github-1935]: https://github.com/JuliaDocs/Documenter.jl/pull/1935
 <!-- end of issue link definitions -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
   **For upgrading:** The cases where an `@eval` results in a object that is not `nothing` or `::Markdown.MD`, the returned object should be reviewed. In case the resulting object is of some `Markdown` node type (e.g. `Markdown.Paragraph` or `Markdown.Table`), it can simply be wrapped in `Markdown.MD([...])` for block nodes, or `Markdown.MD([Markdown.Paragraph([...])])` for inline nodes. In other cases Documenter was likely not handling the returned object in a correct way, but please open an issue if this change has broken a previously working use case.
 
+* ![Enhancement][badge-enhancement] Changed the styling of code blocks in the LaTeXWriter. ([#1935][github-1935])
 * ![Enhancement][badge-enhancement] The `ansicolor` keyword to `HTML()` now defaults to true, meaning that executed outputs from `@example`- and `@repl`-blocks are now by default colored (if they emit colored output). ([#1828][github-1828])
 * ![Enhancement][badge-enhancement] Documenter now shows a link to the root of the repository in the top navigation bar. The link is determined automatically from the remote repository, unless overridden or disabled via the `repolink` argument of `HTML`. ([#1254][github-1254])
 * ![Enhancement][badge-enhancement] A more general API is now available to configure the remote repository URLs via the `repo` argument of `makedocs` by passing objects that are subtypes of `Remotes.Remote` and implement its interface (e.g. `Remotes.GitHub`). Documenter will also try to determine `repo` automatically from the `GITHUB_REPOSITORY` environment variable if other fallbacks have failed. ([#1808][github-1808], [#1881][github-1881])
@@ -1139,6 +1140,7 @@
 [github-1908]: https://github.com/JuliaDocs/Documenter.jl/pull/1908
 [github-1909]: https://github.com/JuliaDocs/Documenter.jl/pull/1909
 [github-1919]: https://github.com/JuliaDocs/Documenter.jl/pull/1919
+[github-1935]: https://github.com/JuliaDocs/Documenter.jl/pull/1935
 <!-- end of issue link definitions -->
 
 [julia-29344]: https://github.com/JuliaLang/julia/issues/29344

--- a/assets/latex/documenter.sty
+++ b/assets/latex/documenter.sty
@@ -36,10 +36,10 @@
     basicstyle = \small\ttfamily,
     breaklines = true,
     columns = fullflexible,
-    frame = leftline,
+    backgroundcolor = \color{codeblock-color},
+    frame = none,
     keepspaces = true,
     showstringspaces = false,
-    xleftmargin = 3pt,
 }
 
 \setminted{

--- a/assets/latex/documenter.sty
+++ b/assets/latex/documenter.sty
@@ -22,6 +22,7 @@
 \definecolor{dark-green}{HTML}{3b972e}
 \definecolor{light-purple}{HTML}{aa7dc0}
 \definecolor{dark-purple}{HTML}{945bb0}
+\definecolor{codeblock-background}{gray}{0.96}  
 %
 
 % maths
@@ -44,7 +45,8 @@
 \setminted{
     breaklines = true,
     fontsize = \small,
-    frame = leftline,
+    frame = none,
+    bgcolor = codeblock-background,
 }
 %
 

--- a/assets/latex/documenter.sty
+++ b/assets/latex/documenter.sty
@@ -36,7 +36,7 @@
     basicstyle = \small\ttfamily,
     breaklines = true,
     columns = fullflexible,
-    backgroundcolor = \color{codeblock-color},
+    backgroundcolor = \color{codeblock-background},
     frame = none,
     keepspaces = true,
     showstringspaces = false,

--- a/assets/latex/documenter.sty
+++ b/assets/latex/documenter.sty
@@ -22,7 +22,8 @@
 \definecolor{dark-green}{HTML}{3b972e}
 \definecolor{light-purple}{HTML}{aa7dc0}
 \definecolor{dark-purple}{HTML}{945bb0}
-\definecolor{codeblock-background}{gray}{0.96}  
+\definecolor{codeblock-background}{gray}{0.96}
+\definecolor{codeblock-border}{gray}{0.8}
 %
 
 % maths
@@ -36,8 +37,8 @@
     basicstyle = \small\ttfamily,
     breaklines = true,
     columns = fullflexible,
-    backgroundcolor = \color{codeblock-background},
-    frame = none,
+    rulecolor = \color{codeblock-border},
+    frame = single,
     keepspaces = true,
     showstringspaces = false,
 }


### PR DESCRIPTION
The exact settings are still somewhat up for discussion.

Closes https://github.com/JuliaDocs/Documenter.jl/issues/1933.

Here are two examples where I've been overriding the settings with a `custom.sty`:

 * MathOptInterface:  https://github.com/jump-dev/MathOptInterface.jl/pull/1999
   * https://jump.dev/MathOptInterface.jl/previews/PR1999/MathOptInterface.pdf
 * JuMP: https://github.com/jump-dev/JuMP.jl/pull/3075
   * https://jump.dev/JuMP.jl/previews/PR3075/JuMP.pdf

I think we could still change the styling of non-minted blocks, but I'm not sure the best settings. Here's what it looks like currently:

<img width="484" alt="image" src="https://user-images.githubusercontent.com/8177701/190299975-b71c3fc5-22e5-46ef-a096-20fbc1292642.png">
