### PR TITLE
Improve styling of tables in LaTeXWriter

### DIFF
--- a/assets/latex/documenter.sty
+++ b/assets/latex/documenter.sty
@@ -107,3 +107,7 @@
 \definecolor{admonition-tip}{HTML}{22c35b}
 \definecolor{admonition-compat}{HTML}{1db5c9}
 %
+
+% Styling of tables.
+\usepackage{booktabs}
+%

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -643,7 +643,7 @@ function latex(io::Context, node::Node, table::MarkdownAST.Table)
     _println(io, "\n\\begin{table}[h]\n\\centering")
     _print(io, "\\begin{tabulary}{\\linewidth}")
     _println(io, "{", uppercase(join(spec_to_align.(table.spec), ' ')), "}")
-    _println(io, "\\hline")
+    _println(io, "\\toprule")
     for (i, row) in enumerate(rows)
         for (j, cell) in enumerate(row.children)
             j === 1 || _print(io, " & ")
@@ -651,10 +651,12 @@ function latex(io::Context, node::Node, table::MarkdownAST.Table)
         end
         _println(io, " \\\\")
         if i === 1
-            _println(io, "\\hline")
+            _println(io, "\\toprule")
+        else
+            _println(io, "\\midrule")
         end
     end
-    _println(io, "\\hline")
+    _println(io, "\\bottomrule")
     _println(io, "\\end{tabulary}\n")
     _println(io, "\\end{table}\n")
 end

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -643,17 +643,16 @@ function latex(io::Context, node::Node, table::MarkdownAST.Table)
     _println(io, "\n\\begin{table}[h]\n\\centering")
     _print(io, "\\begin{tabulary}{\\linewidth}")
     _println(io, "{", uppercase(join(spec_to_align.(table.spec), ' ')), "}")
-    _println(io, "\\toprule")
+    rule = "\\toprule"
     for (i, row) in enumerate(rows)
+        _println(io, rule)
         for (j, cell) in enumerate(row.children)
             j === 1 || _print(io, " & ")
             latex(io, cell.children)
         end
         _println(io, " \\\\")
-        if i === 1
-            _println(io, "\\toprule")
-        else
-            _println(io, "\\midrule")
+        if i === 2
+            rule = "\\midrule"
         end
     end
     _println(io, "\\bottomrule")

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -640,18 +640,21 @@ end
 function latex(io::Context, node::Node, table::MarkdownAST.Table)
     rows = MarkdownAST.tablerows(node)
     # latex(io, node.children)
-    _println(io, "\n\\begin{table}[h]")
-    _print(io, "\n\\begin{tabulary}{\\linewidth}")
-    _println(io, "{|", uppercase(join(spec_to_align.(table.spec), '|')), "|}")
+    _println(io, "\n\\begin{table}[h]\n\\centering")
+    _print(io, "\\begin{tabulary}{\\linewidth}")
+    _println(io, "{", uppercase(join(spec_to_align.(table.spec), ' ')), "}")
+    _println(io, "\\hline")
     for (i, row) in enumerate(rows)
-        i === 1 && _println(io, "\\hline")
         for (j, cell) in enumerate(row.children)
             j === 1 || _print(io, " & ")
             latex(io, cell.children)
         end
         _println(io, " \\\\")
-        _println(io, "\\hline")
+        if i === 1
+            _println(io, "\\hline")
+        end
     end
+    _println(io, "\\hline")
     _println(io, "\\end{tabulary}\n")
     _println(io, "\\end{table}\n")
 end

--- a/test/examples/references/latex_showcase.tex
+++ b/test/examples/references/latex_showcase.tex
@@ -482,7 +482,6 @@ object & implemented & value \\
 \texttt{A} & ✓ & 10.00 \\
 \midrule
 \texttt{BB} & ✓ & 1000000.00 \\
-\midrule
 \bottomrule
 \end{tabulary}
 
@@ -506,7 +505,6 @@ object & implemented & value \\
 \texttt{BB} & ✓ & 1000000.00 \\
 \midrule
 \texttt{CC} & v & 1000000.00 \\
-\midrule
 \bottomrule
 \end{tabulary}
 
@@ -528,7 +526,6 @@ object & implemented & value \\
 \texttt{A} & ✓ & 10.00 \\
 \midrule
 \texttt{BBBBBBBBBBBBBBBBBBBB} & ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓ & 1000000000000000000000000000000000000000000000000000000.00 \\
-\midrule
 \bottomrule
 \end{tabulary}
 

--- a/test/examples/references/latex_showcase.tex
+++ b/test/examples/references/latex_showcase.tex
@@ -494,7 +494,7 @@ With explicit alignment.
 
 
 \begin{table}[h]
-\centerings
+\centering
 \begin{tabulary}{\linewidth}{L C R}
 \hline
 object & implemented & value \\

--- a/test/examples/references/latex_showcase.tex
+++ b/test/examples/references/latex_showcase.tex
@@ -474,13 +474,12 @@ Donec vel nibh sapien. Maecenas ultricies mauris sapien. Nunc et sem ac justo ul
 
 
 \begin{table}[h]
-
-\begin{tabulary}{\linewidth}{|R|R|R|}
+\centering
+\begin{tabulary}{\linewidth}{R R R}
 \hline
 object & implemented & value \\
 \hline
 \texttt{A} & ✓ & 10.00 \\
-\hline
 \texttt{BB} & ✓ & 1000000.00 \\
 \hline
 \end{tabulary}
@@ -495,13 +494,12 @@ With explicit alignment.
 
 
 \begin{table}[h]
-
-\begin{tabulary}{\linewidth}{|L|C|R|}
+\centerings
+\begin{tabulary}{\linewidth}{L C R}
 \hline
 object & implemented & value \\
 \hline
 \texttt{A} & ✓ & 10.00 \\
-\hline
 \texttt{BB} & ✓ & 1000000.00 \\
 \hline
 \end{tabulary}
@@ -516,13 +514,12 @@ Tables that are too wide should become scrollable.
 
 
 \begin{table}[h]
-
-\begin{tabulary}{\linewidth}{|L|C|R|}
+\centering
+\begin{tabulary}{\linewidth}{L C R}
 \hline
 object & implemented & value \\
 \hline
 \texttt{A} & ✓ & 10.00 \\
-\hline
 \texttt{BBBBBBBBBBBBBBBBBBBB} & ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓ & 1000000000000000000000000000000000000000000000000000000.00 \\
 \hline
 \end{tabulary}

--- a/test/examples/references/latex_showcase.tex
+++ b/test/examples/references/latex_showcase.tex
@@ -476,12 +476,14 @@ Donec vel nibh sapien. Maecenas ultricies mauris sapien. Nunc et sem ac justo ul
 \begin{table}[h]
 \centering
 \begin{tabulary}{\linewidth}{R R R}
-\hline
+\toprule
 object & implemented & value \\
-\hline
+\toprule
 \texttt{A} & ✓ & 10.00 \\
+\midrule
 \texttt{BB} & ✓ & 1000000.00 \\
-\hline
+\midrule
+\bottomrule
 \end{tabulary}
 
 \end{table}
@@ -496,12 +498,16 @@ With explicit alignment.
 \begin{table}[h]
 \centering
 \begin{tabulary}{\linewidth}{L C R}
-\hline
+\toprule
 object & implemented & value \\
-\hline
+\toprule
 \texttt{A} & ✓ & 10.00 \\
+\midrule
 \texttt{BB} & ✓ & 1000000.00 \\
-\hline
+\midrule
+\texttt{CC} & v & 1000000.00 \\
+\midrule
+\bottomrule
 \end{tabulary}
 
 \end{table}
@@ -516,12 +522,14 @@ Tables that are too wide should become scrollable.
 \begin{table}[h]
 \centering
 \begin{tabulary}{\linewidth}{L C R}
-\hline
+\toprule
 object & implemented & value \\
-\hline
+\toprule
 \texttt{A} & ✓ & 10.00 \\
+\midrule
 \texttt{BBBBBBBBBBBBBBBBBBBB} & ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓ & 1000000000000000000000000000000000000000000000000000000.00 \\
-\hline
+\midrule
+\bottomrule
 \end{tabulary}
 
 \end{table}

--- a/test/examples/src.latex_showcase/showcase.md
+++ b/test/examples/src.latex_showcase/showcase.md
@@ -214,6 +214,7 @@ With explicit alignment.
 | :---   |    :---:    |       ---: |
 | `A`    |      ✓      |      10.00 |
 | `BB`   |      ✓      | 1000000.00 |
+| `CC`   |      v      | 1000000.00 |
 
 Tables that are too wide should become scrollable.
 


### PR DESCRIPTION
The current tables have all borders and don't distinguish headers from subsequent rows.

## Current

<img width="529" alt="image" src="https://user-images.githubusercontent.com/8177701/190526916-b3213e89-4fbd-4359-9344-6d67c7dca510.png">

<img width="650" alt="image" src="https://user-images.githubusercontent.com/8177701/190527128-562e4ab8-bb8a-4e35-94e8-a9862f895d5b.png">

## New

<img width="650" alt="image" src="https://user-images.githubusercontent.com/8177701/190527092-5350990d-05a3-47e9-a683-0214d75ed67a.png">