### PR TITLE
Fix render-this example in LaTeX showcase

### DIFF
--- a/test/examples/references/latex_showcase.tex
+++ b/test/examples/references/latex_showcase.tex
@@ -731,7 +731,7 @@ struct LaTeXRender
 end
 function Base.show(io, ::MIME"text/latex", r::LaTeXRender)
     write(io, """
-    Rendering \texttt{LaTeXRender}: $(r.s)
+    Rendering \\texttt{LaTeXRender}: $(r.s)
     """)
 end
 \end{minted}
@@ -743,7 +743,7 @@ end
 LaTeXRender("render this")
 \end{minted}
 
-Rendering 	exttt{LaTeXRender}: render this
+Rendering \texttt{LaTeXRender}: render this
 
 
 If the last value in an \texttt{@example} block is a \texttt{nothing}, the standard output from the blocks{\textquotesingle} evaluation gets displayed instead

--- a/test/examples/src.latex_showcase/showcase.md
+++ b/test/examples/src.latex_showcase/showcase.md
@@ -306,7 +306,7 @@ struct LaTeXRender
 end
 function Base.show(io, ::MIME"text/latex", r::LaTeXRender)
     write(io, """
-    Rendering \texttt{LaTeXRender}: $(r.s)
+    Rendering \\texttt{LaTeXRender}: $(r.s)
     """)
 end
 nothing # hide


### PR DESCRIPTION
This PR fixes a small bug in the LaTeX tests. I initially suspected I'd borked something while working on the other PRs I have going, but it's just a typo.

Here's what it was previously:

<img width="776" alt="image" src="https://user-images.githubusercontent.com/8177701/190885170-95e777c0-9498-4705-87ed-ee4003e55b9f.png">
