### PR TITLE
Fix title margin of admonitions in LaTeXWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
   **For upgrading:** The cases where an `@eval` results in a object that is not `nothing` or `::Markdown.MD`, the returned object should be reviewed. In case the resulting object is of some `Markdown` node type (e.g. `Markdown.Paragraph` or `Markdown.Table`), it can simply be wrapped in `Markdown.MD([...])` for block nodes, or `Markdown.MD([Markdown.Paragraph([...])])` for inline nodes. In other cases Documenter was likely not handling the returned object in a correct way, but please open an issue if this change has broken a previously working use case.
 
-* ![Enhancement][badge-enhancement] Admonitions are now styled with color in the LaTeX output. ([#1931][github-1931], [#1932][github-1932])
+* ![Enhancement][badge-enhancement] Admonitions are now styled with color in the LaTeX output. ([#1931][github-1931], [#1932][github-1932], [#1946][github-1946], [#1955][github-1955])
 * ![Enhancement][badge-enhancement] Improved the styling of code blocks in the LaTeXWriter. ([#1933][github-1933], [#1935][github-1935])
 * ![Enhancement][badge-enhancement] Automatically resize oversize `tabular` environments from `@example` blocks in LaTeXWriter. ([#1930][github-1930], [#1937][github-1937])
 * ![Enhancement][badge-enhancement] The `ansicolor` keyword to `HTML()` now defaults to true, meaning that executed outputs from `@example`- and `@repl`-blocks are now by default colored (if they emit colored output). ([#1828][github-1828])
@@ -1154,7 +1154,9 @@
 [github-1933]: https://github.com/JuliaDocs/Documenter.jl/issues/1933
 [github-1935]: https://github.com/JuliaDocs/Documenter.jl/pull/1935
 [github-1937]: https://github.com/JuliaDocs/Documenter.jl/pull/1937
+[github-1946]: https://github.com/JuliaDocs/Documenter.jl/issues/1946
 [github-1948]: https://github.com/JuliaDocs/Documenter.jl/pull/1948
+[github-1955]: https://github.com/JuliaDocs/Documenter.jl/pull/1955
 <!-- end of issue link definitions -->
 
 [julia-29344]: https://github.com/JuliaLang/julia/issues/29344

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -586,7 +586,7 @@ function latex(io::Context, node::Node, md::MarkdownAST.Admonition)
     if md.category in ("danger", "warning", "note", "info", "tip", "compat")
         color = "admonition-$(md.category)"
     end
-    _print(io, "\\begin{tcolorbox}[")
+    _print(io, "\\begin{tcolorbox}[toptitle=-2mm,")
     _print(io, "colback=$(color)!50!white,colframe=$(color),")
     _print(io, "title=\\textbf{")
     latexesc(io, md.title)

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -586,7 +586,7 @@ function latex(io::Context, node::Node, md::MarkdownAST.Admonition)
     if md.category in ("danger", "warning", "note", "info", "tip", "compat")
         color = "admonition-$(md.category)"
     end
-    _print(io, "\\begin{tcolorbox}[toptitle=-2mm,")
+    _print(io, "\\begin{tcolorbox}[toptitle=-1mm,bottomtitle=1mm,")
     _print(io, "colback=$(color)!50!white,colframe=$(color),")
     _print(io, "title=\\textbf{")
     latexesc(io, md.title)

--- a/test/examples/references/latex_showcase.tex
+++ b/test/examples/references/latex_showcase.tex
@@ -122,7 +122,7 @@ By default, the HTML output renders equations with \href{https://katex.org/}{KaT
 
 
 
-\begin{tcolorbox}[colback=admonition-warning!50!white,colframe=admonition-warning,title=\textbf{Warning}]
+\begin{tcolorbox}[toptitle=-2mm,colback=admonition-warning!50!white,colframe=admonition-warning,title=\textbf{Warning}]
 Similar to LaTeX, using \texttt{\$} and \texttt{\$\$} to escape inline and display equations also works. However, doing so is deprecated and this functionality may be removed in a future release.
 
 \end{tcolorbox}
@@ -186,7 +186,7 @@ Documenter supports a range of admonition types for different circumstances.
 \label{3427999462323267970}{}
 
 
-\begin{tcolorbox}[colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{{\textquotesingle}note{\textquotesingle} admonition}]
+\begin{tcolorbox}[toptitle=-2mm,colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{{\textquotesingle}note{\textquotesingle} admonition}]
 Admonitions look like this. This is a \texttt{!!! note}-type admonition.
 
 Note that admonitions themselves can contain other block-level elements too, such as code blocks. E.g.
@@ -222,7 +222,7 @@ Headings are OK though:
 \label{3520455154602929669}{}
 
 
-\begin{tcolorbox}[colback=admonition-info!50!white,colframe=admonition-info,title=\textbf{{\textquotesingle}info{\textquotesingle} admonition}]
+\begin{tcolorbox}[toptitle=-2mm,colback=admonition-info!50!white,colframe=admonition-info,title=\textbf{{\textquotesingle}info{\textquotesingle} admonition}]
 This is a \texttt{!!! info}-type admonition. This is the same as a \texttt{!!! note}-type.
 
 \end{tcolorbox}
@@ -235,7 +235,7 @@ This is a \texttt{!!! info}-type admonition. This is the same as a \texttt{!!! n
 \label{8478099471110135607}{}
 
 
-\begin{tcolorbox}[colback=admonition-tip!50!white,colframe=admonition-tip,title=\textbf{{\textquotesingle}tip{\textquotesingle} admonition}]
+\begin{tcolorbox}[toptitle=-2mm,colback=admonition-tip!50!white,colframe=admonition-tip,title=\textbf{{\textquotesingle}tip{\textquotesingle} admonition}]
 This is a \texttt{!!! tip}-type admonition.
 
 \end{tcolorbox}
@@ -248,7 +248,7 @@ This is a \texttt{!!! tip}-type admonition.
 \label{16113256282093947986}{}
 
 
-\begin{tcolorbox}[colback=admonition-warning!50!white,colframe=admonition-warning,title=\textbf{{\textquotesingle}warning{\textquotesingle} admonition}]
+\begin{tcolorbox}[toptitle=-2mm,colback=admonition-warning!50!white,colframe=admonition-warning,title=\textbf{{\textquotesingle}warning{\textquotesingle} admonition}]
 This is a \texttt{!!! warning}-type admonition.
 
 \end{tcolorbox}
@@ -261,7 +261,7 @@ This is a \texttt{!!! warning}-type admonition.
 \label{3138459326559650208}{}
 
 
-\begin{tcolorbox}[colback=admonition-danger!50!white,colframe=admonition-danger,title=\textbf{{\textquotesingle}danger{\textquotesingle} admonition}]
+\begin{tcolorbox}[toptitle=-2mm,colback=admonition-danger!50!white,colframe=admonition-danger,title=\textbf{{\textquotesingle}danger{\textquotesingle} admonition}]
 This is a \texttt{!!! danger}-type admonition.
 
 \end{tcolorbox}
@@ -274,7 +274,7 @@ This is a \texttt{!!! danger}-type admonition.
 \label{8437579397049066350}{}
 
 
-\begin{tcolorbox}[colback=admonition-compat!50!white,colframe=admonition-compat,title=\textbf{{\textquotesingle}compat{\textquotesingle} admonition}]
+\begin{tcolorbox}[toptitle=-2mm,colback=admonition-compat!50!white,colframe=admonition-compat,title=\textbf{{\textquotesingle}compat{\textquotesingle} admonition}]
 This is a \texttt{!!! compat}-type admonition.
 
 \end{tcolorbox}
@@ -287,7 +287,7 @@ This is a \texttt{!!! compat}-type admonition.
 \label{5611698449794175315}{}
 
 
-\begin{tcolorbox}[colback=admonition-default!50!white,colframe=admonition-default,title=\textbf{Unknown admonition class}]
+\begin{tcolorbox}[toptitle=-2mm,colback=admonition-default!50!white,colframe=admonition-default,title=\textbf{Unknown admonition class}]
 Admonition with an unknown admonition class. This is a \texttt{code example}.
 
 \end{tcolorbox}
@@ -396,7 +396,7 @@ Lists can also be included in other blocks that can contain block level items
 
 
 
-\begin{tcolorbox}[colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{Bulleted lists in admonitions}]
+\begin{tcolorbox}[toptitle=-2mm,colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{Bulleted lists in admonitions}]
 \begin{itemize}
 \item Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 
@@ -410,7 +410,7 @@ Lists can also be included in other blocks that can contain block level items
 \end{tcolorbox}
 
 
-\begin{tcolorbox}[colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{Large lists in admonitions}]
+\begin{tcolorbox}[toptitle=-2mm,colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{Large lists in admonitions}]
 \begin{itemize}
 \item Morbi et varius nisl, eu semper orci.
 
@@ -652,7 +652,7 @@ Footnote with more block contents.\footnotemark[3]
 
 \footnotetext[3]{And a link to another footnote\footnotemark[1].
 
-\begin{tcolorbox}[colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{Admonition..}]
+\begin{tcolorbox}[toptitle=-2mm,colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{Admonition..}]
 .. in a footnote.
 
 \end{tcolorbox}
@@ -702,7 +702,7 @@ To see an example of a level 1 heading see the page title and for level 2 headin
 
 
 
-\begin{tcolorbox}[colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{Headings in sidebars}]
+\begin{tcolorbox}[toptitle=-2mm,colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{Headings in sidebars}]
 Level 1 and 2 heading show up in the sidebar, for the current page.
 
 \end{tcolorbox}
@@ -1212,7 +1212,7 @@ Missing docstring:
 
 
 
-\begin{tcolorbox}[colback=admonition-warning!50!white,colframe=admonition-warning,title=\textbf{Missing docstring.}]
+\begin{tcolorbox}[toptitle=-2mm,colback=admonition-warning!50!white,colframe=admonition-warning,title=\textbf{Missing docstring.}]
 Missing docstring for \texttt{this\_docstring\_does\_not\_exist}. Check Documenter{\textquotesingle}s build log for details.
 
 \end{tcolorbox}
@@ -1227,7 +1227,7 @@ Display equation:
 
 \begin{equation*}
 \begin{split}\frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2}\end{split}\end{equation*}
-\begin{tcolorbox}[colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{Long equations in admonitions}]
+\begin{tcolorbox}[toptitle=-2mm,colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{Long equations in admonitions}]
 Inline: \(\frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2}\)
 
 Display equation:

--- a/test/examples/references/latex_showcase.tex
+++ b/test/examples/references/latex_showcase.tex
@@ -122,7 +122,7 @@ By default, the HTML output renders equations with \href{https://katex.org/}{KaT
 
 
 
-\begin{tcolorbox}[toptitle=-2mm,colback=admonition-warning!50!white,colframe=admonition-warning,title=\textbf{Warning}]
+\begin{tcolorbox}[toptitle=-1mm,bottomtitle=1mm,colback=admonition-warning!50!white,colframe=admonition-warning,title=\textbf{Warning}]
 Similar to LaTeX, using \texttt{\$} and \texttt{\$\$} to escape inline and display equations also works. However, doing so is deprecated and this functionality may be removed in a future release.
 
 \end{tcolorbox}
@@ -186,7 +186,7 @@ Documenter supports a range of admonition types for different circumstances.
 \label{3427999462323267970}{}
 
 
-\begin{tcolorbox}[toptitle=-2mm,colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{{\textquotesingle}note{\textquotesingle} admonition}]
+\begin{tcolorbox}[toptitle=-1mm,bottomtitle=1mm,colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{{\textquotesingle}note{\textquotesingle} admonition}]
 Admonitions look like this. This is a \texttt{!!! note}-type admonition.
 
 Note that admonitions themselves can contain other block-level elements too, such as code blocks. E.g.
@@ -222,7 +222,7 @@ Headings are OK though:
 \label{3520455154602929669}{}
 
 
-\begin{tcolorbox}[toptitle=-2mm,colback=admonition-info!50!white,colframe=admonition-info,title=\textbf{{\textquotesingle}info{\textquotesingle} admonition}]
+\begin{tcolorbox}[toptitle=-1mm,bottomtitle=1mm,colback=admonition-info!50!white,colframe=admonition-info,title=\textbf{{\textquotesingle}info{\textquotesingle} admonition}]
 This is a \texttt{!!! info}-type admonition. This is the same as a \texttt{!!! note}-type.
 
 \end{tcolorbox}
@@ -235,7 +235,7 @@ This is a \texttt{!!! info}-type admonition. This is the same as a \texttt{!!! n
 \label{8478099471110135607}{}
 
 
-\begin{tcolorbox}[toptitle=-2mm,colback=admonition-tip!50!white,colframe=admonition-tip,title=\textbf{{\textquotesingle}tip{\textquotesingle} admonition}]
+\begin{tcolorbox}[toptitle=-1mm,bottomtitle=1mm,colback=admonition-tip!50!white,colframe=admonition-tip,title=\textbf{{\textquotesingle}tip{\textquotesingle} admonition}]
 This is a \texttt{!!! tip}-type admonition.
 
 \end{tcolorbox}
@@ -248,7 +248,7 @@ This is a \texttt{!!! tip}-type admonition.
 \label{16113256282093947986}{}
 
 
-\begin{tcolorbox}[toptitle=-2mm,colback=admonition-warning!50!white,colframe=admonition-warning,title=\textbf{{\textquotesingle}warning{\textquotesingle} admonition}]
+\begin{tcolorbox}[toptitle=-1mm,bottomtitle=1mm,colback=admonition-warning!50!white,colframe=admonition-warning,title=\textbf{{\textquotesingle}warning{\textquotesingle} admonition}]
 This is a \texttt{!!! warning}-type admonition.
 
 \end{tcolorbox}
@@ -261,7 +261,7 @@ This is a \texttt{!!! warning}-type admonition.
 \label{3138459326559650208}{}
 
 
-\begin{tcolorbox}[toptitle=-2mm,colback=admonition-danger!50!white,colframe=admonition-danger,title=\textbf{{\textquotesingle}danger{\textquotesingle} admonition}]
+\begin{tcolorbox}[toptitle=-1mm,bottomtitle=1mm,colback=admonition-danger!50!white,colframe=admonition-danger,title=\textbf{{\textquotesingle}danger{\textquotesingle} admonition}]
 This is a \texttt{!!! danger}-type admonition.
 
 \end{tcolorbox}
@@ -274,7 +274,7 @@ This is a \texttt{!!! danger}-type admonition.
 \label{8437579397049066350}{}
 
 
-\begin{tcolorbox}[toptitle=-2mm,colback=admonition-compat!50!white,colframe=admonition-compat,title=\textbf{{\textquotesingle}compat{\textquotesingle} admonition}]
+\begin{tcolorbox}[toptitle=-1mm,bottomtitle=1mm,colback=admonition-compat!50!white,colframe=admonition-compat,title=\textbf{{\textquotesingle}compat{\textquotesingle} admonition}]
 This is a \texttt{!!! compat}-type admonition.
 
 \end{tcolorbox}
@@ -287,7 +287,7 @@ This is a \texttt{!!! compat}-type admonition.
 \label{5611698449794175315}{}
 
 
-\begin{tcolorbox}[toptitle=-2mm,colback=admonition-default!50!white,colframe=admonition-default,title=\textbf{Unknown admonition class}]
+\begin{tcolorbox}[toptitle=-1mm,bottomtitle=1mm,colback=admonition-default!50!white,colframe=admonition-default,title=\textbf{Unknown admonition class}]
 Admonition with an unknown admonition class. This is a \texttt{code example}.
 
 \end{tcolorbox}
@@ -396,7 +396,7 @@ Lists can also be included in other blocks that can contain block level items
 
 
 
-\begin{tcolorbox}[toptitle=-2mm,colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{Bulleted lists in admonitions}]
+\begin{tcolorbox}[toptitle=-1mm,bottomtitle=1mm,colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{Bulleted lists in admonitions}]
 \begin{itemize}
 \item Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 
@@ -410,7 +410,7 @@ Lists can also be included in other blocks that can contain block level items
 \end{tcolorbox}
 
 
-\begin{tcolorbox}[toptitle=-2mm,colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{Large lists in admonitions}]
+\begin{tcolorbox}[toptitle=-1mm,bottomtitle=1mm,colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{Large lists in admonitions}]
 \begin{itemize}
 \item Morbi et varius nisl, eu semper orci.
 
@@ -652,7 +652,7 @@ Footnote with more block contents.\footnotemark[3]
 
 \footnotetext[3]{And a link to another footnote\footnotemark[1].
 
-\begin{tcolorbox}[toptitle=-2mm,colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{Admonition..}]
+\begin{tcolorbox}[toptitle=-1mm,bottomtitle=1mm,colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{Admonition..}]
 .. in a footnote.
 
 \end{tcolorbox}
@@ -702,7 +702,7 @@ To see an example of a level 1 heading see the page title and for level 2 headin
 
 
 
-\begin{tcolorbox}[toptitle=-2mm,colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{Headings in sidebars}]
+\begin{tcolorbox}[toptitle=-1mm,bottomtitle=1mm,colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{Headings in sidebars}]
 Level 1 and 2 heading show up in the sidebar, for the current page.
 
 \end{tcolorbox}
@@ -1212,7 +1212,7 @@ Missing docstring:
 
 
 
-\begin{tcolorbox}[toptitle=-2mm,colback=admonition-warning!50!white,colframe=admonition-warning,title=\textbf{Missing docstring.}]
+\begin{tcolorbox}[toptitle=-1mm,bottomtitle=1mm,colback=admonition-warning!50!white,colframe=admonition-warning,title=\textbf{Missing docstring.}]
 Missing docstring for \texttt{this\_docstring\_does\_not\_exist}. Check Documenter{\textquotesingle}s build log for details.
 
 \end{tcolorbox}
@@ -1227,7 +1227,7 @@ Display equation:
 
 \begin{equation*}
 \begin{split}\frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2}\end{split}\end{equation*}
-\begin{tcolorbox}[toptitle=-2mm,colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{Long equations in admonitions}]
+\begin{tcolorbox}[toptitle=-1mm,bottomtitle=1mm,colback=admonition-note!50!white,colframe=admonition-note,title=\textbf{Long equations in admonitions}]
 Inline: \(\frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2}\)
 
 Display equation:

--- a/test/examples/references/latex_simple.tex
+++ b/test/examples/references/latex_simple.tex
@@ -57,7 +57,7 @@ julia> 127 % Int8
 
 
 
-\begin{tcolorbox}[colback=admonition-info!50!white,colframe=admonition-info,title=\textbf{{\textasciitilde}, {\textasciicircum}, {\textbackslash}, {\textquotesingle}, {\textquotedbl}, \_, \&, \%, {\textbackslash}, \$, \#, \{ and \}.}]
+\begin{tcolorbox}[toptitle=-2mm,colback=admonition-info!50!white,colframe=admonition-info,title=\textbf{{\textasciitilde}, {\textasciicircum}, {\textbackslash}, {\textquotesingle}, {\textquotedbl}, \_, \&, \%, {\textbackslash}, \$, \#, \{ and \}.}]
 {\textasciitilde}, {\textasciicircum}, {\textbackslash}, {\textquotesingle}, {\textquotedbl}, \_, \&, \%, {\textbackslash}, \$, \#, \{ and \}.
 
 \end{tcolorbox}

--- a/test/examples/references/latex_simple.tex
+++ b/test/examples/references/latex_simple.tex
@@ -57,7 +57,7 @@ julia> 127 % Int8
 
 
 
-\begin{tcolorbox}[toptitle=-2mm,colback=admonition-info!50!white,colframe=admonition-info,title=\textbf{{\textasciitilde}, {\textasciicircum}, {\textbackslash}, {\textquotesingle}, {\textquotedbl}, \_, \&, \%, {\textbackslash}, \$, \#, \{ and \}.}]
+\begin{tcolorbox}[toptitle=-1mm,bottomtitle=1mm,colback=admonition-info!50!white,colframe=admonition-info,title=\textbf{{\textasciitilde}, {\textasciicircum}, {\textbackslash}, {\textquotesingle}, {\textquotedbl}, \_, \&, \%, {\textbackslash}, \$, \#, \{ and \}.}]
 {\textasciitilde}, {\textasciicircum}, {\textbackslash}, {\textquotesingle}, {\textquotedbl}, \_, \&, \%, {\textbackslash}, \$, \#, \{ and \}.
 
 \end{tcolorbox}


### PR DESCRIPTION
Closes #1946 

The default should be 0mm, so it must be some package that's mucking with this? I couldn't find the exact height is being modified, so let's just check how this looks in the PDFs created by CI. It looks okay locally.