### PR TITLE
Make code block styling in LaTeXWriter consistent with HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
   **For upgrading:** The cases where an `@eval` results in a object that is not `nothing` or `::Markdown.MD`, the returned object should be reviewed. In case the resulting object is of some `Markdown` node type (e.g. `Markdown.Paragraph` or `Markdown.Table`), it can simply be wrapped in `Markdown.MD([...])` for block nodes, or `Markdown.MD([Markdown.Paragraph([...])])` for inline nodes. In other cases Documenter was likely not handling the returned object in a correct way, but please open an issue if this change has broken a previously working use case.
 
 * ![Enhancement][badge-enhancement] Admonitions are now styled with color in the LaTeX output. ([#1931][github-1931], [#1932][github-1932])
-* ![Enhancement][badge-enhancement] Improved the styling of code blocks in the LaTeXWriter. ([#1933][github-1933], [#1935][github-1935])
+* ![Enhancement][badge-enhancement] Improved the styling of code blocks in the LaTeXWriter. ([#1933][github-1933], [#1935][github-1935], [#1944][github-1944], [#1956][github-1956])
 * ![Enhancement][badge-enhancement] Automatically resize oversize `tabular` environments from `@example` blocks in LaTeXWriter. ([#1930][github-1930], [#1937][github-1937])
 * ![Enhancement][badge-enhancement] The `ansicolor` keyword to `HTML()` now defaults to true, meaning that executed outputs from `@example`- and `@repl`-blocks are now by default colored (if they emit colored output). ([#1828][github-1828])
 * ![Enhancement][badge-enhancement] Documenter now shows a link to the root of the repository in the top navigation bar. The link is determined automatically from the remote repository, unless overridden or disabled via the `repolink` argument of `HTML`. ([#1254][github-1254])
@@ -1154,7 +1154,9 @@
 [github-1933]: https://github.com/JuliaDocs/Documenter.jl/issues/1933
 [github-1935]: https://github.com/JuliaDocs/Documenter.jl/pull/1935
 [github-1937]: https://github.com/JuliaDocs/Documenter.jl/pull/1937
+[github-1944]: https://github.com/JuliaDocs/Documenter.jl/issues/1944
 [github-1948]: https://github.com/JuliaDocs/Documenter.jl/pull/1948
+[github-1956]: https://github.com/JuliaDocs/Documenter.jl/pull/1956
 <!-- end of issue link definitions -->
 
 [julia-29344]: https://github.com/JuliaLang/julia/issues/29344

--- a/assets/latex/documenter.sty
+++ b/assets/latex/documenter.sty
@@ -41,6 +41,8 @@
     frame = single,
     keepspaces = true,
     showstringspaces = false,
+    xleftmargin = 3.25pt,
+    xrightmargin = 3.25pt,
 }
 
 \setminted{

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -491,13 +491,13 @@ end
 const LEXER = Set([
     "julia",
     "jlcon",
-    "raw",
+    "text",
 ])
 
 function latex(io::Context, node::Node, code::MarkdownAST.CodeBlock)
     language = Utilities.codelang(code.info)
     if isempty(language)
-        language = "raw"
+        language = "text"
     elseif language == "julia-repl"
         language = "jlcon"  # the julia-repl is called "jlcon" in Pygments
     end

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -457,7 +457,9 @@ function latex(io::Context, ::Node, d::Dict{MIME,Any})
     elseif haskey(d, MIME"text/plain"())
         text = d[MIME"text/plain"()]
         out = repr(MIME"text/plain"(), ANSIColoredPrinters.PlainTextPrinter(IOBuffer(text)))
-        codeblock = MarkdownAST.CodeBlock("", out)
+        # We set a "fake" language as text/plain so that the writer knows how to
+        # deal with it.
+        codeblock = MarkdownAST.CodeBlock("text/plain", out)
         latex(io, MarkdownAST.Node(codeblock))
     else
         error("this should never happen.")
@@ -489,13 +491,16 @@ end
 const LEXER = Set([
     "julia",
     "jlcon",
+    "raw",
 ])
 
 function latex(io::Context, node::Node, code::MarkdownAST.CodeBlock)
     language = Utilities.codelang(code.info)
-    language = isempty(language) ? "none" :
-        (language == "julia-repl") ? "jlcon" : # the julia-repl is called "jlcon" in Pygments
-        language
+    if isempty(language)
+        language = "raw"
+    elseif language == "julia-repl"
+        language = "jlcon"  # the julia-repl is called "jlcon" in Pygments
+    end
     text = IOBuffer(code.code)
     code_code = repr(MIME"text/plain"(), ANSIColoredPrinters.PlainTextPrinter(text))
     escape = '⊻' ∈ code_code

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -500,6 +500,9 @@ function latex(io::Context, node::Node, code::MarkdownAST.CodeBlock)
         language = "text"
     elseif language == "julia-repl"
         language = "jlcon"  # the julia-repl is called "jlcon" in Pygments
+    elseif !(language in LEXER) && language != "text/plain"
+        # For all others, like ```python or ```markdown, render as text.
+        language = "text"
     end
     text = IOBuffer(code.code)
     code_code = repr(MIME"text/plain"(), ANSIColoredPrinters.PlainTextPrinter(text))
@@ -517,6 +520,9 @@ function latex(io::Context, node::Node, code::MarkdownAST.CodeBlock)
         end
         _println(io, "\n\\end{minted}\n")
     else
+        # The only blocks that use {lstlisting} are `text/plain` renders of
+        # Julia output.
+        @assert language == "text/plain"
         _print(io, "\n\\begin{lstlisting}")
         if escape
             _println(io, "[escapeinside=\\%\\%]")

--- a/test/examples/references/latex_showcase.tex
+++ b/test/examples/references/latex_showcase.tex
@@ -759,11 +759,11 @@ Script-style doctests are supported too:
 
 
 
-\begin{lstlisting}
+\begin{minted}{text}
 ```@example
 2 + 3
 ```
-\end{lstlisting}
+\end{minted}
 
 
 
@@ -923,11 +923,11 @@ Output from \hyperlinkref{16839343392674353047}{\texttt{@repl} block}s and \hype
 
 
 
-\begin{lstlisting}
+\begin{minted}{text}
 ```@repl
 printstyled("This should be in bold light cyan.", color=:light_cyan, bold=true)
 ```
-\end{lstlisting}
+\end{minted}
 
 
 
@@ -948,11 +948,11 @@ This should be in bold cyan.
 
 
 
-\begin{lstlisting}
+\begin{minted}{text}
 ```@repl; ansicolor=false
 printstyled("This should be in bold light cyan.", color=:light_cyan, bold=true)
 ```
-\end{lstlisting}
+\end{minted}
 
 
 

--- a/test/examples/references/latex_showcase.tex
+++ b/test/examples/references/latex_showcase.tex
@@ -79,10 +79,10 @@ Code blocks are rendered as follows:
 
 
 
-\begin{lstlisting}
+\begin{minted}{raw}
 This is an non-highlighted code block.
 ... Rendered in monospace.
-\end{lstlisting}
+\end{minted}
 
 
 
@@ -168,10 +168,10 @@ Each admonition begins with three \texttt{!!!}, and then the content is indented
 
 
 
-\begin{lstlisting}
+\begin{minted}{raw}
 !!! note "An optional title"
     Here is something you should pay attention to.
-\end{lstlisting}
+\end{minted}
 
 
 
@@ -1240,7 +1240,7 @@ Long equations in footnotes.[{\textasciicircum}longeq-footnote]
 [{\textasciicircum}longeq-footnote]:
 
 
-\begin{lstlisting}
+\begin{minted}{raw}
 Inline: ``\frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2}``
 
 Display equation:
@@ -1248,7 +1248,7 @@ Display equation:
 ```math
 \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2}
 ```
-\end{lstlisting}
+\end{minted}
 
 
 

--- a/test/examples/references/latex_showcase.tex
+++ b/test/examples/references/latex_showcase.tex
@@ -79,7 +79,7 @@ Code blocks are rendered as follows:
 
 
 
-\begin{minted}{raw}
+\begin{minted}{text}
 This is an non-highlighted code block.
 ... Rendered in monospace.
 \end{minted}
@@ -168,7 +168,7 @@ Each admonition begins with three \texttt{!!!}, and then the content is indented
 
 
 
-\begin{minted}{raw}
+\begin{minted}{text}
 !!! note "An optional title"
     Here is something you should pay attention to.
 \end{minted}
@@ -1240,7 +1240,7 @@ Long equations in footnotes.[{\textasciicircum}longeq-footnote]
 [{\textasciicircum}longeq-footnote]:
 
 
-\begin{minted}{raw}
+\begin{minted}{text}
 Inline: ``\frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2}``
 
 Display equation:


### PR DESCRIPTION
Closes #1944 

Now
````
```
A code block
```

```@example
1 + 1
```
````

produces

<img width="570" alt="image" src="https://user-images.githubusercontent.com/8177701/192976358-6cb38a4e-921f-4b81-8f82-4220b723cbfb.png">

The raw code blocks have a gray background `{minted}` with `text` as the language, and `text/plain` outputs are left as `{lstlisting}`s.

I also pulled in the margins of the `{lstlisting}` because they were slightly wider than the `{minted}` environments.