### PR TITLE
Switch to use {minted} for code output in LaTeXWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
   **For upgrading:** The cases where an `@eval` results in a object that is not `nothing` or `::Markdown.MD`, the returned object should be reviewed. In case the resulting object is of some `Markdown` node type (e.g. `Markdown.Paragraph` or `Markdown.Table`), it can simply be wrapped in `Markdown.MD([...])` for block nodes, or `Markdown.MD([Markdown.Paragraph([...])])` for inline nodes. In other cases Documenter was likely not handling the returned object in a correct way, but please open an issue if this change has broken a previously working use case.
 
 * ![Enhancement][badge-enhancement] Admonitions are now styled with color in the LaTeX output. ([#1931][github-1931], [#1932][github-1932], [#1946][github-1946], [#1955][github-1955])
-* ![Enhancement][badge-enhancement] Improved the styling of code blocks in the LaTeXWriter. ([#1933][github-1933], [#1935][github-1935], [#1944][github-1944], [#1956][github-1956])
+* ![Enhancement][badge-enhancement] Improved the styling of code blocks in the LaTeXWriter. ([#1933][github-1933], [#1935][github-1935], [#1936][github-1936], [#1944][github-1944], [#1956][github-1956], [#1957][github-1957])
 * ![Enhancement][badge-enhancement] Automatically resize oversize `tabular` environments from `@example` blocks in LaTeXWriter. ([#1930][github-1930], [#1937][github-1937])
 * ![Enhancement][badge-enhancement] The `ansicolor` keyword to `HTML()` now defaults to true, meaning that executed outputs from `@example`- and `@repl`-blocks are now by default colored (if they emit colored output). ([#1828][github-1828])
 * ![Enhancement][badge-enhancement] Documenter now shows a link to the root of the repository in the top navigation bar. The link is determined automatically from the remote repository, unless overridden or disabled via the `repolink` argument of `HTML`. ([#1254][github-1254])
@@ -1153,12 +1153,14 @@
 [github-1932]: https://github.com/JuliaDocs/Documenter.jl/pull/1932
 [github-1933]: https://github.com/JuliaDocs/Documenter.jl/issues/1933
 [github-1935]: https://github.com/JuliaDocs/Documenter.jl/pull/1935
+[github-1936]: https://github.com/JuliaDocs/Documenter.jl/issues/1936
 [github-1937]: https://github.com/JuliaDocs/Documenter.jl/pull/1937
 [github-1944]: https://github.com/JuliaDocs/Documenter.jl/issues/1944
 [github-1946]: https://github.com/JuliaDocs/Documenter.jl/issues/1946
 [github-1948]: https://github.com/JuliaDocs/Documenter.jl/pull/1948
 [github-1955]: https://github.com/JuliaDocs/Documenter.jl/pull/1955
 [github-1956]: https://github.com/JuliaDocs/Documenter.jl/pull/1956
+[github-1957]: https://github.com/JuliaDocs/Documenter.jl/pull/1957
 <!-- end of issue link definitions -->
 
 [julia-29344]: https://github.com/JuliaLang/julia/issues/29344

--- a/assets/latex/documenter.sty
+++ b/assets/latex/documenter.sty
@@ -31,20 +31,7 @@
 %
 
 % listings
-\usepackage{listings, minted}
-
-\lstset{
-    basicstyle = \small\ttfamily,
-    breaklines = true,
-    columns = fullflexible,
-    rulecolor = \color{codeblock-border},
-    frame = single,
-    keepspaces = true,
-    showstringspaces = false,
-    xleftmargin = 3.25pt,
-    xrightmargin = 3.25pt,
-}
-
+\usepackage{minted}
 \setminted{
     breaklines = true,
     fontsize = \small,

--- a/assets/latex/documenter.sty
+++ b/assets/latex/documenter.sty
@@ -37,6 +37,7 @@
     fontsize = \small,
     frame = none,
     bgcolor = codeblock-background,
+    rulecolor=codeblock-border,
 }
 %
 

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -512,7 +512,7 @@ function latex(io::Context, node::Node, code::MarkdownAST.CodeBlock)
     if language == "text/plain"
         _print(io, escape ? "," : "[")
         # Special-case the formatting of code outputs from Julia.
-        _println(io, "bgcolor=white,frame=single,rulecolor=codeblock-border]{text}")
+        _println(io, "xleftmargin=-\\fboxsep,xrightmargin=-\\fboxsep,bgcolor=white,frame=single]{text}")
     else
         _println(io, escape ? "]{" : "{", language, "}")
     end

--- a/test/examples/references/latex_showcase.tex
+++ b/test/examples/references/latex_showcase.tex
@@ -761,7 +761,7 @@ Script-style doctests are supported too:
 
 \begin{minted}{text}
 ```@example
-2 + 3
+typeof(π)
 ```
 \end{minted}
 
@@ -773,13 +773,13 @@ becomes the following code-output block pair
 
 
 \begin{minted}{julia}
-2 + 3
+typeof(π)
 \end{minted}
 
 
-\begin{lstlisting}
-5
-\end{lstlisting}
+\begin{minted}[bgcolor=white,frame=single,rulecolor=codeblock-border]{text}
+Irrational{:π}
+\end{minted}
 
 
 
@@ -819,9 +819,9 @@ println("Hello World")
 \end{minted}
 
 
-\begin{lstlisting}
+\begin{minted}[bgcolor=white,frame=single,rulecolor=codeblock-border]{text}
 Hello World
-\end{lstlisting}
+\end{minted}
 
 
 
@@ -836,9 +836,9 @@ println("Hello World")
 \end{minted}
 
 
-\begin{lstlisting}
+\begin{minted}[bgcolor=white,frame=single,rulecolor=codeblock-border]{text}
 42
-\end{lstlisting}
+\end{minted}
 
 
 
@@ -894,9 +894,9 @@ x + 1
 \end{minted}
 
 
-\begin{lstlisting}
+\begin{minted}[bgcolor=white,frame=single,rulecolor=codeblock-border]{text}
 6
-\end{lstlisting}
+\end{minted}
 
 
 
@@ -986,11 +986,11 @@ print("\e[m")
 \end{minted}
 
 
-\begin{lstlisting}
+\begin{minted}[bgcolor=white,frame=single,rulecolor=codeblock-border]{text}
     0     1     2     3     4     5     6     7
     8     9    10    11    12    13    14    15
 
-\end{lstlisting}
+\end{minted}
 
 
 

--- a/test/examples/references/latex_showcase.tex
+++ b/test/examples/references/latex_showcase.tex
@@ -777,7 +777,7 @@ typeof(π)
 \end{minted}
 
 
-\begin{minted}[bgcolor=white,frame=single,rulecolor=codeblock-border]{text}
+\begin{minted}[xleftmargin=-\fboxsep,xrightmargin=-\fboxsep,bgcolor=white,frame=single]{text}
 Irrational{:π}
 \end{minted}
 
@@ -819,7 +819,7 @@ println("Hello World")
 \end{minted}
 
 
-\begin{minted}[bgcolor=white,frame=single,rulecolor=codeblock-border]{text}
+\begin{minted}[xleftmargin=-\fboxsep,xrightmargin=-\fboxsep,bgcolor=white,frame=single]{text}
 Hello World
 \end{minted}
 
@@ -836,7 +836,7 @@ println("Hello World")
 \end{minted}
 
 
-\begin{minted}[bgcolor=white,frame=single,rulecolor=codeblock-border]{text}
+\begin{minted}[xleftmargin=-\fboxsep,xrightmargin=-\fboxsep,bgcolor=white,frame=single]{text}
 42
 \end{minted}
 
@@ -894,7 +894,7 @@ x + 1
 \end{minted}
 
 
-\begin{minted}[bgcolor=white,frame=single,rulecolor=codeblock-border]{text}
+\begin{minted}[xleftmargin=-\fboxsep,xrightmargin=-\fboxsep,bgcolor=white,frame=single]{text}
 6
 \end{minted}
 
@@ -986,7 +986,7 @@ print("\e[m")
 \end{minted}
 
 
-\begin{minted}[bgcolor=white,frame=single,rulecolor=codeblock-border]{text}
+\begin{minted}[xleftmargin=-\fboxsep,xrightmargin=-\fboxsep,bgcolor=white,frame=single]{text}
     0     1     2     3     4     5     6     7
     8     9    10    11    12    13    14    15
 

--- a/test/examples/src.latex_showcase/showcase.md
+++ b/test/examples/src.latex_showcase/showcase.md
@@ -322,14 +322,14 @@ E.g. the following Markdown
 
 ````markdown
 ```@example
-2 + 3
+typeof(π)
 ```
 ````
 
 becomes the following code-output block pair
 
 ```@example
-2 + 3
+typeof(π)
 ```
 
 If the last element can be rendered as `text/latex`:


### PR DESCRIPTION
Closes #1936

Fixes formatting issues like this from the JuMP documentation: https://jump.dev/JuMP.jl/previews/PR3094/JuMP.pdf

<img width="934" alt="image" src="https://user-images.githubusercontent.com/8177701/193182447-72b253e6-db19-4294-84ec-c436432edbd4.png">
