### PR TITLE
Don't throw in source_url() due to a non-existing source file

### DIFF
--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -467,7 +467,7 @@ function source_url(repo, mod, file, linerange)
             Base.GIT_VERSION_INFO.commit
         end
         repofile(julia_remote, ref, "base/$file", linerange)
-    else
+    elseif isfile(file)
         path = relpath_from_repo_root(file)
         # If we managed to determine a remote for the current file with getremote,
         # then we use that information instead of the user-provided repo (doc.user.remote)
@@ -487,6 +487,8 @@ function source_url(repo, mod, file, linerange)
             return nothing
         end
         repofile(remote, repo_commit(file), path, linerange)
+    else
+        return nothing
     end
 end
 


### PR DESCRIPTION
@clouds56: sorry it took me this long to get back to you on #1923, but I think this fix is more correct. `relpath_from_repo_root` and `repo_commit` are only called in `edit_url` and `source_url`, and they should never get called with a non-existing file. That `source_url` sometimes does was an oversight from #1808.

It might still be a good idea to add an `isfile(file) || error("...")` to those functions though, just to explicitly catch this case in the future, and you're welcome to update the PR with that.

This should fix the CI errors you reported, which I'm testing over at https://github.com/JuliaLang/julia/pull/47105.