### PR TITLE
Toggle assumption on `curl` failure

### DIFF
--- a/src/deployconfig.jl
+++ b/src/deployconfig.jl
@@ -526,9 +526,9 @@ function verify_github_pull_repository(repo, prnr)
         @debug "pr_head_repo = '$pr_head_repo' vs repo = '$repo'"
         return (pr_head_repo == repo)
     catch e
-        @warn "Unable to verify if PR comes from destination repository -- assuming it does."
+        @warn "Unable to verify if PR comes from destination repository -- assuming it doesn't."
         @debug "Running CURL led to an exception:" exception = (e, catch_backtrace())
-        return true
+        return false
     end
 end
 


### PR DESCRIPTION
Don't assume the `PR` comes from destination repository, on `curl` failure (`preview` deployment is likely to fail, because of missing `DOCUMENTER_KEY`: [secrets are not passed to the runner when a workflow is triggered from a fork](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow)).

Fix https://github.com/JuliaDocs/Documenter.jl/issues/1965.

Of course, fixing the underlying `curl` issue (constantly reproducible, since ~1month) would be even better.