### PR TITLE
Assume branch *is* from fork when not possible to verify.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * ![Bugfix][badge-bugfix] Line endings in Markdown source files are now normalized to `LF` before parsing, to work around [a bug in the Julia Markdown parser][julia-29344] where parsing is sensitive to line endings, and can therefore cause platform-dependent behavior. ([#1906][github-1906])
 * ![Bugfix][badge-bugfix] `HTMLWriter` no longer complains about invalid URLs in docstrings when `makedocs` gets run multiple time in a Julia session, as it no longer modifies the underlying docstring objects. ([#505][github-505], [#1924][github-1924])
 * ![Bugfix][badge-bugfix] Docstring doctests now properly get checked on each `makedocs` run, when run multiple times in the same Julia session. ([#974][github-974], [#1948][github-1948])
+* ![Bugfix][badge-bugfix] The default decision for whether to deploy preview builds for pull requests have been changed from `true` to `false` when not possible to verify the origin of the pull request. ([#1969][github-1969])
 * ![Maintenance][badge-maintenance] Documenter now uses [MarkdownAST][markdownast] to internally represent Markdown documents. While this change should not lead to any visible changes to the user, it is a major refactoring of the code. Please report any novel errors or unexpected behavior you encounter when upgrading to 0.28 on the [Documenter issue tracker][documenter-issues]. ([#1892][github-1892], [#1912][github-1912], [#1924][github-1924], [#1948][github-1948])
 
 ## Version `v0.27.23`
@@ -1161,6 +1162,7 @@
 [github-1955]: https://github.com/JuliaDocs/Documenter.jl/pull/1955
 [github-1956]: https://github.com/JuliaDocs/Documenter.jl/pull/1956
 [github-1957]: https://github.com/JuliaDocs/Documenter.jl/pull/1957
+[github-1969]: https://github.com/JuliaDocs/Documenter.jl/pull/1969
 <!-- end of issue link definitions -->
 
 [julia-29344]: https://github.com/JuliaLang/julia/issues/29344

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -476,6 +476,8 @@ deployed. It defaults to the value of `repo`.
     Hosting previews requires access to the deploy key.
     Therefore, previews are available only for pull requests that were
     submitted directly from the main repository.
+    On GitHub Actions, `GITHUB_TOKEN` must be present for previews to work, even if
+    `DOCUMENTER_KEY` ise being used to deploy.
 
 **`deps`** can be set to a function or a callable object and gets called during deployment,
 and is usually used to install additional dependencies. By default, nothing gets executed.

--- a/src/deployconfig.jl
+++ b/src/deployconfig.jl
@@ -510,7 +510,7 @@ end
 function verify_github_pull_repository(repo, prnr)
     github_token = get(ENV, "GITHUB_TOKEN", nothing)
     if github_token === nothing
-        @warn "Unable to verify if PR comes from destination repository -- assuming it doesn't."
+        @warn "GITHUB_TOKEN is missing, unable to verify if PR comes from destination repository -- assuming it doesn't."
         return false
     end
     # Construct the curl call

--- a/src/deployconfig.jl
+++ b/src/deployconfig.jl
@@ -508,27 +508,28 @@ function post_github_status(type::S, deploydocs_repo::S, sha::S, subfolder=nothi
 end
 
 function verify_github_pull_repository(repo, prnr)
+    github_token = get(ENV, "GITHUB_TOKEN", nothing)
+    if github_token === nothing
+        @warn "Unable to verify if PR comes from destination repository -- assuming it doesn't."
+        return false
+    end
+    # Construct the curl call
+    cmd = `curl -s`
+    push!(cmd.exec, "-H", "Authorization: token $(github_token)")
+    push!(cmd.exec, "-H", "User-Agent: Documenter.jl")
+    push!(cmd.exec, "--fail")
+    push!(cmd.exec, "https://api.github.com/repos/$(repo)/pulls/$(prnr)")
     try
-        github_token = get(ENV, "GITHUB_TOKEN", nothing)
-        github_token === nothing && error("GITHUB_TOKEN missing")
-        # Construct the curl call
-        cmd = `curl -s`
-        push!(cmd.exec, "-X", "GET")
-        push!(cmd.exec, "-H", "Authorization: token $(github_token)")
-        push!(cmd.exec, "-H", "User-Agent: Documenter.jl")
-        push!(cmd.exec, "-H", "Content-Type: application/json")
-        push!(cmd.exec, "--fail")
-        push!(cmd.exec, "https://api.github.com/repos/$(repo)/pulls/$(prnr)")
         # Run the command (silently)
         response = run_and_capture(cmd)
         response = JSON.parse(response.stdout)
         pr_head_repo = response["head"]["repo"]["full_name"]
         @debug "pr_head_repo = '$pr_head_repo' vs repo = '$repo'"
-        return (pr_head_repo == repo)
+        return pr_head_repo == repo
     catch e
-        @warn "Unable to verify if PR comes from destination repository -- assuming it does."
+        @warn "Unable to verify if PR comes from destination repository -- assuming it doesn't."
         @debug "Running CURL led to an exception:" exception = (e, catch_backtrace())
-        return true
+        return false
     end
 end
 

--- a/test/deployconfig.jl
+++ b/test/deployconfig.jl
@@ -180,99 +180,112 @@ end end
         @test Documenter.authentication_method(cfg) === Documenter.SSH
         @test Documenter.documenter_key(cfg) === "SGVsbG8sIHdvcmxkLg=="
     end
-    # Regular pull request build with GITHUB_TOKEN
-    withenv("GITHUB_EVENT_NAME" => "pull_request",
-            "GITHUB_REPOSITORY" => "JuliaDocs/Documenter.jl",
-            "GITHUB_REF" => "refs/pull/42/merge",
-            "GITHUB_ACTOR" => "github-actions",
-            "GITHUB_TOKEN" => "SGVsbG8sIHdvcmxkLg==",
-            "DOCUMENTER_KEY" => nothing,
-        ) do
-        cfg = Documenter.GitHubActions()
-        d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
-                                     devbranch="master", devurl="hello-world", push_preview=true)
-        @test d.all_ok
-        @test d.subfolder == "previews/PR42"
-        @test d.repo == "github.com/JuliaDocs/Documenter.jl.git"
-        @test d.branch == "gh-pages"
-        d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
-                                     devbranch="not-master", devurl="hello-world", push_preview=false)
-        @test !d.all_ok
-        @test Documenter.authentication_method(cfg) === Documenter.HTTPS
-        @test Documenter.authenticated_repo_url(cfg) === "https://github-actions:SGVsbG8sIHdvcmxkLg==@github.com/JuliaDocs/Documenter.jl.git"
-    end
-    # Regular pull request build with SSH deploy key (SSH key prioritized)
-    withenv("GITHUB_EVENT_NAME" => "pull_request",
-            "GITHUB_REPOSITORY" => "JuliaDocs/Documenter.jl",
-            "GITHUB_REF" => "refs/pull/42/merge",
-            "GITHUB_ACTOR" => "github-actions",
-            "GITHUB_TOKEN" => "SGVsbG8sIHdvcmxkLg==",
-            "DOCUMENTER_KEY" => "SGVsbG8sIHdvcmxkLg==",
-        ) do
-        cfg = Documenter.GitHubActions()
-        d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
-                                     devbranch="master", devurl="hello-world", push_preview=true)
-        @test d.all_ok
-        @test d.subfolder == "previews/PR42"
-        @test d.repo == "github.com/JuliaDocs/Documenter.jl.git"
-        @test d.branch == "gh-pages"
-        d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
-                                     devbranch="not-master", devurl="hello-world", push_preview=false)
-        @test !d.all_ok
-        @test Documenter.authentication_method(cfg) === Documenter.SSH
-        @test Documenter.documenter_key(cfg) === "SGVsbG8sIHdvcmxkLg=="
-    end
-    # Regular pull request build with SSH deploy key (SSH key prioritized), but push previews to a different repo and different branch
-    withenv("GITHUB_EVENT_NAME" => "pull_request",
-            "GITHUB_REPOSITORY" => "JuliaDocs/Documenter.jl",
-            "GITHUB_REF" => "refs/pull/42/merge",
-            "GITHUB_ACTOR" => "github-actions",
-            "GITHUB_TOKEN" => "SGVsbG8sIHdvcmxkLg==",
-            "DOCUMENTER_KEY" => "SGVsbG8sIHdvcmxkLg==",
-        ) do
-        cfg = Documenter.GitHubActions()
-        d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
-                                     devbranch="master", devurl="hello-world", push_preview=true,
-                                     repo_previews="github.com/JuliaDocs/Documenter-previews.jl.git",
-                                     branch_previews="gh-pages-previews")
-        @test d.all_ok
-        @test d.subfolder == "previews/PR42"
-        @test d.repo == "github.com/JuliaDocs/Documenter-previews.jl.git"
-        @test d.branch == "gh-pages-previews"
-        d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
-                                     devbranch="not-master", devurl="hello-world", push_preview=false,
-                                     repo_previews="",
-                                     branch_previews="")
-        @test !d.all_ok
-        @test Documenter.authentication_method(cfg) === Documenter.SSH
-        @test Documenter.documenter_key(cfg) === "SGVsbG8sIHdvcmxkLg=="
-    end
-    # Regular pull request build with SSH deploy key (SSH key prioritized), but push previews to a different repo and different branch; use a different deploy key for previews
-    withenv("GITHUB_EVENT_NAME" => "pull_request",
-            "GITHUB_REPOSITORY" => "JuliaDocs/Documenter.jl",
-            "GITHUB_REF" => "refs/pull/42/merge",
-            "GITHUB_ACTOR" => "github-actions",
-            "GITHUB_TOKEN" => "SGVsbG8sIHdvcmxkLg==",
-            "DOCUMENTER_KEY" => "SGVsbG8sIHdvcmxkLg==",
-            "DOCUMENTER_KEY_PREVIEWS" => "SGVsbG8sIHdvcmxkLw==",
-        ) do
-        cfg = Documenter.GitHubActions()
-        d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
-                                     devbranch="master", devurl="hello-world", push_preview=true,
-                                     repo_previews="github.com/JuliaDocs/Documenter-previews.jl.git",
-                                     branch_previews="gh-pages-previews")
-        @test d.all_ok
-        @test d.subfolder == "previews/PR42"
-        @test d.repo == "github.com/JuliaDocs/Documenter-previews.jl.git"
-        @test d.branch == "gh-pages-previews"
-        d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
-                                     devbranch="not-master", devurl="hello-world", push_preview=false,
-                                     repo_previews="",
-                                     branch_previews="")
-        @test !d.all_ok
-        @test Documenter.authentication_method(cfg) === Documenter.SSH
-        @test Documenter.documenter_key(cfg) === "SGVsbG8sIHdvcmxkLg=="
-        @test Documenter.documenter_key_previews(cfg) === "SGVsbG8sIHdvcmxkLw=="
+
+    # These tests requires GITHUB_TOKEN to be set (and valid) in order to verify the origin
+    # of the PR. Only runs on CI.
+    if get(ENV, "GITHUB_ACTIONS", nothing) == "true" && haskey(ENV, "GITHUB_TOKEN")
+        # Regular pull request build with GITHUB_TOKEN
+        withenv("GITHUB_EVENT_NAME" => "pull_request",
+                "GITHUB_REPOSITORY" => "JuliaDocs/Documenter.jl",
+                "GITHUB_REF" => "refs/pull/1962/merge",
+                "GITHUB_ACTOR" => "github-actions",
+                "DOCUMENTER_KEY" => nothing,
+            ) do
+            cfg = Documenter.GitHubActions()
+            d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
+                                         devbranch="master", devurl="hello-world", push_preview=true)
+            @test d.all_ok
+            @test d.subfolder == "previews/PR1962"
+            @test d.repo == "github.com/JuliaDocs/Documenter.jl.git"
+            @test d.branch == "gh-pages"
+            d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
+                                         devbranch="not-master", devurl="hello-world", push_preview=false)
+            @test !d.all_ok
+            @test Documenter.authentication_method(cfg) === Documenter.HTTPS
+            @test Documenter.authenticated_repo_url(cfg) == "https://github-actions:$(ENV["GITHUB_TOKEN"])@github.com/JuliaDocs/Documenter.jl.git"
+        end
+        # Regular pull request build with GITHUB_TOKEN, PR from a fork
+        withenv("GITHUB_EVENT_NAME" => "pull_request",
+                "GITHUB_REPOSITORY" => "JuliaDocs/Documenter.jl",
+                "GITHUB_REF" => "refs/pull/1967/merge",
+                "GITHUB_ACTOR" => "github-actions",
+                "DOCUMENTER_KEY" => nothing,
+            ) do
+            cfg = Documenter.GitHubActions()
+            d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
+                                         devbranch="master", devurl="hello-world", push_preview=true)
+            @test !d.all_ok
+        end
+        # Regular pull request build with SSH deploy key (SSH key prioritized)
+        withenv("GITHUB_EVENT_NAME" => "pull_request",
+                "GITHUB_REPOSITORY" => "JuliaDocs/Documenter.jl",
+                "GITHUB_REF" => "refs/pull/1962/merge",
+                "GITHUB_ACTOR" => "github-actions",
+                "DOCUMENTER_KEY" => "SGVsbG8sIHdvcmxkLg==",
+            ) do
+            cfg = Documenter.GitHubActions()
+            d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
+                                         devbranch="master", devurl="hello-world", push_preview=true)
+            @test d.all_ok
+            @test d.subfolder == "previews/PR1962"
+            @test d.repo == "github.com/JuliaDocs/Documenter.jl.git"
+            @test d.branch == "gh-pages"
+            d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
+                                         devbranch="not-master", devurl="hello-world", push_preview=false)
+            @test !d.all_ok
+            @test Documenter.authentication_method(cfg) === Documenter.SSH
+            @test Documenter.documenter_key(cfg) === "SGVsbG8sIHdvcmxkLg=="
+        end
+        # Regular pull request build with SSH deploy key (SSH key prioritized), but push previews to a different repo and different branch
+        withenv("GITHUB_EVENT_NAME" => "pull_request",
+                "GITHUB_REPOSITORY" => "JuliaDocs/Documenter.jl",
+                "GITHUB_REF" => "refs/pull/1962/merge",
+                "GITHUB_ACTOR" => "github-actions",
+                "DOCUMENTER_KEY" => "SGVsbG8sIHdvcmxkLg==",
+            ) do
+            cfg = Documenter.GitHubActions()
+            d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
+                                         devbranch="master", devurl="hello-world", push_preview=true,
+                                         repo_previews="github.com/JuliaDocs/Documenter-previews.jl.git",
+                                         branch_previews="gh-pages-previews")
+            @test d.all_ok
+            @test d.subfolder == "previews/PR1962"
+            @test d.repo == "github.com/JuliaDocs/Documenter-previews.jl.git"
+            @test d.branch == "gh-pages-previews"
+            d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
+                                         devbranch="not-master", devurl="hello-world", push_preview=false,
+                                         repo_previews="",
+                                         branch_previews="")
+            @test !d.all_ok
+            @test Documenter.authentication_method(cfg) === Documenter.SSH
+            @test Documenter.documenter_key(cfg) === "SGVsbG8sIHdvcmxkLg=="
+        end
+        # Regular pull request build with SSH deploy key (SSH key prioritized), but push previews to a different repo and different branch; use a different deploy key for previews
+        withenv("GITHUB_EVENT_NAME" => "pull_request",
+                "GITHUB_REPOSITORY" => "JuliaDocs/Documenter.jl",
+                "GITHUB_REF" => "refs/pull/1962/merge",
+                "GITHUB_ACTOR" => "github-actions",
+                "DOCUMENTER_KEY" => "SGVsbG8sIHdvcmxkLg==",
+                "DOCUMENTER_KEY_PREVIEWS" => "SGVsbG8sIHdvcmxkLw==",
+            ) do
+            cfg = Documenter.GitHubActions()
+            d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
+                                         devbranch="master", devurl="hello-world", push_preview=true,
+                                         repo_previews="github.com/JuliaDocs/Documenter-previews.jl.git",
+                                         branch_previews="gh-pages-previews")
+            @test d.all_ok
+            @test d.subfolder == "previews/PR1962"
+            @test d.repo == "github.com/JuliaDocs/Documenter-previews.jl.git"
+            @test d.branch == "gh-pages-previews"
+            d = Documenter.deploy_folder(cfg; repo="github.com/JuliaDocs/Documenter.jl.git",
+                                         devbranch="not-master", devurl="hello-world", push_preview=false,
+                                         repo_previews="",
+                                         branch_previews="")
+            @test !d.all_ok
+            @test Documenter.authentication_method(cfg) === Documenter.SSH
+            @test Documenter.documenter_key(cfg) === "SGVsbG8sIHdvcmxkLg=="
+            @test Documenter.documenter_key_previews(cfg) === "SGVsbG8sIHdvcmxkLw=="
+        end
     end
     # Missing environment variables
     withenv("GITHUB_EVENT_NAME" => "push",


### PR DESCRIPTION
This patch changes the default assumption when verifying if a pull request is coming from a branch or not from true to false.

Fixes #1961, fixes #1965, closes #1966.