### PR TITLE
Work around a Git default configuration change

### DIFF
--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -227,7 +227,11 @@ end
             # NOTE: the target path in the `git submodule add` command is necessary for
             # Windows builds, since otherwise Git claims that the path is in a .gitignore
             # file.
-            @test trun(`$(git()) submodule add $(path_repo) repository`)
+            #
+            # protocol.file.allow=always is necessary to work around a changed default
+            # setting that was changed due to a security flaw.
+            # See: https://bugs.launchpad.net/ubuntu/+source/git/+bug/1993586
+            @test trun(`$(git()) -c protocol.file.allow=always submodule add $(path_repo) repository`)
             @test trun(`$(git()) add -A`)
             @test trun(`$(git()) commit -m"Initial commit."`)
         end


### PR DESCRIPTION
The default behaviour of `git submodule` was changed [in a security patch](https://bugs.launchpad.net/ubuntu/+source/git/+bug/1993586), which means our tests started failing (x-ref #1970). This patch introduces a [workaround suggested by Mark Esler](https://bugs.launchpad.net/ubuntu/+source/git/+bug/1993586/comments/3), to fix our `git submodule` invocation.