### PR TITLE
Implement JuliaValue for writers

### DIFF
--- a/src/Writers/HTMLWriter.jl
+++ b/src/Writers/HTMLWriter.jl
@@ -2036,8 +2036,12 @@ function domify(dctx::DCtx, node::Node, t::MarkdownAST.Table)
     )
 end
 
-# TODO: implement support for JuliaValue
-#domify(dctx::DCtx, node::Node, e::MarkdownAST.JuliaValue) = string(e.ref)
+function domify(dctx::DCtx, node::Node, e::MarkdownAST.JuliaValue)
+    @warn """
+    Unexpected Julia interpolation of type $(typeof(e.ref)) in the Markdown.
+    """ value = e.ref
+    string(e.ref)
+end
 
 function domify(dctx::DCtx, node::Node, f::MarkdownAST.FootnoteLink)
     @tags sup a

--- a/src/Writers/LaTeXWriter.jl
+++ b/src/Writers/LaTeXWriter.jl
@@ -752,6 +752,13 @@ latex(io::Context, node::Node, ::Documents.MetaNode) = _println(io, "\n")
 # In the original AST, SetupNodes were just mapped to empty Markdown.MD() objects.
 latex(io::Context, node::Node, ::Documents.SetupNode) = nothing
 
+function latex(io::Context, node::Node, value::MarkdownAST.JuliaValue)
+    @warn """
+    Unexpected Julia interpolation of type $(typeof(value.ref)) in the Markdown.
+    """ value = value.ref
+    latexesc(io, string(value.ref))
+end
+
 # TODO: Implement SoftBreak, Backslash (but they don't appear in standard library Markdown conversions)
 latex(io::Context, node::Node, ::MarkdownAST.LineBreak) = _println(io, "\\\\")
 

--- a/test/examples/src/index.md
+++ b/test/examples/src/index.md
@@ -604,3 +604,11 @@ Also in block quotes:
 > #### Heading 4
 > ##### Heading 5
 > ###### Heading 6
+
+# JuliaValue
+
+It is possible to create pseudo-interpolations with the `Markdown` parser: $foo.
+
+$([1 2 3; 4 5 6])
+
+They do not get evaluated.


### PR DESCRIPTION
This is something I omitted in the MarkdownAST transition (#1892).

You can end up with `JuliaValue`s in the Markdown AST if you have dollar signs in the source code. This is actually a common source of problems, so I think it is useful that we issue a warning here (but not break the build).