### PR TITLE
Add option to ignore Markdown files not in pages keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * ![Enhancement][badge-enhancement] The code copy buttons in HTML now have `title` and `aria-label` attributes. ([#1903][github-1903])
 * ![Enhancement][badge-enhancement] The at-ref links are now more flexible, allowing arbitrary links to point to both docstrings and section headings. ([#781][github-781], [#1900][github-1900])
 * ![Enhancement][badge-enhancement] Code blocks like `@example` or `@repl` are now also expanded in nested contexts (e.g. admonitions, lists or block quotes). ([#491][github-491], [#1970][github-1970])
+* ![Enhancement][badge-enhancement] The new `pagesonly` keyword to `makedocs` can be used to restrict builds to just the Markdown files listed in `pages` (as opposed to all `.md` files under `src/`). ([#1980][github-1980])
 * ![Bugfix][badge-bugfix] Documenter now generates the correct source URLs for docstrings from other packages when the `repo` argument to `makedocs` is set (note: the source links to such docstrings only work if the external package is cloned from GitHub and added as a dev-dependency). However, this change **breaks** the case where the `repo` argument is used to override the main package/repository URL, assuming the repository is cloned from GitHub. ([#1808][github-1808])
 * ![Bugfix][badge-bugfix] Documenter no longer uses the `TRAVIS_REPO_SLUG` environment variable to determine the Git remote of non-main repositories (when inferring it from the Git repository configuration has failed), which could previously lead to bad source links. ([#1881][github-1881])
 * ![Bugfix][badge-bugfix] Line endings in Markdown source files are now normalized to `LF` before parsing, to work around [a bug in the Julia Markdown parser][julia-29344] where parsing is sensitive to line endings, and can therefore cause platform-dependent behavior. ([#1906][github-1906])
@@ -1171,6 +1172,7 @@
 [github-1969]: https://github.com/JuliaDocs/Documenter.jl/pull/1969
 [github-1970]: https://github.com/JuliaDocs/Documenter.jl/pull/1970
 [github-1977]: https://github.com/JuliaDocs/Documenter.jl/pull/1977
+[github-1980]: https://github.com/JuliaDocs/Documenter.jl/pull/1980
 <!-- end of issue link definitions -->
 
 [julia-29344]: https://github.com/JuliaLang/julia/issues/29344

--- a/src/Builder.jl
+++ b/src/Builder.jl
@@ -155,6 +155,15 @@ function Selectors.runner(::Type{SetupBuildDirectory}, doc::Documenter.Document)
         end
         prev = navnode
     end
+
+    # If the user specified pagesonly, we will remove all the pages not in the navigation
+    # menu (.pages).
+    if doc.user.pagesonly
+        navlist_pages = getfield.(doc.internal.navlist, :page)
+        for page in keys(doc.blueprint.pages)
+            page ∈ navlist_pages || delete!(doc.blueprint.pages, page)
+        end
+    end
 end
 
 """

--- a/src/documents.jl
+++ b/src/documents.jl
@@ -246,6 +246,7 @@ struct User
     doctestfilters::Vector{Regex} # Filtering for doctests
     strict::Union{Bool,Symbol,Vector{Symbol}} # Throw an exception when any warnings are encountered.
     pages   :: Vector{Any}    # Ordering of document pages specified by the user.
+    pagesonly :: Bool         # Discard any .md pages from processing that are not in .pages
     expandfirst::Vector{String} # List of pages that get "expanded" before others
     remote  :: Union{Remotes.Remote,Nothing} # Remote Git repository information
     sitename:: String
@@ -301,6 +302,7 @@ function Document(plugins = nothing;
         strict::Union{Bool,Symbol,Vector{Symbol}} = false,
         modules  :: ModVec = Module[],
         pages    :: Vector           = Any[],
+        pagesonly:: Bool             = false,
         expandfirst :: Vector        = String[],
         repo     :: Union{Remotes.Remote, AbstractString} = "",
         sitename :: AbstractString   = "",
@@ -351,6 +353,7 @@ function Document(plugins = nothing;
         doctestfilters,
         strict,
         pages,
+        pagesonly,
         expandfirst,
         remote,
         sitename,

--- a/src/makedocs.jl
+++ b/src/makedocs.jl
@@ -106,6 +106,40 @@ is enabled by default.
 
 **`sitename`** is displayed in the title bar and/or the navigation menu when applicable.
 
+**`pages`** can be use to specify a hierarchical page structure, and the order in which
+the pages appear in the navigation of the rendered output. If omitted, Documenter will
+automatically generate a flat list of pages based on the files present in the source
+directory.
+
+```julia
+pages = [
+    "Overview" => "index.md",
+    "tutorial.md",
+    "Tutorial" => [
+        "tutorial/introduction.md",
+        "Advanced" => "tutorial/features.md",
+    ],
+    "apireference.md",
+]
+```
+
+The `pages` keyword must be a list where each element must be one of the following:
+
+1. A string containing the full path of a Markdown file _within_ the source directory (i.e. relative to the `docs/src/` root in standard deployments).
+2. A `"Page title" => "path/to/page.md"` pair, where `Page title` overrides the page title in the navigation menu (but not on the page itself).
+3. A `"Subsection title" => [...]` pair, indicating a subsection of pages with the given title in the navigation menu. The list of pages for the subsection follow the same rules as the top-level `pages` keyword.
+
+See also [`hide`](@ref), which can be used to hide certain pages in the navigation menu.
+
+Note that, by default, regardless of what is specified in `pages`, Documenter will run and
+render _all_ Markdown files it finds, even if they are not present in `pages`. The
+`pagesonly` keyword can be used to change this behaviour.
+
+**`pagesonly`** can be set to `true` (default: `false`) to make Documenter process only the
+pages listed in with the `pages` keyword. In that case, the Markdown files not present in
+`pages` are ignored, i.e. code blocks do not run, docstrings do not get included, and the
+pages are not rendered in the output in any way.
+
 **`expandfirst`** allows some of the pages to be _expanded_ (i.e. at-blocks evaluated etc.)
 before the others. Documenter normally evaluates the files in the alphabetic order of their
 file paths relative to `src`, but `expandfirst` allows some pages to be prioritized.

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -19,7 +19,7 @@ else
     ["html", "html-mathjax2-custom", "html-mathjax3", "html-mathjax3-custom",
     "html-local", "html-draft", "html-repo-git", "html-repo-gha", "html-repo-travis",
     "html-repo-nothing", "html-repo-error", "latex_texonly", "latex_simple_texonly",
-    "latex_showcase_texonly"]
+    "latex_showcase_texonly", "html-pagesonly"]
 end
 
 # Modules `Mod` and `AutoDocs`
@@ -370,6 +370,30 @@ examples_html_local_doc = if "html-draft" in EXAMPLE_BUILDS
     )
 else
     @info "Skipping build: HTML/draft"
+    @debug "Controlling variables:" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
+    nothing
+end
+
+# HTML: pagesonly
+examples_html_pagesonly_doc = if "html-pagesonly" in EXAMPLE_BUILDS
+    @info("Building mock package docs: HTMLWriter / draft build")
+    @quietly makedocs(
+        debug = true,
+        draft = true,
+        root  = examples_root,
+        build = "builds/html-pagesonly",
+        sitename = "Documenter example (pagesonly)",
+        pages = [
+            "**Home**" => "index.md",
+            "Manual" => [
+                "man/tutorial.md",
+                "man/style.md",
+            ],
+        ],
+        pagesonly = true,
+    )
+else
+    @info "Skipping build: HTML/pagesonly"
     @debug "Controlling variables:" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
     nothing
 end

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -189,7 +189,7 @@ end
                 filename, _ = splitext(filename)
                 htmlpath = (filename == "index") ? joinpath(build_dir, dir, "index.html") :
                     joinpath(build_dir, dir, filename, "index.html")
-                if mdfile ∈ ("index.md", "man/tutorial.md", "man/style.md")
+                if mdfile ∈ ("index.md", joinpath("man", "tutorial.md"), joinpath("man", "style.md"))
                     @test isfile(htmlpath)
                 else
                     @test !ispath(htmlpath)

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -64,6 +64,19 @@ function compare_files(a, b)
     return false
 end
 
+all_md_files_in_src = let srcdir = joinpath(@__DIR__, "src"), mdfiles = String[]
+    for (root, _, pages) in walkdir(srcdir)
+        rootdir = relpath(root, srcdir)
+        rootdir == "." && (rootdir = "")
+        for page in pages
+            endswith(page, ".md") || continue
+            push!(mdfiles, joinpath(rootdir, page))
+        end
+    end
+    mdfiles
+end
+@test length(all_md_files_in_src) == 25
+
 @testset "Examples" begin
     @testset "HTML: deploy/$name" for (doc, name) in [
         (Main.examples_html_doc, "html"),
@@ -74,11 +87,14 @@ end
         @test isa(doc, Documenter.Documenter.Document)
 
         let build_dir = joinpath(examples_root, "builds", name)
-            @test joinpath(build_dir, "index.html") |> isfile
-            @test joinpath(build_dir, "omitted", "index.html") |> isfile
-            @test joinpath(build_dir, "hidden", "index.html") |> isfile
-            @test joinpath(build_dir, "lib", "autodocs", "index.html") |> isfile
-            @test joinpath(build_dir, "man", "style", "index.html") |> isfile
+            # Make sure that each .md file has a corresponding generated HTML file
+            for mdfile in all_md_files_in_src
+                dir, filename = splitdir(mdfile)
+                filename, _ = splitext(filename)
+                htmlpath = (filename == "index") ? joinpath(build_dir, dir, "index.html") :
+                    joinpath(build_dir, dir, filename, "index.html")
+                @test isfile(htmlpath)
+            end
 
             # Test existence of some HTML elements
             man_style_html = String(read(joinpath(build_dir, "man", "style", "index.html")))
@@ -145,10 +161,40 @@ end
             @test occursin("<strong>bold</strong> output from MarkdownOnly", index_html)
             @test occursin("documenter-example-output", index_html)
 
-            @test isfile(joinpath(build_dir, "index.html"))
-            @test isfile(joinpath(build_dir, "omitted.html"))
-            @test isfile(joinpath(build_dir, "hidden.html"))
-            @test isfile(joinpath(build_dir, "lib", "autodocs.html"))
+            # Make sure that each .md file has a corresponding generated HTML file
+            for mdfile in all_md_files_in_src
+                dir, filename = splitdir(mdfile)
+                filename, _ = splitext(filename)
+                htmlpath = joinpath(build_dir, dir, "$(filename).html")
+                @test isfile(htmlpath)
+            end
+
+            # Assets
+            @test joinpath(build_dir, "assets", "documenter.js") |> isfile
+            documenterjs = String(read(joinpath(build_dir, "assets", "documenter.js")))
+            @test occursin("languages/julia.min", documenterjs)
+            @test occursin("languages/julia-repl.min", documenterjs)
+        end
+    end
+
+    @testset "HTML: pagesonly" begin
+        doc = Main.examples_html_pagesonly_doc
+
+        @test isa(doc, Documenter.Documenter.Document)
+
+        let build_dir = joinpath(examples_root, "builds", "html-pagesonly")
+            # Make sure that each .md file has a corresponding generated HTML file
+            for mdfile in all_md_files_in_src
+                dir, filename = splitdir(mdfile)
+                filename, _ = splitext(filename)
+                htmlpath = (filename == "index") ? joinpath(build_dir, dir, "index.html") :
+                    joinpath(build_dir, dir, filename, "index.html")
+                if mdfile ∈ ("index.md", "man/tutorial.md", "man/style.md")
+                    @test isfile(htmlpath)
+                else
+                    @test !ispath(htmlpath)
+                end
+            end
 
             # Assets
             @test joinpath(build_dir, "assets", "documenter.js") |> isfile

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -88,7 +88,7 @@ end
 
         let build_dir = joinpath(examples_root, "builds", name)
             # Make sure that each .md file has a corresponding generated HTML file
-            for mdfile in all_md_files_in_src
+            @testset "md: $mdfile" for mdfile in all_md_files_in_src
                 dir, filename = splitdir(mdfile)
                 filename, _ = splitext(filename)
                 htmlpath = (filename == "index") ? joinpath(build_dir, dir, "index.html") :
@@ -162,7 +162,7 @@ end
             @test occursin("documenter-example-output", index_html)
 
             # Make sure that each .md file has a corresponding generated HTML file
-            for mdfile in all_md_files_in_src
+            @testset "md: $mdfile" for mdfile in all_md_files_in_src
                 dir, filename = splitdir(mdfile)
                 filename, _ = splitext(filename)
                 htmlpath = joinpath(build_dir, dir, "$(filename).html")
@@ -184,7 +184,7 @@ end
 
         let build_dir = joinpath(examples_root, "builds", "html-pagesonly")
             # Make sure that each .md file has a corresponding generated HTML file
-            for mdfile in all_md_files_in_src
+            @testset "md: $mdfile" for mdfile in all_md_files_in_src
                 dir, filename = splitdir(mdfile)
                 filename, _ = splitext(filename)
                 htmlpath = (filename == "index") ? joinpath(build_dir, dir, "index.html") :


### PR DESCRIPTION
Adds a new `pagesonly` keyword which, if set to `true`, makes `makedocs` not run or render any pages that are not explicitly present in `pages`. This can be particularly useful if you want to temporarily stop Documenter from building some of the pages (e.g. when they take a long time to build).

Also, fix #1896.