### PR TITLE
Support regex => substitution pairs in doctest filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
   **For upgrading:** The cases where an `@eval` results in a object that is not `nothing` or `::Markdown.MD`, the returned object should be reviewed. In case the resulting object is of some `Markdown` node type (e.g. `Markdown.Paragraph` or `Markdown.Table`), it can simply be wrapped in `Markdown.MD([...])` for block nodes, or `Markdown.MD([Markdown.Paragraph([...])])` for inline nodes. In other cases Documenter was likely not handling the returned object in a correct way, but please open an issue if this change has broken a previously working use case.
 
+* ![Enhancement][badge-enhancement] Doctest filters can now be specified as regex/substitution pairs, i.e. `r"..." => s"..."`, in order to control the replacement (which defaults to the empty string, `""`). ([#1989][github-1989])
 * ![Enhancement][badge-enhancement] Documenter is now more careful not to accidentally leak SSH keys (in e.g. error messages) by removing `DOCUMENTER_KEY` from the environment when it is not needed. ([#1958][github-1958], [#1962][github-1962])
 * ![Enhancement][badge-enhancement] Admonitions are now styled with color in the LaTeX output. ([#1931][github-1931], [#1932][github-1932], [#1946][github-1946], [#1955][github-1955])
 * ![Enhancement][badge-enhancement] Improved the styling of code blocks in the LaTeXWriter. ([#1933][github-1933], [#1935][github-1935], [#1936][github-1936], [#1944][github-1944], [#1956][github-1956], [#1957][github-1957])
@@ -1173,6 +1174,7 @@
 [github-1970]: https://github.com/JuliaDocs/Documenter.jl/pull/1970
 [github-1977]: https://github.com/JuliaDocs/Documenter.jl/pull/1977
 [github-1980]: https://github.com/JuliaDocs/Documenter.jl/pull/1980
+[github-1989]: https://github.com/JuliaDocs/Documenter.jl/pull/1989
 <!-- end of issue link definitions -->
 
 [julia-29344]: https://github.com/JuliaLang/julia/issues/29344

--- a/docs/src/man/doctests.md
+++ b/docs/src/man/doctests.md
@@ -266,8 +266,9 @@ julia> foo(2)
 A part of the output of a doctest might be non-deterministic, e.g. pointer addresses and timings.
 It is therefore possible to filter a doctest so that the deterministic part can still be tested.
 
-A filter takes the form of a regular expression.
-In a doctest, each match in the expected output and the actual output is removed before the two outputs are compared.
+Filters are defined with regular expressions, either as a regex/substition pair (e.g. `r"..." => s"..."`)
+or as a single regex (e.g. `r"..."`). In the latter case the match is replaced with `""`.
+In a doctest, each match in the expected output and the actual output is replaced before the two outputs are compared.
 Filters are added globally, i.e. applied to all doctests in the documentation, by passing a list of regular expressions to
 `makedocs` with the keyword `doctestfilters`.
 

--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -293,9 +293,10 @@ function filter_doctests(strings::NTuple{2, AbstractString},
     meta_block_filters = get(Vector{Any}, meta, :DocTestFilters)
     meta_block_filters === nothing && (meta_block_filters = [])
     doctest_local_filters = get(meta[:LocalDocTestArguments], :filter, [])
-    for r in [doc.user.doctestfilters; meta_block_filters; doctest_local_filters]
+    for rs in [doc.user.doctestfilters; meta_block_filters; doctest_local_filters]
+        r, s = rs isa Pair ? rs : (rs => "")
         if all(occursin.((r,), strings))
-            strings = replace.(strings, (r => "",))
+            strings = replace.(strings, (r => s,))
         end
     end
     return strings

--- a/test/doctests/src/working.md
+++ b/test/doctests/src/working.md
@@ -71,3 +71,10 @@ Empty output:
 nothing
 # output
 ```
+
+Filtering with regex substitutions:
+
+```jldoctest; filter = r"([0-9]+\.[0-9]{8})[0-9]+" => s"\1***"
+julia> sqrt(2)
+1.41421356000
+```


### PR DESCRIPTION
This patch adds support for using regex => substitution pairs in doctest filters. This is useful when you do not want to replace the full match, but only remove some part. As an example, consider a test where the output may differ in the third decimal:

````
```jlddoctest
julia> 1.124
1.123
```
````

With this patch it is still possible to test the first 2 decimals using the filter `r"(\d\.\d\d)\d*" => s"\1"`.