### PR TITLE
Allow automated test missingdocs

### DIFF
--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -24,7 +24,7 @@ Prints out the name of each object that has not had its docs spliced into the do
 Returns the number of missing bindings to allow for automated testing of documentation.
 """
 function missingdocs(doc::Documenter.Document)
-    doc.user.checkdocs === :none && return
+    doc.user.checkdocs === :none && return 0
     bindings = missingbindings(doc)
     n = reduce(+, map(length, values(bindings)), init=0)
     if n > 0

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -20,9 +20,32 @@ Checks that a [`Documenter.Document`](@ref) contains all available docstrings th
 defined in the `modules` keyword passed to [`Documenter.makedocs`](@ref).
 
 Prints out the name of each object that has not had its docs spliced into the document.
+
+Returns the number of missing bindings to allow for automated testing of documentation.
 """
-function missingdocs(doc::Documenter.Document)
+function missingdocs(doc::Documenter.Document; print=true)
     doc.user.checkdocs === :none && return
+    bindings = missingbindings(doc)
+    n = reduce(+, map(length, values(bindings)), init=0)
+    if n > 0
+        b = IOBuffer()
+        println(b, "$n docstring$(n ≡ 1 ? "" : "s") not included in the manual:\n")
+        for (binding, signatures) in bindings
+            for sig in signatures
+                println(b, "    $binding", sig ≡ Union{} ? "" : " :: $sig")
+            end
+        end
+        println(b)
+        print(b, """
+        These are docstrings in the checked modules (configured with the modules keyword)
+        that are not included in @docs or @autodocs blocks.
+        """)
+        @docerror(doc, :missing_docs, String(take!(b)))
+    end
+    return n
+end
+
+function missingbindings(doc::Documenter.Document)
     @debug "checking for missing docstrings."
     bindings = allbindings(doc.user.checkdocs, doc.blueprint.modules)
     for object in keys(doc.internal.objects)
@@ -47,22 +70,7 @@ function missingdocs(doc::Documenter.Document)
             end
         end
     end
-    n = reduce(+, map(length, values(bindings)), init=0)
-    if n > 0
-        b = IOBuffer()
-        println(b, "$n docstring$(n ≡ 1 ? "" : "s") not included in the manual:\n")
-        for (binding, signatures) in bindings
-            for sig in signatures
-                println(b, "    $binding", sig ≡ Union{} ? "" : " :: $sig")
-            end
-        end
-        println(b)
-        print(b, """
-        These are docstrings in the checked modules (configured with the modules keyword)
-        that are not included in @docs or @autodocs blocks.
-        """)
-        @docerror(doc, :missing_docs, String(take!(b)))
-    end
+    return bindings
 end
 
 function allbindings(checkdocs::Symbol, mods)

--- a/src/DocChecks.jl
+++ b/src/DocChecks.jl
@@ -23,7 +23,7 @@ Prints out the name of each object that has not had its docs spliced into the do
 
 Returns the number of missing bindings to allow for automated testing of documentation.
 """
-function missingdocs(doc::Documenter.Document; print=true)
+function missingdocs(doc::Documenter.Document)
     doc.user.checkdocs === :none && return
     bindings = missingbindings(doc)
     n = reduce(+, map(length, values(bindings)), init=0)

--- a/test/missingdocs/make.jl
+++ b/test/missingdocs/make.jl
@@ -14,15 +14,19 @@ module MissingDocs
 end
 
 @testset "missing docs" begin
-    for sym in [:none, :exports, :all]
-        @quietly @test makedocs(
+    for (sym, n_expected) in zip([:none, :exports, :all], [0, 1, 2])
+        kwargs = (
             root = dirname(@__FILE__),
             source = joinpath("src", string(sym)),
             build = joinpath("build", string(sym)),
             modules = MissingDocs,
             checkdocs = sym,
             sitename = "MissingDocs Checks",
-        ) === nothing
+        )
+        @quietly @test makedocs(; kwargs...) === nothing
+
+        doc = Documenter.Document(; kwargs...)
+        @quietly @test Documenter.DocChecks.missingdocs(doc) == n_expected
     end
 
     @quietly @test_throws ErrorException makedocs(


### PR DESCRIPTION
We wish to use the missingdocs functionality in a CI/CD environment. For this, it is useful to have the missingdocs function not only print out missing documentation, but also return the number of missing documents. This can then be verified using a `@test missingdocs(...) == 0`. 