### PR TITLE
Include stacktraces in at-block code errors

### DIFF
--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -358,7 +358,7 @@ end
 
 function error_to_string(buf, er, bt)
     # Remove unimportant backtrace info.
-    bt = remove_common_backtrace(bt, backtrace())
+    bt = Documenter.remove_common_backtrace(bt, backtrace())
     # Remove everything below the last eval call (which should be the one in IOCapture.capture)
     index = findlast(ptr -> Base.ip_matches_func(ptr, :eval), bt)
     bt = (index === nothing) ? bt : bt[1:(index - 1)]
@@ -366,22 +366,6 @@ function error_to_string(buf, er, bt)
     print(buf, "ERROR: ")
     Base.invokelatest(showerror, buf, er, bt)
     return sanitise(buf)
-end
-
-function remove_common_backtrace(bt, reference_bt)
-    cutoff = nothing
-    # We'll start from the top of the backtrace (end of the array) and go down, checking
-    # if the backtraces agree
-    for ridx in 1:length(bt)
-        # Cancel search if we run out the reference BT or find a non-matching one frames:
-        if ridx > length(reference_bt) || bt[length(bt) - ridx + 1] != reference_bt[length(reference_bt) - ridx + 1]
-            cutoff = length(bt) - ridx + 1
-            break
-        end
-    end
-    # It's possible that the loop does not find anything, i.e. that all BT elements are in
-    # the reference_BT too. In that case we'll just return an empty BT.
-    bt[1:(cutoff === nothing ? 0 : cutoff)]
 end
 
 # Strip trailing whitespace from each line and return resulting string

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -599,7 +599,7 @@ function Selectors.runner(::Type{EvalBlocks}, node, page, doc)
                     ```$(x.info)
                     $(x.code)
                     ```
-                    """, exception = err)
+                    """, exception = (err, catch_backtrace()))
             end
         end
         result = if isnothing(result)
@@ -882,7 +882,7 @@ function Selectors.runner(::Type{SetupBlocks}, node, page, doc)
             ```$(x.info)
             $(x.code)
             ```
-            """, exception=(err, catch_backtrace())
+            """, exception=(err, catch_backtrace()))
     end
     node.element = Documenter.SetupNode(x.info, x.code)
 end

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -882,7 +882,7 @@ function Selectors.runner(::Type{SetupBlocks}, node, page, doc)
             ```$(x.info)
             $(x.code)
             ```
-            """, exception=err)
+            """, exception=(err, catch_backtrace())
     end
     node.element = Documenter.SetupNode(x.info, x.code)
 end

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -593,7 +593,6 @@ function Selectors.runner(::Type{EvalBlocks}, node, page, doc)
             try
                 result = Core.eval(sandbox, ex)
             catch err
-                #bt = Documenter.DocTests.remove_common_backtrace(catch_backtrace(), backtrace())
                 bt = Documenter.remove_common_backtrace(catch_backtrace())
                 @docerror(doc, :eval_block,
                     """

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -593,13 +593,15 @@ function Selectors.runner(::Type{EvalBlocks}, node, page, doc)
             try
                 result = Core.eval(sandbox, ex)
             catch err
+                #bt = Documenter.DocTests.remove_common_backtrace(catch_backtrace(), backtrace())
+                bt = Documenter.remove_common_backtrace(catch_backtrace())
                 @docerror(doc, :eval_block,
                     """
                     failed to evaluate `@eval` block in $(Documenter.locrepr(page.source))
                     ```$(x.info)
                     $(x.code)
                     ```
-                    """, exception = (err, catch_backtrace()))
+                    """, exception = (err, bt))
             end
         end
         result = if isnothing(result)
@@ -720,13 +722,14 @@ function Selectors.runner(::Type{ExampleBlocks}, node, page, doc)
             result = c.value
             print(buffer, c.output)
             if c.error
+                bt = Documenter.remove_common_backtrace(c.backtrace)
                 @docerror(doc, :example_block,
                     """
                     failed to run `@example` block in $(Documenter.locrepr(page.source, lines))
                     ```$(x.info)
                     $(x.code)
                     ```
-                    """, exception = (c.value, c.backtrace))
+                    """, exception = (c.value, bt))
                 page.mapping[x] = x
                 return
             end
@@ -876,13 +879,14 @@ function Selectors.runner(::Type{SetupBlocks}, node, page, doc)
             include_string(mod, x.code)
         end
     catch err
+        bt = Documenter.remove_common_backtrace(catch_backtrace())
         @docerror(doc, :setup_block,
             """
             failed to run `@setup` block in $(Documenter.locrepr(page.source))
             ```$(x.info)
             $(x.code)
             ```
-            """, exception=(err, catch_backtrace()))
+            """, exception=(err, bt))
     end
     node.element = Documenter.SetupNode(x.info, x.code)
 end

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -726,7 +726,7 @@ function Selectors.runner(::Type{ExampleBlocks}, node, page, doc)
                     ```$(x.info)
                     $(x.code)
                     ```
-                    """, value = c.value)
+                    """, exception = (c.value, c.backtrace))
                 page.mapping[x] = x
                 return
             end

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -27,6 +27,8 @@ macro docerror(doc, tag, msg, exs...)
     isa(tag, QuoteNode) && isa(tag.value, Symbol) || error("invalid call of @docerror: tag=$tag")
     tag.value ∈ ERROR_NAMES || throw(ArgumentError("tag $(tag) is not a valid Documenter error"))
     doc, msg = esc(doc), esc(msg)
+    # The `exs` portion can contain variable name / label overrides, i.e. `foo = bar()`
+    # We don't want to apply esc() on new labels, since they get printed as expressions then.
     exs = map(exs) do ex
         if isa(ex, Expr) && ex.head == :(=) && ex.args[1] isa Symbol
             ex.args[2:end] .= esc.(ex.args[2:end])

--- a/test/doctests/doctests.jl
+++ b/test/doctests/doctests.jl
@@ -242,18 +242,4 @@ rfile(filename) = joinpath(@__DIR__, "stdouts", filename)
     end
 end
 
-using Documenter.DocTests: remove_common_backtrace
-@testset "DocTest.remove_common_backtrace" begin
-    @test remove_common_backtrace([], []) == []
-    @test remove_common_backtrace([1], []) == [1]
-    @test remove_common_backtrace([1,2], []) == [1,2]
-    @test remove_common_backtrace([1,2,3], [1]) == [1,2,3]
-    @test remove_common_backtrace([1,2,3], [2]) == [1,2,3]
-    @test remove_common_backtrace([1,2,3], [3]) == [1,2]
-    @test remove_common_backtrace([1,2,3], [2,3]) == [1]
-    @test remove_common_backtrace([1,2,3], [1,3]) == [1,2]
-    @test remove_common_backtrace([1,2,3], [1,2,3]) == []
-    @test remove_common_backtrace([1,2,3], [0,1,2,3]) == []
-end
-
 end # module

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -621,6 +621,20 @@ end
             end
         end
     end
+
+    using Documenter: remove_common_backtrace
+    @testset "remove_common_backtrace" begin
+        @test remove_common_backtrace([], []) == []
+        @test remove_common_backtrace([1], []) == [1]
+        @test remove_common_backtrace([1,2], []) == [1,2]
+        @test remove_common_backtrace([1,2,3], [1]) == [1,2,3]
+        @test remove_common_backtrace([1,2,3], [2]) == [1,2,3]
+        @test remove_common_backtrace([1,2,3], [3]) == [1,2]
+        @test remove_common_backtrace([1,2,3], [2,3]) == [1]
+        @test remove_common_backtrace([1,2,3], [1,3]) == [1,2]
+        @test remove_common_backtrace([1,2,3], [1,2,3]) == []
+        @test remove_common_backtrace([1,2,3], [0,1,2,3]) == []
+    end
 end
 
 end


### PR DESCRIPTION
I was frustrated that the warnings when the code in an `example` block gets an error don't include a backtrace.

This change includes a backtrace for errors in `example`, `repl` and `setup` blocks.

Much thanks to Morten Piibeleht for responding to my question on Slack, pointing me at the code and telling me how to do this.
