### PR TITLE
Fix expanding of x-ref targets containing a code block

### DIFF
--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -277,9 +277,7 @@ function Selectors.runner(::Type{TrackHeaders}, node, page, doc)
             # the tree.
             link_node = first(node.children)
             MarkdownAST.unlink!(link_node)
-            for child in collect(link_node.children)
-                push!(node.children, child)
-            end
+            append!(node.children, link_node.children)
             match(NAMEDHEADER_REGEX, link_node.element.destination)[1]
         else
             # TODO: remove this hack (replace with mdflatten?)

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -277,7 +277,9 @@ function Selectors.runner(::Type{TrackHeaders}, node, page, doc)
             # the tree.
             link_node = first(node.children)
             MarkdownAST.unlink!(link_node)
-            append!(node.children, link_node.children)
+            for child in collect(link_node.children)
+                push!(node.children, child)
+            end
             match(NAMEDHEADER_REGEX, link_node.element.destination)[1]
         else
             # TODO: remove this hack (replace with mdflatten?)

--- a/test/examples/src/xrefs.md
+++ b/test/examples/src/xrefs.md
@@ -16,3 +16,5 @@ Named x-refs:
 ## [X-ref target with id](@id xreftarget)
 
 ## [x-ref with `@code` block](@id xrefcodeblock)
+
+This should render as ```x-ref with `@code` block```: #2010, #2011.

--- a/test/examples/src/xrefs.md
+++ b/test/examples/src/xrefs.md
@@ -14,3 +14,5 @@ Named x-refs:
 ## X-ref target
 
 ## [X-ref target with id](@id xreftarget)
+
+## [x-ref with `@code` block](@id xrefcodeblock)


### PR DESCRIPTION
Took me a while to find the right place, but I think this is the correct fix. 

It renders the example from https://github.com/JuliaDocs/Documenter.jl/issues/2010 okay.

<img width="657" alt="image" src="https://user-images.githubusercontent.com/8177701/211223685-a4a42f8f-c12b-4670-b77e-5966caeadae1.png">

Not sure how/where to test this?