### PR TITLE
catch existing symlinks when adding new ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * ![Bugfix][badge-bugfix] `HTMLWriter` no longer complains about invalid URLs in docstrings when `makedocs` gets run multiple time in a Julia session, as it no longer modifies the underlying docstring objects. ([#505][github-505], [#1924][github-1924])
 * ![Bugfix][badge-bugfix] Docstring doctests now properly get checked on each `makedocs` run, when run multiple times in the same Julia session. ([#974][github-974], [#1948][github-1948])
 * ![Bugfix][badge-bugfix] The default decision for whether to deploy preview builds for pull requests have been changed from `true` to `false` when not possible to verify the origin of the pull request. ([#1969][github-1969])
+* ![Bugfix][badge-bugfix] `deploydocs` now correctly handles version symlinks where the destination directory has been deleted. ([#2012][github-2012])
 * ![Maintenance][badge-maintenance] Documenter now uses [MarkdownAST][markdownast] to internally represent Markdown documents. While this change should not lead to any visible changes to the user, it is a major refactoring of the code. Please report any novel errors or unexpected behavior you encounter when upgrading to 0.28 on the [Documenter issue tracker][documenter-issues]. ([#1892][github-1892], [#1912][github-1912], [#1924][github-1924], [#1948][github-1948])
 * ![Maintenance][badge-maintenance] The code layout has changed considerably, with many of the internal submodules removed. This **may be breaking** for code that hooks into various Documenter internals, as various types and functions now live at different code paths. ([#1977][github-1977])
 
@@ -1183,6 +1184,7 @@
 [github-1989]: https://github.com/JuliaDocs/Documenter.jl/pull/1989
 [github-1991]: https://github.com/JuliaDocs/Documenter.jl/pull/1991
 [github-1993]: https://github.com/JuliaDocs/Documenter.jl/pull/1993
+[github-2012]: https://github.com/JuliaDocs/Documenter.jl/pull/2012
 <!-- end of issue link definitions -->
 
 [julia-29344]: https://github.com/JuliaLang/julia/issues/29344

--- a/src/deploydocs.jl
+++ b/src/deploydocs.jl
@@ -442,7 +442,7 @@ function git_push(
 end
 
 function rm_and_add_symlink(target, link)
-    if ispath(link)
+    if ispath(link) || islink(link)
         @warn "removing `$(link)` and linking `$(link)` to `$(target)`."
         rm(link; force = true, recursive = true)
     end


### PR DESCRIPTION
`ispath(existing_symlink)` returns `false` if the target of the symlink doesn't exist anymore, but `symlink(target, existing_symlink)` errors with `file already exists`. I had this problem after I deleted something that the `stable` symlink pointed to.