### PR TITLE
Remove pirated method from Expanders.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ AbstractTrees = "0.4"
 DocStringExtensions = "0.4, 0.5, 0.6, 0.7, 0.8, 0.9"
 IOCapture = "0.2"
 JSON = "0.19, 0.20, 0.21"
-MarkdownAST = "0.1"
+MarkdownAST = "0.1.1"
 julia = "1.6"
 
 [extras]

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -763,13 +763,6 @@ function Selectors.runner(::Type{ExampleBlocks}, node, page, doc)
     append!(node.children, content)
 end
 
-# TODO: move into MarkdownAST
-function Base.append!(nodechildren::MarkdownAST.NodeChildren, children)
-    for child in children
-        push!(nodechildren, child)
-    end
-end
-
 # Replace references to gensym'd module with Main
 function remove_sandbox_from_output(str, mod::Module)
     replace(str, Regex(("(Main\\.)?$(nameof(mod))")) => "Main")


### PR DESCRIPTION
Closes https://github.com/JuliaDocs/Documenter.jl/pull/2011

We should potentially update the lower bound on MarkdownAST to 0.1.1 as well?