### PR TITLE
add trailing slash to version selector URL

### DIFF
--- a/assets/html/js/versions.js
+++ b/assets/html/js/versions.js
@@ -27,7 +27,7 @@ $(document).ready(function() {
     var existing_versions = version_selector_select.children("option");
     var existing_versions_texts = existing_versions.map(function(i,x){return x.text});
     DOC_VERSIONS.forEach(function(each) {
-      var version_url = documenterBaseURL + "/../" + each;
+      var version_url = documenterBaseURL + "/../" + each + "/";
       var existing_id = $.inArray(each, existing_versions_texts);
       // if not already in the version selector, add it as a new option,
       // otherwise update the old option with the URL and enable it


### PR DESCRIPTION
Fix #2022 .

I haven't tested that yet.