### PR TITLE
Retrigger precompilation when Project.toml changes

### DIFF
--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -25,6 +25,7 @@ using Base64: base64decode
 # Version number of Documenter itself
 const DOCUMENTER_VERSION = let
     project = joinpath(dirname(dirname(pathof(Documenter))), "Project.toml")
+    Base.include_dependency(project) # Retrigger precompilation when Project.toml changes
     toml = read(project, String)
     m = match(r"(*ANYCRLF)^version\s*=\s\"(.*)\"$"m, toml)
     VersionNumber(m[1])


### PR DESCRIPTION
This patch make precompilation dependent on the Project.toml file. This is necessary since the Documenter version is read from this file during precompilation, and it will not be updated correctly otherwise. This only matters if you are currently developing the package and will have no effect on regular use/users.