### PR TITLE
Bump KaTeX from `v0.13.24` to `v0.16.4`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added keyboard shortcuts for search box (`Ctrl + /` or `Cmd + /` to focus into the search box, `Esc` to focus out of it). (#1536), (#2027)
 
+* KaTeX has been updated from `v0.13.24` to `v0.16.4` (major version bump).
+
 ### Fixed
 
 * Documenter now generates the correct source URLs for docstrings from other packages when the `repo` argument to `makedocs` is set (note: the source links to such docstrings only work if the external package is cloned from GitHub and added as a dev-dependency). However, this change **breaks** the case where the `repo` argument is used to override the main package/repository URL, assuming the repository is cloned from GitHub. (#1808)

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -171,7 +171,7 @@ struct KaTeX <: MathEngine
             :delimiters => [
                 Dict(:left => raw"$",   :right => raw"$",   display => false),
                 Dict(:left => raw"$$",  :right => raw"$$",  display => true),
-                Dict(:left => raw"\[", :right => raw"\]", display => true),
+                Dict(:left => raw"\[",  :right => raw"\]",  display => true),
             ]
         )
         new((config === nothing) ? default : override ? config : merge(default, config))

--- a/src/html/RD.jl
+++ b/src/html/RD.jl
@@ -60,7 +60,7 @@ module RD
     end
 
     # MathJax & KaTeX
-    const katex_version = "0.13.24"
+    const katex_version = "0.16.4"
     const katex_css = "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/$(katex_version)/katex.min.css"
     function mathengine!(r::RequireJS, engine::KaTeX)
         push!(r, RemoteLibrary(


### PR DESCRIPTION
Close #2043
