### PR TITLE
Update JS deps to latest non-breaking version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added keyboard shortcuts for search box (`Ctrl + /` or `Cmd + /` to focus into the search box, `Esc` to focus out of it). (#1536), (#2027)
 
+* highlight.js has been updated from `v11.5.1` to `v11.7.0`.
+
 ### Fixed
 
 * Documenter now generates the correct source URLs for docstrings from other packages when the `repo` argument to `makedocs` is set (note: the source links to such docstrings only work if the external package is cloned from GitHub and added as a dev-dependency). However, this change **breaks** the case where the `repo` argument is used to override the main package/repository URL, assuming the repository is cloned from GitHub. (#1808)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,10 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added keyboard shortcuts for search box (`Ctrl + /` or `Cmd + /` to focus into the search box, `Esc` to focus out of it). (#1536), (#2027)
 
-* KaTeX has been updated from `v0.13.24` to `v0.16.4` (major version bump). (#2066)
+* The various JS and font dependencies of the HTML backend have been updated to the latest non-breaking versions. (#2066, #2067)
 
-* The various JS and font dependencies of the HTML backend have been updated to the latest non-breaking versions. (#2067)
-    
+  - KaTeX has been updated from `v0.13.24` to `v0.16.4` (major version bump).    
   - highlight.js has been updated from `v11.5.1` to `v11.7.0`.
   - JuliaMono has been updated from `v0.045` to `v0.048`.
   - jQuery UI has been updated from `v1.12.1` to `v1.13.2`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - highlight.js has been updated from `v11.5.1` to `v11.7.0`.
   - JuliaMono has been updated from `v0.045` to `v0.048`.
   - jQuery UI has been updated from `v1.12.1` to `v1.13.2`.
+  - jquery has been updated from `v3.6.0` to `v3.6.4`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,9 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added keyboard shortcuts for search box (`Ctrl + /` or `Cmd + /` to focus into the search box, `Esc` to focus out of it). (#1536), (#2027)
 
-* KaTeX has been updated from `v0.13.24` to `v0.16.4` (major version bump).
+* KaTeX has been updated from `v0.13.24` to `v0.16.4` (major version bump). (#2066)
 
-* The various JS and font dependencies of the HTML backend have been updated to the latest non-breaking versions.
+* The various JS and font dependencies of the HTML backend have been updated to the latest non-breaking versions. (#2067)
     
   - highlight.js has been updated from `v11.5.1` to `v11.7.0`.
   - JuliaMono has been updated from `v0.045` to `v0.048`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - JuliaMono has been updated from `v0.045` to `v0.048`.
   - jQuery UI has been updated from `v1.12.1` to `v1.13.2`.
   - jquery has been updated from `v3.6.0` to `v3.6.4`.
+  - MathJax 2 has been updated  from `v2.7.7` to `v2.7.9`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,9 +63,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added keyboard shortcuts for search box (`Ctrl + /` or `Cmd + /` to focus into the search box, `Esc` to focus out of it). (#1536), (#2027)
 
-* highlight.js has been updated from `v11.5.1` to `v11.7.0`.
-
-* JuliaMono has been updated from `v0.045` to `v0.048`.
+* The various JS and font dependencies of the HTML backend have been updated to the latest non-breaking versions.
+    
+  - highlight.js has been updated from `v11.5.1` to `v11.7.0`.
+  - JuliaMono has been updated from `v0.045` to `v0.048`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * highlight.js has been updated from `v11.5.1` to `v11.7.0`.
 
+* JuliaMono has been updated from `v0.045` to `v0.048`.
+
 ### Fixed
 
 * Documenter now generates the correct source URLs for docstrings from other packages when the `repo` argument to `makedocs` is set (note: the source links to such docstrings only work if the external package is cloned from GitHub and added as a dev-dependency). However, this change **breaks** the case where the `repo` argument is used to override the main package/repository URL, assuming the repository is cloned from GitHub. (#1808)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     
   - highlight.js has been updated from `v11.5.1` to `v11.7.0`.
   - JuliaMono has been updated from `v0.045` to `v0.048`.
+  - jQuery UI has been updated from `v1.12.1` to `v1.13.2`.
 
 ### Fixed
 

--- a/assets/html/scss/highlightjs/a11y-dark.css
+++ b/assets/html/scss/highlightjs/a11y-dark.css
@@ -1,3 +1,4 @@
+/* https://github.com/highlightjs/highlight.js/blob/11.7.0/src/styles/a11y-dark.css */
 /*!
   Theme: a11y-dark
   Author: @ericwbailey

--- a/assets/html/scss/highlightjs/default.css
+++ b/assets/html/scss/highlightjs/default.css
@@ -1,3 +1,4 @@
+/* https://github.com/highlightjs/highlight.js/blob/11.7.0/src/styles/default.css */
 /*!
   Theme: Default
   Description: Original highlight.js style
@@ -17,6 +18,7 @@ Typically this "required" baseline CSS is added by `makestuff.js` during build.
 pre code.hljs {
   display: block;
   overflow-x: auto;
+  padding: 1em;
 }
 
 code.hljs {
@@ -25,7 +27,7 @@ code.hljs {
 /* end baseline CSS */
 
 .hljs {
-  background: #F0F0F0;
+  background: #F3F3F3;
   color: #444;
 }
 
@@ -42,7 +44,7 @@ code.hljs {
 .hljs-params {}
 
 .hljs-comment {
-  color: #888888;
+  color: #697070;
 }
 .hljs-tag,
 .hljs-punctuation {
@@ -93,13 +95,13 @@ code.hljs {
 .hljs-selector-attr,
 .hljs-operator,
 .hljs-selector-pseudo {
-  color: #BC6060;
+  color: #ab5656;
 }
 
 /* Language color: hue: 90; */
 
 .hljs-literal {
-  color: #78A960;
+  color: #695;
 }
 
 .hljs-built_in,
@@ -117,7 +119,7 @@ code.hljs {
 }
 
 .hljs-meta .hljs-string {
-  color: #4d99bf;
+  color: #38a;
 }
 
 

--- a/assets/html/themes/documenter-dark.css
+++ b/assets/html/themes/documenter-dark.css
@@ -1056,6 +1056,7 @@ html.theme--documenter-dark {
  *
  * The main container is <div> that is identified by id #documenter.
  */
+  /* https://github.com/highlightjs/highlight.js/blob/11.7.0/src/styles/a11y-dark.css */
   /*!
   Theme: a11y-dark
   Author: @ericwbailey

--- a/assets/html/themes/documenter-light.css
+++ b/assets/html/themes/documenter-light.css
@@ -7638,6 +7638,7 @@ code.language-julia-repl > span.hljs-meta {
   color: #066f00;
   font-weight: bolder; }
 
+/* https://github.com/highlightjs/highlight.js/blob/11.7.0/src/styles/default.css */
 /*!
   Theme: Default
   Description: Original highlight.js style
@@ -7655,14 +7656,15 @@ Typically this "required" baseline CSS is added by `makestuff.js` during build.
 */
 pre code.hljs {
   display: block;
-  overflow-x: auto; }
+  overflow-x: auto;
+  padding: 1em; }
 
 code.hljs {
   padding: 3px 5px; }
 
 /* end baseline CSS */
 .hljs {
-  background: #F0F0F0;
+  background: #F3F3F3;
   color: #444; }
 
 /* Base color: saturation 0; */
@@ -7671,7 +7673,7 @@ code.hljs {
 
 /* purposely ignored */
 .hljs-comment {
-  color: #888888; }
+  color: #697070; }
 
 .hljs-tag,
 .hljs-punctuation {
@@ -7713,11 +7715,11 @@ code.hljs {
 .hljs-selector-attr,
 .hljs-operator,
 .hljs-selector-pseudo {
-  color: #BC6060; }
+  color: #ab5656; }
 
 /* Language color: hue: 90; */
 .hljs-literal {
-  color: #78A960; }
+  color: #695; }
 
 .hljs-built_in,
 .hljs-bullet,
@@ -7730,7 +7732,7 @@ code.hljs {
   color: #1f7199; }
 
 .hljs-meta .hljs-string {
-  color: #4d99bf; }
+  color: #38a; }
 
 /* Misc effects */
 .hljs-emphasis {

--- a/src/html/RD.jl
+++ b/src/html/RD.jl
@@ -34,7 +34,7 @@ module RD
         # NOTE: the CSS themes for hightlightjs are compiled into the Documenter CSS
         # When updating this dependency, it is also necessary to update the the CSS
         # files the CSS files in assets/html/scss/highlightjs
-        hljs_version = "11.5.1"
+        hljs_version = "11.7.0"
         push!(r, RemoteLibrary(
             "highlight",
             "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/$(hljs_version)/highlight.min.js"

--- a/src/html/RD.jl
+++ b/src/html/RD.jl
@@ -14,7 +14,7 @@ module RD
         "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/$(fontawesome_version)/css/brands.min.css",
     ]
 
-    const jquery = RemoteLibrary("jquery", "https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js")
+    const jquery = RemoteLibrary("jquery", "https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.4/jquery.min.js")
     const jqueryui = RemoteLibrary("jqueryui", "https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.13.2/jquery-ui.min.js")
     const lunr = RemoteLibrary("lunr", "https://cdnjs.cloudflare.com/ajax/libs/lunr.js/2.3.9/lunr.min.js")
     const lodash = RemoteLibrary("lodash", "https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js")

--- a/src/html/RD.jl
+++ b/src/html/RD.jl
@@ -86,7 +86,7 @@ module RD
         ))
     end
     function mathengine!(r::RequireJS, engine::MathJax2)
-        url = isempty(engine.url) ? "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-AMS_HTML" : engine.url
+        url = isempty(engine.url) ? "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-AMS_HTML" : engine.url
         push!(r, RemoteLibrary(
             "mathjax",
             url,

--- a/src/html/RD.jl
+++ b/src/html/RD.jl
@@ -6,7 +6,7 @@ module RD
 
     const requirejs_cdn = "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"
     const lato = "https://cdnjs.cloudflare.com/ajax/libs/lato-font/3.0.0/css/lato-font.min.css"
-    const juliamono = "https://cdnjs.cloudflare.com/ajax/libs/juliamono/0.045/juliamono.min.css"
+    const juliamono = "https://cdnjs.cloudflare.com/ajax/libs/juliamono/0.048/juliamono.min.css"
     const fontawesome_version = "5.15.4"
     const fontawesome_css = [
         "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/$(fontawesome_version)/css/fontawesome.min.css",

--- a/src/html/RD.jl
+++ b/src/html/RD.jl
@@ -15,7 +15,7 @@ module RD
     ]
 
     const jquery = RemoteLibrary("jquery", "https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js")
-    const jqueryui = RemoteLibrary("jqueryui", "https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js")
+    const jqueryui = RemoteLibrary("jqueryui", "https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.13.2/jquery-ui.min.js")
     const lunr = RemoteLibrary("lunr", "https://cdnjs.cloudflare.com/ajax/libs/lunr.js/2.3.9/lunr.min.js")
     const lodash = RemoteLibrary("lodash", "https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js")
 


### PR DESCRIPTION
- require.js: No Update, 2.3.6
  https://requirejs.org/docs/download.html
- lato-font: No Update, 3.0.0
  https://cdnjs.dev/libraries/lato-font
- [x] JuliaMono from v0.045 to v0.048
  https://github.com/cormullion/juliamono/releases/latest
- Font Awesome: No Update, v5.15.4
  https://fontawesome.com/v5/download

~~Do we need to update jQuery UI?~~
- [x] jquery: 3.6.0 => 3.6.4
  https://jquery.com/download/
- [x] jQuery UI: 1.12.1 => 1.13.2
  https://jqueryui.com/download/
- lunr.js: No update, 2.3.9
  No updates since August 2020, https://github.com/olivernn/lunr.js/
- lodash.js: No update, 4.17.21
  No updates since April 2021, https://github.com/lodash/lodash
- headroom: No Update, 0.12.0
  https://cdnjs.dev/libraries/headroom
- [x] highlight.js from v11.5.1 to v11.7.0
  https://github.com/highlightjs/highlight.js/releases/latest

MathJax & KaTeX
- KaTeX: major update: v0.13.24 => v0.16.4
  #2066
- [x] MathJax 2: may update from `2.7.7` to `2.7.9`
  https://cdnjs.dev/libraries/mathjax/2.7.9
- MathJax 3: No Update, v3.2.2
  https://github.com/mathjax/MathJax-src/releases/latest

xref: last update: #1846
