### PR TITLE
Remove .mapping field from Page

### DIFF
--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -729,7 +729,6 @@ function Selectors.runner(::Type{ExampleBlocks}, node, page, doc)
                     $(x.code)
                     ```
                     """, exception = (c.value, bt))
-                page.mapping[x] = x
                 return
             end
         end

--- a/src/documents.jl
+++ b/src/documents.jl
@@ -34,7 +34,6 @@ struct Page
     element does not need expanding or some other object, such as a `DocsNode` in the case
     of `@docs` code blocks.
     """
-    mapping  :: IdDict{Any,Any}
     globals  :: Globals
     mdast   :: MarkdownAST.Node{Nothing}
 end
@@ -56,7 +55,7 @@ function Page(source::AbstractString, build::AbstractString, workdir::AbstractSt
             """
         rethrow(err)
     end
-    Page(source, build, workdir, mdpage.content, IdDict{Any,Any}(), Globals(), mdast)
+    Page(source, build, workdir, mdpage.content, Globals(), mdast)
 end
 
 # FIXME -- special overload for parseblock

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -280,7 +280,7 @@ end
     end
 
     import Documenter: Document, Page, Globals
-    let page = Page("source", "build", :build, [], IdDict{Any,Any}(), Globals(), MarkdownAST.@ast MarkdownAST.Document()), doc = Document()
+    let page = Page("source", "build", :build, [], Globals(), MarkdownAST.@ast MarkdownAST.Document()), doc = Document()
         code = """
         x += 3
         γγγ_γγγ


### PR DESCRIPTION
This field is no longer used. Should have been removed in #1948.