### PR TITLE
Bump Font Awesome from v5.15.4 to v6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - jquery has been updated from `v3.6.0` to `v3.6.4`.
   - MathJax 2 has been updated  from `v2.7.7` to `v2.7.9`.
 
-
 ### Fixed
 
 * Documenter now generates the correct source URLs for docstrings from other packages when the `repo` argument to `makedocs` is set (note: the source links to such docstrings only work if the external package is cloned from GitHub and added as a dev-dependency). However, this change **breaks** the case where the `repo` argument is used to override the main package/repository URL, assuming the repository is cloned from GitHub. (#1808)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * KaTeX has been updated from `v0.13.24` to `v0.16.4` (major version bump).
 
+* Font Awesome has been updated from `v5.15.4` to `v6.3.0` (major version bump).
+
 ### Fixed
 
 * Documenter now generates the correct source URLs for docstrings from other packages when the `repo` argument to `makedocs` is set (note: the source links to such docstrings only work if the external package is cloned from GitHub and added as a dev-dependency). However, this change **breaks** the case where the `repo` argument is used to override the main package/repository URL, assuming the repository is cloned from GitHub. (#1808)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,16 +63,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added keyboard shortcuts for search box (`Ctrl + /` or `Cmd + /` to focus into the search box, `Esc` to focus out of it). (#1536), (#2027)
 
-* The various JS and font dependencies of the HTML backend have been updated to the latest non-breaking versions. (#2066, #2067)
+* The various JS and font dependencies of the HTML backend have been updated to the latest non-breaking versions. (#2066, #2067, #2070)
 
-  - KaTeX has been updated from `v0.13.24` to `v0.16.4` (major version bump).    
+  - KaTeX has been updated from `v0.13.24` to `v0.16.4` (major version bump).
+  - Font Awesome has been updated from `v5.15.4` to `v6.3.0` (major version bump).
   - highlight.js has been updated from `v11.5.1` to `v11.7.0`.
   - JuliaMono has been updated from `v0.045` to `v0.048`.
   - jQuery UI has been updated from `v1.12.1` to `v1.13.2`.
   - jquery has been updated from `v3.6.0` to `v3.6.4`.
   - MathJax 2 has been updated  from `v2.7.7` to `v2.7.9`.
 
-* Font Awesome has been updated from `v5.15.4` to `v6.3.0` (major version bump).
 
 ### Fixed
 

--- a/assets/html/js/copy.js
+++ b/assets/html/js/copy.js
@@ -1,7 +1,7 @@
 function addCopyButtonCallbacks() {
   for (const el of document.getElementsByTagName("pre")) {
     const button = document.createElement("button");
-    button.classList.add("copy-button", "fas", "fa-copy");
+    button.classList.add("copy-button", "fa-solid", "fa-copy");
     button.setAttribute("aria-label", "Copy this code block");
     button.setAttribute("title", "Copy");
 
@@ -13,7 +13,7 @@ function addCopyButtonCallbacks() {
     };
 
     const failure = function () {
-      button.classList.add("error", "fa-times");
+      button.classList.add("error", "fa-xmark");
       button.classList.remove("fa-copy");
     };
 
@@ -22,7 +22,7 @@ function addCopyButtonCallbacks() {
 
       setTimeout(function () {
         button.classList.add("fa-copy");
-        button.classList.remove("success", "fa-check", "fa-times");
+        button.classList.remove("success", "fa-check", "fa-xmark");
       }, 5000);
     });
   }

--- a/assets/html/scss/documenter/_elements.scss
+++ b/assets/html/scss/documenter/_elements.scss
@@ -15,6 +15,7 @@ h1, h2, h3, h4, h5, h6 {
 
     &::before {
       @include font-awesome;
+      // fa-link
       content: "\f0c1";
     }
   }
@@ -63,7 +64,7 @@ pre {
     height: 2.5em;
     background: transparent;
     border: none;
-    font-family: "Font Awesome 5 Free";
+    font-family: "Font Awesome 6 Free";
     color: $body-color;
     cursor: pointer;
     text-align: center;

--- a/assets/html/scss/documenter/_utilities.scss
+++ b/assets/html/scss/documenter/_utilities.scss
@@ -1,5 +1,5 @@
-/* Font Awesome 5 mixin. Can be included in any rule that should render Font Awesome icons. */
+/* Font Awesome 6 mixin. Can be included in any rule that should render Font Awesome icons. */
 @mixin font-awesome {
-  font-family: "Font Awesome 5 Free";
+  font-family: "Font Awesome 6 Free";
   font-weight: 900;
 }

--- a/assets/html/scss/documenter/components/_admonition.scss
+++ b/assets/html/scss/documenter/components/_admonition.scss
@@ -87,6 +87,7 @@ $admonition-header-color: () !default;
   &:before {
     @include font-awesome;
     margin-right: $documenter-container-left-padding;
+    // fa-circle-exclamation
     content: "\f06a";
   }
 }

--- a/assets/html/scss/documenter/layout/_sidebar.scss
+++ b/assets/html/scss/documenter/layout/_sidebar.scss
@@ -136,11 +136,13 @@
         margin-bottom: auto;
         &::before {
           @include font-awesome;
+          // fa-chevron-right
           content: "\f054";
         }
       }
     }
     input:checked ~ label.tocitem .docs-chevron::before {
+      // fa-chevron-down
       content: "\f078";
     }
 

--- a/assets/html/themes/documenter-dark.css
+++ b/assets/html/themes/documenter-dark.css
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-/* Font Awesome 5 mixin. Can be included in any rule that should render Font Awesome icons. */
+/* Font Awesome 6 mixin. Can be included in any rule that should render Font Awesome icons. */
 @keyframes spinAround {
   from {
     transform: rotate(0deg); }
@@ -7079,7 +7079,7 @@ html.theme--documenter-dark {
     margin-left: 0.5em;
     font-size: 0.7rem; }
     html.theme--documenter-dark h1 .docs-heading-anchor-permalink::before, html.theme--documenter-dark h2 .docs-heading-anchor-permalink::before, html.theme--documenter-dark h3 .docs-heading-anchor-permalink::before, html.theme--documenter-dark h4 .docs-heading-anchor-permalink::before, html.theme--documenter-dark h5 .docs-heading-anchor-permalink::before, html.theme--documenter-dark h6 .docs-heading-anchor-permalink::before {
-      font-family: "Font Awesome 5 Free";
+      font-family: "Font Awesome 6 Free";
       font-weight: 900;
       content: "\f0c1"; }
   html.theme--documenter-dark h1:hover .docs-heading-anchor-permalink, html.theme--documenter-dark h2:hover .docs-heading-anchor-permalink, html.theme--documenter-dark h3:hover .docs-heading-anchor-permalink, html.theme--documenter-dark h4:hover .docs-heading-anchor-permalink, html.theme--documenter-dark h5:hover .docs-heading-anchor-permalink, html.theme--documenter-dark h6:hover .docs-heading-anchor-permalink {
@@ -7108,7 +7108,7 @@ html.theme--documenter-dark {
       height: 2.5em;
       background: transparent;
       border: none;
-      font-family: "Font Awesome 5 Free";
+      font-family: "Font Awesome 6 Free";
       color: #fff;
       cursor: pointer;
       text-align: center; }
@@ -7178,7 +7178,7 @@ html.theme--documenter-dark {
     padding: 0.5rem 0.75rem;
     position: relative; }
     html.theme--documenter-dark .admonition-header:before {
-      font-family: "Font Awesome 5 Free";
+      font-family: "Font Awesome 6 Free";
       font-weight: 900;
       margin-right: 0.75rem;
       content: "\f06a"; }
@@ -7470,7 +7470,7 @@ html.theme--documenter-dark {
           margin-top: auto;
           margin-bottom: auto; }
           html.theme--documenter-dark #documenter .docs-sidebar ul.docs-menu label.tocitem .docs-chevron::before {
-            font-family: "Font Awesome 5 Free";
+            font-family: "Font Awesome 6 Free";
             font-weight: 900;
             content: "\f054"; }
       html.theme--documenter-dark #documenter .docs-sidebar ul.docs-menu input:checked ~ label.tocitem .docs-chevron::before {

--- a/assets/html/themes/documenter-light.css
+++ b/assets/html/themes/documenter-light.css
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-/* Font Awesome 5 mixin. Can be included in any rule that should render Font Awesome icons. */
+/* Font Awesome 6 mixin. Can be included in any rule that should render Font Awesome icons. */
 @keyframes spinAround {
   from {
     transform: rotate(0deg); }
@@ -6990,7 +6990,7 @@ h1 .docs-heading-anchor-permalink, h2 .docs-heading-anchor-permalink, h3 .docs-h
   margin-left: 0.5em;
   font-size: 0.7rem; }
   h1 .docs-heading-anchor-permalink::before, h2 .docs-heading-anchor-permalink::before, h3 .docs-heading-anchor-permalink::before, h4 .docs-heading-anchor-permalink::before, h5 .docs-heading-anchor-permalink::before, h6 .docs-heading-anchor-permalink::before {
-    font-family: "Font Awesome 5 Free";
+    font-family: "Font Awesome 6 Free";
     font-weight: 900;
     content: "\f0c1"; }
 
@@ -7022,7 +7022,7 @@ pre {
     height: 2.5em;
     background: transparent;
     border: none;
-    font-family: "Font Awesome 5 Free";
+    font-family: "Font Awesome 6 Free";
     color: #222222;
     cursor: pointer;
     text-align: center; }
@@ -7113,7 +7113,7 @@ pre {
   padding: 0.5rem 0.75rem;
   position: relative; }
   .admonition-header:before {
-    font-family: "Font Awesome 5 Free";
+    font-family: "Font Awesome 6 Free";
     font-weight: 900;
     margin-right: 0.75rem;
     content: "\f06a"; }
@@ -7433,7 +7433,7 @@ li.no-marker {
         margin-top: auto;
         margin-bottom: auto; }
         #documenter .docs-sidebar ul.docs-menu label.tocitem .docs-chevron::before {
-          font-family: "Font Awesome 5 Free";
+          font-family: "Font Awesome 6 Free";
           font-weight: 900;
           content: "\f054"; }
     #documenter .docs-sidebar ul.docs-menu input:checked ~ label.tocitem .docs-chevron::before {

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -1196,7 +1196,7 @@ function render_navbar(ctx, navnode, edit_page_link::Bool)
             repo_title = "View the repository" * (isempty(host) ? "" : " on $host")
             push!(navbar_right.nodes,
                 a[".docs-navbar-link", :href => url, :title => repo_title](
-                    span[".docs-icon.fab"](logo),
+                    span[".docs-icon.fa-brands"](logo),
                     span[".docs-label.is-hidden-touch"](isempty(host) ? "Repository" : host)
                 )
             )
@@ -1207,20 +1207,20 @@ function render_navbar(ctx, navnode, edit_page_link::Bool)
     edit_page_link && edit_link(ctx, navnode) do logo, title, url
         push!(navbar_right.nodes,
             a[".docs-navbar-link", :href => url, :title => title](
-                span[".docs-icon.fas"](logo)
+                span[".docs-icon.fa-solid"](logo)
             )
         )
     end
 
     # Settings cog
     push!(navbar_right.nodes, a[
-        "#documenter-settings-button.docs-settings-button.docs-navbar-link.fas.fa-cog",
+        "#documenter-settings-button.docs-settings-button.docs-navbar-link.fa-solid.fa-gear",
         :href => "#", :title => "Settings",
     ])
 
     # Hamburger on mobile
     push!(navbar_right.nodes, a[
-        "#documenter-sidebar-button.docs-sidebar-button.docs-navbar-link.fa.fa-bars.is-hidden-desktop",
+        "#documenter-sidebar-button.docs-sidebar-button.docs-navbar-link.fa-solid.fa-bars.is-hidden-desktop",
         :href => "#",
     ])
 
@@ -1232,7 +1232,7 @@ end
 Calls `f(logo, title, url)` if it is possible to create an edit link for the `navnode`.
 """
 function edit_link(f, ctx, navnode)
-    view_logo, edit_logo = "\uf15c", "\uf044" # 'file-alt' and 'edit', from .fas class
+    view_logo, edit_logo = "\uf15c", "\uf044" # 'fa-file-lines' and 'fa-pen-to-square', from .fa-solid class
     # Let's fetch the edit path. Usually this is the source file of the page, but the user
     # can override it specifying the EditURL option in an @meta block. Usually, it is a
     # relative path pointing to a file, but can also be set to an absolute URL.
@@ -1281,12 +1281,12 @@ function edit_link(f, ctx, navnode)
     return
 end
 
-# All these logos are from the .fab (brands) class
-const host_logo_github    = (host = "GitHub",       logo = "\uf09b")
-const host_logo_bitbucket = (host = "BitBucket",    logo = "\uf171")
-const host_logo_gitlab    = (host = "GitLab",       logo = "\uf296")
-const host_logo_azure     = (host = "Azure DevOps", logo = "\uf3ca") # microsoft; TODO: change to ADO logo when added to FontAwesome
-const host_logo_fallback  = (host = "",             logo = "\uf841") # git-alt
+# All these logos are from the .fa-brands (brands) class
+const host_logo_github    = (host = "GitHub",       logo = "\uf09b") # fa-github
+const host_logo_bitbucket = (host = "BitBucket",    logo = "\uf171") # fa-bitbucket
+const host_logo_gitlab    = (host = "GitLab",       logo = "\uf296") # fa-gitlab
+const host_logo_azure     = (host = "Azure DevOps", logo = "\uf3ca") # fa-microsoft; TODO: change to ADO logo when added to FontAwesome
+const host_logo_fallback  = (host = "",             logo = "\uf841") # fa-git-alt
 host_logo(remote::Remotes.GitHub) = host_logo_github
 host_logo(remote::Remotes.URL) = host_logo(remote.urltemplate)
 host_logo(remote::Union{Remotes.Remote,Nothing}) = host_logo_fallback

--- a/src/html/RD.jl
+++ b/src/html/RD.jl
@@ -7,7 +7,7 @@ module RD
     const requirejs_cdn = "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"
     const lato = "https://cdnjs.cloudflare.com/ajax/libs/lato-font/3.0.0/css/lato-font.min.css"
     const juliamono = "https://cdnjs.cloudflare.com/ajax/libs/juliamono/0.045/juliamono.min.css"
-    const fontawesome_version = "5.15.4"
+    const fontawesome_version = "6.3.0"
     const fontawesome_css = [
         "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/$(fontawesome_version)/css/fontawesome.min.css",
         "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/$(fontawesome_version)/css/solid.min.css",


### PR DESCRIPTION
icon & class rename:
- `f00d`: [v5 fa-times](https://fontawesome.com/v5/icons/times?s=solid&f=classic) => [v6 fa-xmark](https://fontawesome.com/icons/xmark?s=solid&f=classic)
- `f013`: [v5 fa-cog](https://fontawesome.com/v5/icons/cog?s=solid&f=classic) => [v6 fa-gear](https://fontawesome.com/icons/gear?s=solid&f=classic)
- `f15c`: [v5 fa-file-alt](https://fontawesome.com/v5/icons/file-alt?s=solid&f=classic) => [v6 fa-file-lines](https://fontawesome.com/icons/file-lines?s=solid&f=classic)
- `f044`: [v5 fa-edit](https://fontawesome.com/v5/icons/edit?s=solid&f=classic) => [v6 fa-pen-to-square](https://fontawesome.com/icons/pen-to-square?s=solid&f=classic)
- `fas` => `fa-solid`
- `fab` => `fa-brands`
