### PR TITLE
Correct some missed typos

### DIFF
--- a/assets/latex/preamble.tex
+++ b/assets/latex/preamble.tex
@@ -22,9 +22,9 @@
 %       - Figure 9.2: Layout of a ToC
 %       - Table 9.3: Value of K in macros for styling entries
 \makeatletter
-% {part} to {chaper}
+% {part} to {chapter}
 \setlength{\cftbeforepartskip}{1.5em \@plus \p@}
-% {chaper} to {chaper}
+% {chapter} to {chapter}
 \setlength{\cftbeforechapterskip}{0.0em \@plus \p@}
 % Chapter num to chapter title spacing (Figure 9.2@memman)
 \setlength{\cftchapternumwidth}{2.5em \@plus \p@}

--- a/test/TestUtilities.jl
+++ b/test/TestUtilities.jl
@@ -16,7 +16,7 @@ end
 function quietly_next_log()
     quietly_logs_enabled() || return nothing, nothing
     isdir(QUIETLY_LOG_DIR) || mkdir(QUIETLY_LOG_DIR)
-    # Find the next availble log file
+    # Find the next available log file
     logid, logfile = quietly_logfile(QUIETLY_LOG_COUNTER[])
     while isfile(logfile)
         QUIETLY_LOG_COUNTER[] += 1


### PR DESCRIPTION
I'm trying to set up [typos](https://github.com/crate-ci/typos) as a GitHub action to check for typos in pull requests, and I've found two typos that I've previously missed. I think we should get rid of them first.