### PR TITLE
Add Dockerfile for LaTeX build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MIT OR CC0-1.0
+# build image:
+#   docker build -t juliadocs/documenter-latex:1.0  .
+FROM ubuntu:18.04
+
+RUN useradd --create-home zeptodoctor
+RUN set -eux; \
+    apt-get update; \
+    apt-get install --no-install-recommends -y \
+    # minimal texlive
+        texlive-luatex \
+        texlive-latex-base \
+        texlive-latex-recommended \
+        texlive-latex-extra \
+    # latexmk: LaTeX build tool
+        latexmk \
+    # code highlighting
+        python-pygments \
+    # refresh the font cache
+        fontconfig \
+        ; \
+    rm -rf /var/lib/apt/lists/*; \
+    apt-get purge -y --auto-remove;
+
+WORKDIR /home/zeptodoctor/

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,10 @@
+# documenter-latex
+
+Docker image for compiling pdf output with
+[`Documenter.jl`](https://github.com/JuliaDocs/Documenter.jl)
+
+
+## Whats in the image?
+
+Ubuntu + a (minimal) texlive installation, essentially only including what's
+needed for compiling the output of `Documenter.jl`/`DocumenterLaTeX.jl`.

--- a/src/latex/LaTeXWriter.jl
+++ b/src/latex/LaTeXWriter.jl
@@ -171,6 +171,7 @@ function latex_fileprefix(doc::Documenter.Document, settings::LaTeX)
 end
 
 const DOCKER_IMAGE_TAG = "0.1"
+# TODO: const DOCKER_IMAGE_TAG = "1.0"
 
 function compile_tex(doc::Documenter.Document, settings::LaTeX, fileprefix::String)
     if settings.platform == "native"


### PR DESCRIPTION
Fix #2073 

- Do we want to update the version of Ubuntu? Maybe use `ubuntu:latest`
- Do we need a `tectonic` docker image? `juliadocs/documenter-tectonic`
	And rename texlive-based image to: `juliadocs/documenter-texlive`  
	Estimated size is 100MB~. And current image is 430MB+

todo
- [ ] run PDF build for `JuliaDocs/Documenter.jl`
- [ ] run PDF build for `JuliaLang/julia`
- [ ] release docker image, and update `DOCKER_IMAGE_TAG` in `src/latex/LaTeXWriter.jl`
