### PR TITLE
ci: generate better TagBot changelogs

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -16,5 +16,15 @@ jobs:
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
+          changelog: |
+            {% if custom %}
+            {{ custom }}
+            {% endif %}
+
+            The changes are documented in the [`CHANGELOG.md`](https://github.com/JuliaDocs/Documenter.jl/blob/{{ version }}/CHANGELOG.md) file.
+
+            {% if previous_release %}
+            [Diff since {{ previous_release }}]({{ compare_url }})
+            {% endif %}
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
This should hopefully solve the problem of bad, confusing changelogs appearing in the GitHub Release release notes going forward. I don't know if it actually works correctly, but I hope it would generated something like this:

![image](https://user-images.githubusercontent.com/147757/233208283-5a698cba-00be-4517-a648-33d2e0275d56.png)
