### PR TITLE
Add `@diagram` support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 IOCapture = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Kroki = "b3565e16-c1f2-4fe9-b4ab-221c88942068"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
@@ -18,6 +19,7 @@ MarkdownAST = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
@@ -28,6 +30,7 @@ IOCapture = "0.2"
 JSON = "0.19, 0.20, 0.21"
 MarkdownAST = "0.1.1"
 SnoopPrecompile = "1"
+TranscodingStreams = "=0.9.11"
 julia = "1.6"
 
 [extras]

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -761,3 +761,36 @@ It will show up as follows, with code having been copied over verbatim to the HT
     (SVG)
 </svg>
 ```
+
+## `@diagram <format>` block
+
+Uses the [Kroki.jl](https://github.com/bauglir/Kroki.jl/) binding for [kroki](https://kroki.io)
+to generate diagrams in multiple formats.
+
+````markdown
+```@diagram ditaa
++----------------+    +---------------+  +------+
+| @diagram block |--->| Documenter.jl |->| .svg |
++----------------+    +---------------+  +------+
+                       |        ^
+                       v        |
+                      +----------+   +----------+
+                      | Kroki.jl |<->| kroki.io |
+                      +----------+   +----------+
+
+```
+````
+
+It will render and inline the resulting image:
+
+```@diagram ditaa
++----------------+    +---------------+  +------+
+| @diagram block |--->| Documenter.jl |->| .svg |
++----------------+    +---------------+  +------+
+                       |        ^
+                       v        |
+                      +----------+   +----------+
+                      | Kroki.jl |<->| kroki.io |
+                      +----------+   +----------+
+
+```

--- a/src/Expanders.jl
+++ b/src/Expanders.jl
@@ -103,6 +103,7 @@ The default node expander "pipeline", which consists of the following expanders:
 - [`ExampleBlocks`](@ref)
 - [`SetupBlocks`](@ref)
 - [`REPLBlocks`](@ref)
+- [`DiagramBlocks`](@ref)
 
 """
 abstract type ExpanderPipeline <: Selectors.AbstractSelector end
@@ -236,6 +237,11 @@ Similar to the [`ExampleBlocks`](@ref) expander, but hides all output in the fin
 """
 abstract type SetupBlocks <: NestedExpanderPipeline end
 
+"""
+Similar to the `RawBlocks` expander, but generates diagrams instead.
+"""
+abstract type DiagramBlocks <: NestedExpanderPipeline end
+
 Selectors.order(::Type{TrackHeaders})   = 1.0
 Selectors.order(::Type{MetaBlocks})     = 2.0
 Selectors.order(::Type{DocsBlocks})     = 3.0
@@ -247,6 +253,7 @@ Selectors.order(::Type{ExampleBlocks})  = 8.0
 Selectors.order(::Type{REPLBlocks})     = 9.0
 Selectors.order(::Type{SetupBlocks})    = 10.0
 Selectors.order(::Type{RawBlocks})      = 11.0
+Selectors.order(::Type{DiagramBlocks})  = 12.0
 
 Selectors.matcher(::Type{TrackHeaders},   node, page, doc) = isa(node.element, MarkdownAST.Heading)
 Selectors.matcher(::Type{MetaBlocks},     node, page, doc) = iscode(node, "@meta")
@@ -259,6 +266,7 @@ Selectors.matcher(::Type{ExampleBlocks},  node, page, doc) = iscode(node, r"^@ex
 Selectors.matcher(::Type{REPLBlocks},     node, page, doc) = iscode(node, r"^@repl")
 Selectors.matcher(::Type{SetupBlocks},    node, page, doc) = iscode(node, r"^@setup")
 Selectors.matcher(::Type{RawBlocks},      node, page, doc) = iscode(node, r"^@raw")
+Selectors.matcher(::Type{DiagramBlocks},  node, page, doc) = iscode(node, r"^@diagram")
 
 # Default Expander.
 
@@ -893,6 +901,19 @@ function Selectors.runner(::Type{RawBlocks}, node, page, doc)
     m === nothing && error("invalid '@raw <name>' syntax: $(x.info)")
     node.element = Documenter.RawNode(Symbol(m[1]), x.code)
 end
+
+# @diagram
+# --------
+
+function Selectors.runner(::Type{DiagramBlocks}, node, page, doc)
+    @assert node.element isa MarkdownAST.CodeBlock
+    x = node.element
+
+    m = match(r"@diagram[ ](.+)$", x.info)
+    m === nothing && error("invalid '@diagram <format>' syntax: $(x.info)")
+    node.element = Documenter.DiagramNode(Symbol(m[1]), x.code)
+end
+
 
 # Documenter.
 # ----------

--- a/src/documents.jl
+++ b/src/documents.jl
@@ -165,6 +165,11 @@ struct RawNode <: AbstractDocumenterBlock
     text::String
 end
 
+struct DiagramNode <: AbstractDocumenterBlock
+    format::Symbol
+    code::String
+end
+
 # MultiOutput contains child nodes in .content that are either code blocks or
 # dictionaries corresponding to the outputs rendered with various MIME types.
 # In the MarkdownAST representation, the dictionaries get converted into
@@ -597,6 +602,7 @@ Base.show(io::IO, node::AbstractDocumenterBlock) = print(io, typeof(node), "([..
 MDFlatten.mdflatten(io, node::MarkdownAST.Node, ::AnchoredHeader) = MDFlatten.mdflatten(io, node.children)
 MDFlatten.mdflatten(io, node::MarkdownAST.Node, e::SetupNode) = MDFlatten.mdflatten(io, node, MarkdownAST.CodeBlock(e.name, e.code))
 MDFlatten.mdflatten(io, node::MarkdownAST.Node, e::RawNode) = MDFlatten.mdflatten(io, node, MarkdownAST.CodeBlock("@raw $(e.name)", e.text))
+MDFlatten.mdflatten(io, node::MarkdownAST.Node, e::DiagramNode) = MDFlatten.mdflatten(io, node, MarkdownAST.CodeBlock("@diagram $(e.format)", e.code))
 MDFlatten.mdflatten(io, node::MarkdownAST.Node, e::AbstractDocumenterBlock) = MDFlatten.mdflatten(io, node, e.codeblock)
 function MDFlatten.mdflatten(io, ::MarkdownAST.Node, e::DocsNode)
     # this special case separates top level blocks with newlines

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -44,6 +44,7 @@ using Dates: Dates, @dateformat_str, now
 import Markdown
 using MarkdownAST: MarkdownAST, Node
 import JSON
+import Kroki
 
 import ...Documenter:
     Anchors,
@@ -1669,6 +1670,12 @@ domify(::DCtx, ::Node, ::Documenter.SetupNode) = DOM.Node[]
 
 function domify(::DCtx, ::Node, raw::Documenter.RawNode)
     raw.name === :html ? Tag(Symbol("#RAW#"))(raw.text) : DOM.Node[]
+end
+
+function domify(::DCtx, ::Node, diag::Documenter.DiagramNode)
+    diagram_svg = Kroki.render(Kroki.Diagram(diag.format, diag.code), "svg")
+
+    Tag(Symbol("#RAW#"))(String(diagram_svg))
 end
 
 

--- a/src/latex/LaTeXWriter.jl
+++ b/src/latex/LaTeXWriter.jl
@@ -664,6 +664,12 @@ function latex(io::Context, node::Node, raw::Documenter.RawNode)
     raw.name === :latex ? _println(io, "\n", raw.text, "\n") : nothing
 end
 
+function latex(io::Context, ::Node, diag::Documenter.DiagramNode)
+    # TODO: Not sure about this.
+    # IDEA: write figure as png/pdf and _println \includegraphics since svg (default) is not very LaTeX-friendly
+    nothing
+end
+
 # Inline Elements.
 
 function latex(io::Context, node::Node, e::MarkdownAST.Text)


### PR DESCRIPTION
This pull request aims to add support for native diagrams in Julia docs by leveraging [Kroki.jl](https://github.com/bauglir/Kroki.jl/).

It adds a `@diagram <format>` code block allowing the user to select a format from those supported by [kroki](https://kroki.io).

PS: documentation skectch for `@diagram` already included.

Task list:
- [x] Implement `@diagram` block
- [ ] Add LaTeX support
- [ ] Write unit tests?