### PR TITLE
Changed display to none on docs-left

### DIFF
--- a/assets/html/scss/documenter/layout/_main.scss
+++ b/assets/html/scss/documenter/layout/_main.scss
@@ -59,7 +59,7 @@
         padding-top: 2px;
         padding-right: 0.5rem;
         .docs-sidebar-button {
-          display: inline-block;
+          display: none;
           font-size: 1.5rem;
         }
       }


### PR DESCRIPTION
Hey, I went ahead and fixed the bug by replacing the display: inline-block to display: none as it was mentioned. It would be wonderful if someone could validate this.