### PR TITLE
docs: run build with clean=true

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -105,7 +105,6 @@ makedocs(
     end,
     build = ("pdf" in ARGS) ? "build-pdf" : "build",
     debug = ("pdf" in ARGS),
-    clean = false,
     sitename = "Documenter.jl",
     authors = "Michael Hatherly, Morten Piibeleht, and contributors.",
     linkcheck = "linkcheck" in ARGS,


### PR DESCRIPTION
The default to `clean` is `true`, so might as well just omit it.