### PR TITLE
Render details admonitions as <details> in HTML backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Invalid local link warnings during HTML rendering now print a bit more context, helping in pinpointing the offending link. (#2100)
 
+* Admonitions with category `details` are now rendered as (collapsed) `<details>` in the HTML backend. The admonition title is used as the `<summary>`. (#2128)
+
 ### Fixed
 
 * Documenter now generates the correct source URLs for docstrings from other packages when the `repo` argument to `makedocs` is set (note: the source links to such docstrings only work if the external package is cloned from GitHub and added as a dev-dependency). However, this change **breaks** the case where the `repo` argument is used to override the main package/repository URL, assuming the repository is cloned from GitHub. (#1808)

--- a/assets/html/scss/documenter/components/_admonition.scss
+++ b/assets/html/scss/documenter/components/_admonition.scss
@@ -92,6 +92,21 @@ $admonition-header-color: () !default;
   }
 }
 
+details.admonition.is-details > .admonition-header {
+    list-style: none;
+    &:before {
+        @include font-awesome;
+        // fa-circle-plus
+        content: "\f055";
+    }
+}
+
+details[open].admonition.is-details > .admonition-header:before {
+    @include font-awesome;
+    // fa-circle-minus
+    content: "\f056";
+}
+
 .admonition-body {
   color: $message-body-color;
   padding: $documenter-admonition-body-padding;

--- a/assets/html/themes/documenter-dark.css
+++ b/assets/html/themes/documenter-dark.css
@@ -8095,6 +8095,16 @@ html.theme--documenter-dark {
       font-weight: 900;
       margin-right: 0.75rem;
       content: "\f06a"; }
+  html.theme--documenter-dark details.admonition.is-details > .admonition-header {
+    list-style: none; }
+    html.theme--documenter-dark details.admonition.is-details > .admonition-header:before {
+      font-family: "Font Awesome 6 Free";
+      font-weight: 900;
+      content: "\f055"; }
+  html.theme--documenter-dark details.admonition.is-details[open] > .admonition-header:before {
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    content: "\f056"; }
   html.theme--documenter-dark .admonition-body {
     color: #fff;
     padding: 0.5rem 0.75rem; }

--- a/assets/html/themes/documenter-light.css
+++ b/assets/html/themes/documenter-light.css
@@ -8037,6 +8037,18 @@ pre {
     margin-right: 0.75rem;
     content: "\f06a"; }
 
+details.admonition.is-details > .admonition-header {
+  list-style: none; }
+  details.admonition.is-details > .admonition-header:before {
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    content: "\f055"; }
+
+details.admonition.is-details[open] > .admonition-header:before {
+  font-family: "Font Awesome 6 Free";
+  font-weight: 900;
+  content: "\f056"; }
+
 .admonition-body {
   color: #222222;
   padding: 0.5rem 0.75rem; }

--- a/docs/src/showcase.md
+++ b/docs/src/showcase.md
@@ -118,6 +118,13 @@ Documenter supports a range of admonition types for different circumstances.
 !!! compat "'compat' admonition"
     This is a `!!! compat`-type admonition.
 
+###### Details admonition
+Admonitions with type `details` is rendered as a collapsed `<details>` block in
+the HTML output, with the admonition title as the `<summary>`.
+
+!!! details "'details' admonition"
+    This is a `!!! details`-type admonition.
+
 ###### Unknown admonition class
 !!! ukw "Unknown admonition class"
     Admonition with an unknown admonition class. This is a `code example`.

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -2048,7 +2048,7 @@ function domify(dctx::DCtx, node::Node, f::MarkdownAST.FootnoteDefinition)
 end
 
 function domify(dctx::DCtx, node::Node, a::MarkdownAST.Admonition)
-    @tags header div
+    @tags header div details summary
     colorclass =
         (a.category == "danger")  ? ".is-danger"  :
         (a.category == "warning") ? ".is-warning" :
@@ -2076,10 +2076,18 @@ function domify(dctx::DCtx, node::Node, a::MarkdownAST.Admonition)
             # apply a class
             isempty(cat_sanitized) ? "" : ".is-category-$(cat_sanitized)"
         end
-    div[".admonition$(colorclass)"](
-        header[".admonition-header"](a.title),
-        div[".admonition-body"](domify(dctx, node.children))
-    )
+
+    inner_div = div[".admonition-body"](domify(dctx, node.children))
+    if a.category == "details"
+        # details admonitions are rendered as <details><summary> blocks
+        details[".admonition.is-details"](
+            summary[".admonition-header"](a.title), inner_div
+        )
+    else
+        div[".admonition$(colorclass)"](
+            header[".admonition-header"](a.title), inner_div
+        )
+    end
 end
 
 # Select the "best" representation for HTML output.

--- a/test/examples/src/index.md
+++ b/test/examples/src/index.md
@@ -612,3 +612,46 @@ It is possible to create pseudo-interpolations with the `Markdown` parser: $foo.
 $([1 2 3; 4 5 6])
 
 They do not get evaluated.
+
+# Admonitions
+
+!!! note "'note' admonition"
+    Admonitions look like this. This is a `!!! note`-type admonition.
+
+    Note that admonitions themselves can contain other block-level elements too,
+    such as code blocks. E.g.
+
+    ```julia
+    f(x) = x^2
+    ```
+
+    However, you **can not** have at-blocks, docstrings, doctests etc. in an admonition.
+
+    Headings are OK though:
+    # Heading 1
+    ## Heading 2
+    ### Heading 3
+    #### Heading 4
+    ##### Heading 5
+    ###### Heading 6
+
+!!! info "'info' admonition"
+    This is a `!!! info`-type admonition.
+
+!!! tip "'tip' admonition"
+    This is a `!!! tip`-type admonition.
+
+!!! warning "'warning' admonition"
+    This is a `!!! warning`-type admonition.
+
+!!! danger "'danger' admonition"
+    This is a `!!! danger`-type admonition.
+
+!!! compat "'compat' admonition"
+    This is a `!!! compat`-type admonition.
+
+!!! details "'details' admonition"
+    This is a `!!! details`-type admonition.
+
+!!! ukw "Unknown admonition class"
+    Admonition with an unknown admonition class.


### PR DESCRIPTION
This patch renders admonitions with category `details` as `<details>` in the HTML output. The admonition title is used for the `<summary>`. For example
```markdown
!!! details "Expand for more details"
    Here are the details.
```
is rendered as
```html
<details>
  <summary>
    Expand for more details
  </summary>
  Here are the details.
</details>
```