### PR TITLE
[LaTeXWriter] fix escaping in header titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `deploydocs` now correctly handles version symlinks where the destination directory has been deleted. (#2012)
 
+* Page headings are now correctly escaped in `LaTeXWriter`. (#2134)
+
 ### Other
 
 * Documenter now uses [MarkdownAST](https://github.com/JuliaDocs/MarkdownAST.jl) to internally represent Markdown documents. While this change should not lead to any visible changes to the user, it is a major refactoring of the code. Please report any novel errors or unexpected behavior you encounter when upgrading to 0.28 on the [Documenter issue tracker](https://github.com/JuliaDocs/Documenter.jl/issues). (#1892), (#1912), (#1924), (#1948)

--- a/src/latex/LaTeXWriter.jl
+++ b/src/latex/LaTeXWriter.jl
@@ -83,6 +83,7 @@ Context(io, doc) = Context{typeof(io)}(io, false, Dict(), 1, "", doc)
 
 _print(c::Context, args...) = Base.print(c.io, args...)
 _println(c::Context, args...) = Base.println(c.io, args...)
+_print(io, args...) = Base.print(io, args...)
 
 # Labels in the TeX file are hashes of plain text labels.
 # To keep the plain text label (for debugging), say _hash(x) = x

--- a/src/latex/LaTeXWriter.jl
+++ b/src/latex/LaTeXWriter.jl
@@ -118,7 +118,7 @@ function render(doc::Documenter.Document, settings::LaTeX=LaTeX())
                     empty!(context.footnotes)
                     if 1 <= depth <= length(DOCUMENT_STRUCTURE)
                         header_type = DOCUMENT_STRUCTURE[depth]
-                        header_text = "\n\\$(header_type){$(title)}\n"
+                        header_text = "\n\\$(header_type){$(latexesc(title))}\n"
                         if isempty(filename)
                             _println(context, header_text)
                         else

--- a/src/latex/LaTeXWriter.jl
+++ b/src/latex/LaTeXWriter.jl
@@ -118,7 +118,8 @@ function render(doc::Documenter.Document, settings::LaTeX=LaTeX())
                     empty!(context.footnotes)
                     if 1 <= depth <= length(DOCUMENT_STRUCTURE)
                         header_type = DOCUMENT_STRUCTURE[depth]
-                        header_text = "\n\\$(header_type){$(latexesc(title))}\n"
+                        title_text = latexesc("$title")
+                        header_text = "\n\\$(header_type){$title_text}\n"
                         if isempty(filename)
                             _println(context, header_text)
                         else

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -517,7 +517,8 @@ examples_latex_doc = if "latex" in EXAMPLE_BUILDS
                 "latex.md",
                 "unicode.md",
                 hide("hidden.md"),
-                "example-output.md",
+                # The title override tests that we escape headings correctly
+                "`@example_output`" => "example-output.md",
             ],
             # SVG images nor code blocks in footnotes are allowed in LaTeX
             # "Manual" => [
@@ -593,7 +594,7 @@ examples_latex_texonly_doc = if "latex_texonly" in EXAMPLE_BUILDS
         sitename = "Documenter LaTeX",
         root  = examples_root,
         build = "builds/latex_texonly",
-        pages = htmlbuild_pages = Any[
+        pages = Any[
             "General" => [
                 "index.md",
                 "latex.md",


### PR DESCRIPTION
I think this is the culprit of https://github.com/jump-dev/JuMP.jl/pull/3386. I'll test on this branch before adding tests etc.