### PR TITLE
Fix deprecation warning in SCSS compilation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Install dependencies
         run: julia --color=yes --project=test/themes/ docs/instantiate.jl test/themes/
       - name: Verify theme CSS files
-        run: julia --project=test/themes test/themes/themes.jl
+        run: julia --color=yes --project=test/themes test/themes/themes.jl
 
   prerender:
     name: "NodeJS for prerender"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Page headings are now correctly escaped in `LaTeXWriter`. (#2134)
 
+* Compiling the dark theme with Sass no longer emits deprecation warnings about `!global` assignments. (#1766, #1983, #2145)
+
 ### Other
 
 * Documenter now uses [MarkdownAST](https://github.com/JuliaDocs/MarkdownAST.jl) to internally represent Markdown documents. While this change should not lead to any visible changes to the user, it is a major refactoring of the code. Please report any novel errors or unexpected behavior you encounter when upgrading to 0.28 on the [Documenter issue tracker](https://github.com/JuliaDocs/Documenter.jl/issues). (#1892), (#1912), (#1924), (#1948)

--- a/assets/html/scss/documenter-dark.scss
+++ b/assets/html/scss/documenter-dark.scss
@@ -34,6 +34,11 @@ $admonition-background: (
   'danger': $background, 'compat': $background
 );
 $admonition-header-background: ('default': $grey);
+// These would normally get initialized in _admonition.scss. However, since we are not
+// loading it on the top level, we need to set them here too to avoid deprecation warnings.
+// https://github.com/JuliaDocs/Documenter.jl/issues/1766
+$admonition-header-color: ();
+$admonition-body-color: ();
 
 $body-size: 16px;
 $documenter-sidebar-background: $grey-darker;

--- a/assets/html/themes/documenter-dark.css
+++ b/assets/html/themes/documenter-dark.css
@@ -8056,33 +8056,52 @@ html.theme--documenter-dark {
       background-color: #282f2f;
       border-color: #5e6d6f; }
       html.theme--documenter-dark .admonition.is-default > .admonition-header {
-        background-color: #5e6d6f; }
+        background-color: #5e6d6f;
+        color: #fff; }
+      html.theme--documenter-dark .admonition.is-default > .admonition-body {
+        color: #fff; }
     html.theme--documenter-dark .admonition.is-info {
       background-color: #282f2f;
       border-color: #024c7d; }
       html.theme--documenter-dark .admonition.is-info > .admonition-header {
-        background-color: #024c7d; }
+        background-color: #024c7d;
+        color: #fff; }
+      html.theme--documenter-dark .admonition.is-info > .admonition-body {
+        color: #fff; }
     html.theme--documenter-dark .admonition.is-success {
       background-color: #282f2f;
       border-color: #008438; }
       html.theme--documenter-dark .admonition.is-success > .admonition-header {
-        background-color: #008438; }
+        background-color: #008438;
+        color: #fff; }
+      html.theme--documenter-dark .admonition.is-success > .admonition-body {
+        color: #fff; }
     html.theme--documenter-dark .admonition.is-warning {
       background-color: #282f2f;
       border-color: #ad8100; }
       html.theme--documenter-dark .admonition.is-warning > .admonition-header {
-        background-color: #ad8100; }
+        background-color: #ad8100;
+        color: #fff; }
+      html.theme--documenter-dark .admonition.is-warning > .admonition-body {
+        color: #fff; }
     html.theme--documenter-dark .admonition.is-danger {
       background-color: #282f2f;
       border-color: #9e1b0d; }
       html.theme--documenter-dark .admonition.is-danger > .admonition-header {
-        background-color: #9e1b0d; }
+        background-color: #9e1b0d;
+        color: #fff; }
+      html.theme--documenter-dark .admonition.is-danger > .admonition-body {
+        color: #fff; }
     html.theme--documenter-dark .admonition.is-compat {
       background-color: #282f2f;
       border-color: #137886; }
       html.theme--documenter-dark .admonition.is-compat > .admonition-header {
-        background-color: #137886; }
+        background-color: #137886;
+        color: #fff; }
+      html.theme--documenter-dark .admonition.is-compat > .admonition-body {
+        color: #fff; }
   html.theme--documenter-dark .admonition-header {
+    color: #fff;
     background-color: #5e6d6f;
     align-items: center;
     font-weight: 700;
@@ -8167,6 +8186,7 @@ html.theme--documenter-dark {
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
     z-index: 999;
     background-color: #282f2f;
+    color: #fff;
     border-bottom: 3px solid #9e1b0d;
     padding: 10px 35px;
     text-align: center;

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -396,7 +396,7 @@ Tries to determine the root directory of the repository containing `file`. If th
 not in a repository, the function returns `nothing`.
 
 The `dbdir` keyword argument specifies the name of the directory we are searching for to
-determine if this is a repostory or not. If there is a file called `dbdir`, then it's
+determine if this is a repository or not. If there is a file called `dbdir`, then it's
 contents is checked under the assumption that it is a Git worktree or a submodule.
 """
 function repo_root(file; dbdir=".git")


### PR DESCRIPTION
If I understand correctly, it is because we wrap a lot of the SCSS variables in `html.theme--#{$themename} {` in the dark theme.

Close #1766, close #1983.