### PR TITLE
Fix nightly tests that broke due to parser changes

### DIFF
--- a/test/doctests/doctestapi.jl
+++ b/test/doctests/doctestapi.jl
@@ -143,7 +143,56 @@ Stacktrace:
 [...]
 ```
 """
-module ParseErrorSuccess end
+module ParseErrorSuccess_1x00 end
+
+"""
+```jldoctest
+julia> map(tuple, 1/(i+j) for i=1:2, j=1:2, [1:4;])
+ERROR: ParseError:
+# Error @ none:1:44
+map(tuple, 1/(i+j) for i=1:2, j=1:2, [1:4;])
+#                                          └ ── invalid iteration spec: expected one of `=` `in` or `∈`
+Stacktrace:
+[...]
+```
+```jldoctest
+julia> 1.2.3
+ERROR: ParseError:
+# Error @ none:1:1
+1.2.3
+└──┘ ── invalid numeric constant
+# Error @ none:1:5
+1.2.3
+#   ╙ ── extra tokens after end of expression
+Stacktrace:
+[...]
+```
+```jldoctest
+println(9.8.7)
+# output
+ERROR: ParseError:
+# Error @ none:1:9
+println(9.8.7)
+#       └──┘ ── invalid numeric constant
+# Error @ none:1:13
+println(9.8.7)
+#           ╙ ── Expected `)`
+Stacktrace:
+[...]
+```
+```jldoctest
+julia> Meta.ParseError("foo")
+Base.Meta.ParseError("foo", nothing)
+
+julia> Meta.ParseError("foo") |> throw
+ERROR: ParseError("foo")
+Stacktrace:
+[...]
+```
+"""
+module ParseErrorSuccess_1x10 end
+# The JuliaSyntax swap in 1.10 changed the printing of parse errors quite considerably
+ParseErrorSuccess() = (VERSION >= v"1.10.0-DEV.1520") ? ParseErrorSuccess_1x10 : ParseErrorSuccess_1x00
 
 """
 ```jldoctest
@@ -254,7 +303,7 @@ module BadDocTestKwargs3 end
     end
 
     # Parse errors in doctests (https://github.com/JuliaDocs/Documenter.jl/issues/1046)
-    run_doctest(nothing, [ParseErrorSuccess]) do result, success, backtrace, output
+    run_doctest(nothing, [ParseErrorSuccess()]) do result, success, backtrace, output
         @test success
         @test result isa Test.DefaultTestSet
     end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -493,7 +493,8 @@ end
             # Ref: #639
             @test jsescape("\u2028") == "\\u2028"
             @test jsescape("\u2029") == "\\u2029"
-            @test jsescape("policy to  delete.") == "policy to\\u2028 delete."
+            include("utilities.sample.jl")
+            @test jsescape(U2028_STRING) == "policy to\\u2028 delete."
         end
 
         @testset "json_jsescape" begin

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -298,7 +298,11 @@ end
         @test exprs[2][2] == "γγγ_γγγ\n"
 
         @test exprs[3][1] === :γγγ
-        @test exprs[3][2] == "γγγ\n"
+        if VERSION >= v"1.10.0-DEV.1520" # JuliaSyntax merge
+            @test exprs[3][2] == "γγγ\n\n"
+        else
+            @test exprs[3][2] == "γγγ\n"
+        end
     end
 
     @testset "TextDiff" begin
@@ -317,9 +321,14 @@ end
             for LE in ("\r\n", "\n")
                 l1, l2 = parse("x = Int[]$(LE)$(LE)push!(x, 1)$(LE)")
                 @test l1[1] == :(x = Int[])
-                @test l1[2] == "x = Int[]$(LE)"
                 @test l2[1] == :(push!(x, 1))
-                @test l2[2] == "push!(x, 1)$(LE)"
+                if VERSION >= v"1.10.0-DEV.1520" # JuliaSyntax merge
+                    @test l1[2] == "x = Int[]$(LE)$(LE)"
+                    @test l2[2] == "push!(x, 1)$(LE)\n"
+                else
+                    @test l1[2] == "x = Int[]$(LE)"
+                    @test l2[2] == "push!(x, 1)$(LE)"
+                end
             end
         end
     end
@@ -338,7 +347,11 @@ end
             @test exs[1][1].head == :toplevel
             @test exs[1][1].args[1] == LineNumberNode(124, "testfile.jl")
             @test exs[1][1].args[2] == Expr(:call, :+, 1, 1)
-            @test exs[2][2] == "2 + 2\n"
+            if VERSION >= v"1.10.0-DEV.1520" # JuliaSyntax merge
+                @test exs[2][2] == "2 + 2\n\n"
+            else
+                @test exs[2][2] == "2 + 2\n"
+            end
             @test exs[2][1].head == :toplevel
             @test exs[2][1].args[1] == LineNumberNode(125, "testfile.jl")
             @test exs[2][1].args[2] == Expr(:call, :+, 2, 2)
@@ -356,7 +369,15 @@ end
             for code in (code1, code2)
                 exs = parse(code)
                 @test length(exs) == 1
-                @test exs[1][2] == "1 + 1\n"
+                if VERSION >= v"1.10.0-DEV.1520" # JuliaSyntax merge
+                    if code == code1
+                        @test exs[1][2] == "1 + 1\n\n\n"
+                    else
+                        @test exs[1][2] == "1 + 1\n# comment\n\n"
+                    end
+                else
+                    @test exs[1][2] == "1 + 1\n"
+                end
                 @test exs[1][1].head == :toplevel
                 @test exs[1][1].args[1] == LineNumberNode(124, "testfile.jl")
                 @test exs[1][1].args[2] == Expr(:call, :+, 1, 1)

--- a/test/utilities.sample.jl
+++ b/test/utilities.sample.jl
@@ -1,0 +1,4 @@
+# This string is defined in a separate file so that VS Code would not
+# complain (or even accidentally "fix") the weird character we want
+# to have present every time you open utilities.jl.
+const U2028_STRING = "policy to  delete."


### PR DESCRIPTION
Some of the `Meta.parse` calls are different with the new parser when newlines are involved.