### PR TITLE
docs: move backported changelog entries to correct version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,17 +99,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `deploydocs` now correctly handles version symlinks where the destination directory has been deleted. (#2012)
 
-* Page headings are now correctly escaped in `LaTeXWriter`. (#2134)
-
-* Compiling the dark theme with Sass no longer emits deprecation warnings about `!global` assignments. (#1766, #1983, #2145)
-
-* The CSS Documenter ships is now minified. (#2153, #2157)
-
 ### Other
 
 * Documenter now uses [MarkdownAST](https://github.com/JuliaDocs/MarkdownAST.jl) to internally represent Markdown documents. While this change should not lead to any visible changes to the user, it is a major refactoring of the code. Please report any novel errors or unexpected behavior you encounter when upgrading to 0.28 on the [Documenter issue tracker](https://github.com/JuliaDocs/Documenter.jl/issues). (#1892), (#1912), (#1924), (#1948)
 
 * The code layout has changed considerably, with many of the internal submodules removed. This **may be breaking** for code that hooks into various Documenter internals, as various types and functions now live at different code paths. (#1977)
+
+
+## Version v0.27.25 - 2023-01-23
+
+### Fixed
+
+* Page headings are now correctly escaped in `LaTeXWriter`. (#2134)
+
+* Compiling the dark theme with Sass no longer emits deprecation warnings about `!global` assignments. (#1766, #1983, #2145)
+
+* The CSS Documenter ships is now minified. (#2153, #2157)
 
 ## Version v0.27.24 - 2023-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The code layout has changed considerably, with many of the internal submodules removed. This **may be breaking** for code that hooks into various Documenter internals, as various types and functions now live at different code paths. (#1977)
 
 
-## Version v0.27.25 - 2023-01-23
+## Version v0.27.25 - 2023-07-03
 
 ### Fixed
 


### PR DESCRIPTION
#2162