### PR TITLE
test: fix online linkchecks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -153,9 +153,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.6'
+          version: '1'
+      - name: Install dependencies
+        run: julia --color=yes --project -e'using Pkg; Pkg.instantiate()'
       - name: Run online linkcheck tests
-        run: julia --color=yes test/run_docchecks.jl
+        run: julia --color=yes --project test/online_linkcheck.jl
 
   linkcheck-manual:
     name: "Linkcheck: Documenter manual"
@@ -164,7 +166,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.6'
+          version: '1'
       - name: Install dependencies
         run: julia --color=yes --project=docs/ docs/instantiate.jl
       - name: Build and check documentation

--- a/test/docchecks.jl
+++ b/test/docchecks.jl
@@ -69,41 +69,10 @@ module TestModule
 end
 
 @testset "DocChecks" begin
-    @testset "linkcheck" begin
-        if haskey(ENV, "DOCUMENTER_TEST_LINKCHECK")
-            src = md"""
-                [HTTP (HTTP/1.1) success](http://www.google.com)
-                [HTTPS (HTTP/2) success](https://www.google.com)
-                [FTP success](ftp://ftp.iana.org/tz/data/etcetera)
-                [FTP (no proto) success](ftp.iana.org/tz/data/etcetera)
-                [Redirect success](google.com)
-                [HEAD fail GET success](https://codecov.io/gh/invenia/LibPQ.jl)
-                """
-
-            Documenter.walk(Dict{Symbol, Any}(), src) do block
-                doc = Documenter.Document(; linkcheck=true, linkcheck_timeout=20)
-                result = linkcheck(block, doc)
-                @test doc.internal.errors == Set{Symbol}()
-                result
-            end
-
-            src = Markdown.parse("[FILE failure](file://$(@__FILE__))")
-            doc = Documenter.Document(; linkcheck=true)
-            Documenter.walk(Dict{Symbol, Any}(), src) do block
-                linkcheck(block, doc)
-            end
-            @test doc.internal.errors == Set{Symbol}([:linkcheck])
-
-            src = Markdown.parse("[Timeout](http://httpbin.org/delay/3)")
-            doc = Documenter.Document(; linkcheck=true, linkcheck_timeout=0.1)
-            Documenter.walk(Dict{Symbol, Any}(), src) do block
-                linkcheck(block, doc)
-            end
-            @test doc.internal.errors == Set{Symbol}([:linkcheck])
-        else
-            @info "DOCUMENTER_TEST_LINKCHECK not set, skipping online linkcheck tests."
-            @test_broken false
-        end
+    if haskey(ENV, "DOCUMENTER_TEST_ONLINE_LINKCHECK")
+        include("online_linkcheck.jl")
+    else
+        @info "Online linkchecks skipped (DOCUMENTER_TEST_ONLINE_LINKCHECK not set)"
     end
 
     @testset "allbindings" begin

--- a/test/online_linkcheck.jl
+++ b/test/online_linkcheck.jl
@@ -1,0 +1,41 @@
+module OnlineLinkcheckTests
+using Documenter: Documenter, MarkdownAST, AbstractTrees
+using Documenter.DocChecks: linkcheck
+using Markdown
+using Test
+
+@testset "Online linkcheck" begin
+    @testset "Successes" begin
+        src = convert(
+            MarkdownAST.Node,
+            md"""
+            [HTTP (HTTP/1.1) success](http://www.google.com)
+            [HTTPS (HTTP/2) success](https://www.google.com)
+            [FTP success](ftp://ftp.iana.org/tz/data/etcetera)
+            [FTP (no proto) success](ftp.iana.org/tz/data/etcetera)
+            [Redirect success](google.com)
+            [HEAD fail GET success](https://codecov.io/gh/invenia/LibPQ.jl)
+            """
+        )
+        doc = Documenter.Document(; linkcheck=true, linkcheck_timeout=20)
+        doc.blueprint.pages["testpage"] = Documenter.Page("", "", "", [], Documenter.Globals(), src)
+        @test_logs (:warn,) (:warn,) @test linkcheck(doc) === nothing
+        @test doc.internal.errors == Set{Symbol}()
+    end
+
+    @testset "Failures" begin
+        src = convert(MarkdownAST.Node, Markdown.parse("[FILE failure](file://$(@__FILE__))"))
+        doc = Documenter.Document(; linkcheck=true)
+        doc.blueprint.pages["testpage"] = Documenter.Page("", "", "", [], Documenter.Globals(), src)
+        @test_logs (:warn,) @test linkcheck(doc) === nothing
+        @test doc.internal.errors == Set{Symbol}([:linkcheck])
+
+        src = Markdown.parse("[Timeout](http://httpbin.org/delay/3)")
+        doc = Documenter.Document(; linkcheck=true, linkcheck_timeout=0.1)
+        doc.blueprint.pages["testpage"] = Documenter.Page("", "", "", [], Documenter.Globals(), src)
+        @test_logs (:warn,) @test linkcheck(doc) === nothing
+        @test doc.internal.errors == Set{Symbol}([:linkcheck])
+    end
+end
+
+end # module

--- a/test/run_docchecks.jl
+++ b/test/run_docchecks.jl
@@ -1,7 +1,0 @@
-using Pkg
-mktempdir() do envdir
-    Pkg.activate(envdir)
-    Pkg.add(PackageSpec(path=joinpath(@__DIR__, "..")))
-    Pkg.status()
-    include("docchecks.jl")
-end


### PR DESCRIPTION
Apparently the online linkcheck workflow has been slacking off recently:

![image](https://github.com/JuliaDocs/Documenter.jl/assets/147757/454348a9-89fb-434e-b912-e8041b417c91)

This brings the online linkcheck tests up to speed with what's been happening on master, and the actual online tests should run again in the workflow.