### PR TITLE
Fix documentation docs build on Windows

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -306,9 +306,7 @@ dependencies your package might have. If Documenter is the only dependency, then
 
 ````@eval
 import Documenter, Markdown
-m = match(r"^version = \"(\d+.\d+.\d+)(-DEV)?(\+.+)?\"$"m,
-    read(joinpath(dirname(dirname(pathof(Documenter))), "Project.toml"), String))
-v = VersionNumber(m.captures[1])
+v = Documenter.DOCUMENTER_VERSION
 Markdown.parse("""
 ```toml
 [deps]


### PR DESCRIPTION
Apparently the regex doesn't work on Windows.

cc @Hetarth02 