### PR TITLE
add --project to julia command using --color

### DIFF
--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -99,7 +99,7 @@ Note that `$` just represents the prompt character. You don't need to type that.
 If you'd like to see the output from this command in color use
 
 ```sh
-$ julia --color=yes make.jl
+$ julia --color=yes --project make.jl
 ```
 
 When you run that you should see the following output


### PR DESCRIPTION
Just a tiny fix for the guide. I copy-pasted the command that included colored output, and of course it didn't work for a large project with several dependencies, so I was wandering what had happened to my environment only to then realize that --project was not part of the command.