### PR TITLE
@debug the next REPL line before evaling it

### DIFF
--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -242,6 +242,8 @@ end
 function eval_repl(block, sandbox, meta::Dict, doc::Documenter.Document, page)
     for (input, output) in repl_splitter(block.code)
         result = Result(block, input, output, meta[:CurrentFile])
+        src_lines = Documenter.find_block_in_file(result.block.code, result.file)
+        @debug "Evaluating doctest REPL line from $(Documenter.locrepr(result.file, src_lines))" input expected_output = output
         for (ex, str) in Documenter.parseblock(input, doc, page; keywords = false, raise=false)
             # Input containing a semi-colon gets suppressed in the final output.
             result.hide = REPL.ends_with_semicolon(str)

--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -243,9 +243,9 @@ function eval_repl(block, sandbox, meta::Dict, doc::Documenter.Document, page)
     for (input, output) in repl_splitter(block.code)
         result = Result(block, input, output, meta[:CurrentFile])
         src_lines = Documenter.find_block_in_file(result.block.code, result.file)
-        @debug "Evaluating doctest REPL line from $(Documenter.locrepr(result.file, src_lines))" input expected_output = output
         for (ex, str) in Documenter.parseblock(input, doc, page; keywords = false, raise=false)
             # Input containing a semi-colon gets suppressed in the final output.
+            @debug "Evaluating doctest REPL line from $(Documenter.locrepr(result.file, src_lines))" unparsed_string = str parsed_expression = ex
             result.hide = REPL.ends_with_semicolon(str)
             # Use the REPL softscope for REPL jldoctests,
             # see https://github.com/JuliaLang/julia/pull/33864

--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -240,9 +240,9 @@ mutable struct Result
 end
 
 function eval_repl(block, sandbox, meta::Dict, doc::Documenter.Document, page)
+    src_lines = Documenter.find_block_in_file(block.code, meta[:CurrentFile])
     for (input, output) in repl_splitter(block.code)
         result = Result(block, input, output, meta[:CurrentFile])
-        src_lines = Documenter.find_block_in_file(result.block.code, result.file)
         for (ex, str) in Documenter.parseblock(input, doc, page; keywords = false, raise=false)
             # Input containing a semi-colon gets suppressed in the final output.
             @debug "Evaluating REPL line from doctest at $(Documenter.locrepr(result.file, src_lines))" unparsed_string = str parsed_expression = ex

--- a/src/DocTests.jl
+++ b/src/DocTests.jl
@@ -245,7 +245,7 @@ function eval_repl(block, sandbox, meta::Dict, doc::Documenter.Document, page)
         src_lines = Documenter.find_block_in_file(result.block.code, result.file)
         for (ex, str) in Documenter.parseblock(input, doc, page; keywords = false, raise=false)
             # Input containing a semi-colon gets suppressed in the final output.
-            @debug "Evaluating doctest REPL line from $(Documenter.locrepr(result.file, src_lines))" unparsed_string = str parsed_expression = ex
+            @debug "Evaluating REPL line from doctest at $(Documenter.locrepr(result.file, src_lines))" unparsed_string = str parsed_expression = ex
             result.hide = REPL.ends_with_semicolon(str)
             # Use the REPL softscope for REPL jldoctests,
             # see https://github.com/JuliaLang/julia/pull/33864


### PR DESCRIPTION
Add a `@debug` expression within DocTests.eval_repl to show which line is about to be evaluated.
This was requested in https://github.com/JuliaDocs/Documenter.jl/issues/2013

I have found it useful while attempting to track down a similar issue.