### PR TITLE
Fix Prettier action when running PRs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -176,10 +176,7 @@ jobs:
     name: Prettier (JS code formatting)
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
+      - uses: actions/checkout@v3
       - uses: actionsx/prettier@v2
         with:
           args: --check .


### PR DESCRIPTION
The `ref` shouldn't actually be necessary. I believe I copied it from somewhere, and the motivation was to make sure it runs on the actual branch commit and not on the PR merge commit. But it should be fine to run on the merge commit (in fact, would be more correct if the merge somehow breaks formatting?).