### PR TITLE
Fix image and link references in LaTeXWriter

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,13 +57,15 @@ jobs:
         with:
           version: '1'
       - uses: julia-actions/cache@v1
-      - run: |
-          julia --project=test/examples -e '
-            using Pkg
-            Pkg.instantiate()
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.add(["IOCapture", "tectonic_jll"])'
-      - run: julia --project=test/examples --code-coverage test/examples/tests_latex.jl
+      - name: Instantiate Pkg environment
+        shell: julia --color=yes --project=test/examples
+        run: |
+          using Pkg
+          Pkg.instantiate()
+          Pkg.develop(PackageSpec(path=pwd()))
+          Pkg.add(["IOCapture", "tectonic_jll"])
+      - name: Run test/examples/tests_latex.jl
+        run: julia --color=yes --project=test/examples --code-coverage test/examples/tests_latex.jl
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,7 +58,7 @@ jobs:
           version: '1'
       - uses: julia-actions/cache@v1
       - name: Instantiate Pkg environment
-        shell: julia --color=yes --project=test/examples
+        shell: julia --color=yes --project=test/examples {0}
         run: |
           using Pkg
           Pkg.instantiate()

--- a/src/documents.jl
+++ b/src/documents.jl
@@ -189,11 +189,23 @@ struct PageLink <: MarkdownAST.AbstractInline
     fragment::String
 end
 
+"""
+Represents a reference to a local file. The `path` can be assumed to be an "absolute" path
+relative to the document root (i.e. `src/` or `build/` directories).
+
+In the standard setup, when the documentation setup lives in `docs/`, with source files
+in `docs/src`, a link to the file `docs/src/foo/bar.md` would have `path = "foo/bar.md"`.
+"""
 struct LocalLink <: MarkdownAST.AbstractInline
     path::String
     fragment::String
 end
 
+"""
+Represents a reference to a local image. The `path` can be assumed to be an "absolute" path
+relative to the document root (i.e. `src/` or `build/` directories). See [`LocalLink`](@ref)
+for more details.
+"""
 struct LocalImage <: MarkdownAST.AbstractInline
     path::String
 end

--- a/src/latex/LaTeXWriter.jl
+++ b/src/latex/LaTeXWriter.jl
@@ -197,7 +197,7 @@ function compile_tex(doc::Documenter.Document, settings::LaTeX, fileprefix::Stri
         catch err
             logs = cp(pwd(), mktempdir(; cleanup=false); force=true)
             @error "LaTeXWriter: failed to compile tex with tectonic. " *
-                   "Logs and partial output can be found in $(Documenter.locrepr(logs))." exception = err
+                   "Logs and partial output can be found in $(Documenter.locrepr(logs))" exception = err
             return false
         end
     elseif settings.platform == "docker"
@@ -217,7 +217,7 @@ function compile_tex(doc::Documenter.Document, settings::LaTeX, fileprefix::Stri
         catch err
             logs = cp(pwd(), mktempdir(; cleanup=false); force=true)
             @error "LaTeXWriter: failed to compile tex with docker. " *
-                   "Logs and partial output can be found in $(Documenter.locrepr(logs))." exception = err
+                   "Logs and partial output can be found in $(Documenter.locrepr(logs))" exception = err
             return false
         finally
             try; piperun(`docker stop latex-container`); catch; end

--- a/src/latex/LaTeXWriter.jl
+++ b/src/latex/LaTeXWriter.jl
@@ -184,7 +184,7 @@ function compile_tex(doc::Documenter.Document, settings::LaTeX, fileprefix::Stri
         catch err
             logs = cp(pwd(), mktempdir(; cleanup=false); force=true)
             @error "LaTeXWriter: failed to compile tex with latexmk. " *
-                   "Logs and partial output can be found in $(Documenter.locrepr(logs))." exception = err
+                   "Logs and partial output can be found in $(Documenter.locrepr(logs))" exception = err
             return false
         end
     elseif settings.platform == "tectonic"
@@ -724,6 +724,13 @@ function latex(io::Context, node::Node, f::MarkdownAST.FootnoteLink)
 end
 
 function latex(io::Context, node::Node, link::Documenter.PageLink)
+    # If we're in a header, we don't want to print any \hyperlinkref commands,
+    # so we handle this here.
+    if io.in_header
+        latex(io, node.children)
+        return
+    end
+    # This branch is the normal case, when we're not in a header.
     # TODO: this link handling does not seem correct
     if !isempty(link.fragment)
         id = _hash(link.fragment)
@@ -742,6 +749,13 @@ function latex(io::Context, node::Node, link::Documenter.PageLink)
 end
 
 function latex(io::Context, node::Node, link::Documenter.LocalLink)
+    # If we're in a header, we don't want to print any \hyperlinkref commands,
+    # so we handle this here.
+    if io.in_header
+        latex(io, node.children)
+        return
+    end
+    # This branch is the normal case, when we're not in a header.
     # TODO: this link handling does not seem correct
     wrapinline(io, "href") do
         href = isempty(link.fragment) ? link.path : "$(link.path)#($(link.fragment))"
@@ -753,17 +767,20 @@ function latex(io::Context, node::Node, link::Documenter.LocalLink)
 end
 
 function latex(io::Context, node::Node, link::MarkdownAST.Link)
-    # TODO: handle the .title attribute
+    # If we're in a header, we don't want to print any \hyperlinkref commands,
+    # so we handle this here.
     if io.in_header
         latex(io, node.children)
-    else
-        wrapinline(io, "href") do
-            latexesc(io, link.destination)
-        end
-        _print(io, "{")
-        latex(io, node.children)
-        _print(io, "}")
+        return
     end
+    # This branch is the normal case, when we're not in a header.
+    # TODO: handle the .title attribute
+    wrapinline(io, "href") do
+        latexesc(io, link.destination)
+    end
+    _print(io, "{")
+    latex(io, node.children)
+    _print(io, "}")
 end
 
 function latex(io::Context, node::Node, math::MarkdownAST.InlineMath)

--- a/src/latex/LaTeXWriter.jl
+++ b/src/latex/LaTeXWriter.jl
@@ -688,15 +688,8 @@ function latex(io::Context, node::Node, image::Documenter.LocalImage)
     # TODO: also print the .title field somehow
     wrapblock(io, "figure") do
         _println(io, "\\centering")
-        url = if startswith(image.path, '/')
-            # URLs starting with a / are assumed to be relative to the document's root
-            normpath(lstrip(image.path, '/'))
-        else
-            normpath(joinpath(dirname(io.filename), image.path))
-        end
-        url = replace(url, "\\" => "/") # use / on Windows too.
         wrapinline(io, "includegraphics[max width=\\linewidth]") do
-            _print(io, url)
+            _print(io, image.path)
         end
         _println(io)
         wrapinline(io, "caption") do


### PR DESCRIPTION
Was broken in #2187 (unreleased), and has been failing our PDF builds since.