### PR TITLE
test: fix doctestapi tests

### DIFF
--- a/test/doctests/doctestapi.jl
+++ b/test/doctests/doctestapi.jl
@@ -184,7 +184,6 @@ Stacktrace:
 """
 module ParseErrorSuccess_1x10 end
 # The JuliaSyntax swap in 1.10 changed the printing of parse errors quite considerably
-# (v"1.10.0-DEV.1520" <= VERSION < v"1.10.0-beta3") || (v"1.11.0-" < VERSION < v"1.11.0-DEV.293")
 ParseErrorSuccess() = (VERSION >= v"1.10.0-DEV.1520") ? ParseErrorSuccess_1x10 : ParseErrorSuccess_1x00
 
 """

--- a/test/doctests/doctestapi.jl
+++ b/test/doctests/doctestapi.jl
@@ -161,10 +161,6 @@ ERROR: ParseError:
 # Error @ none:1:1
 1.2.3
 └──┘ ── invalid numeric constant
-# Error @ none:1:5
-1.2.3
-#   ╙ ── extra tokens after end of expression
-Stacktrace:
 [...]
 ```
 ```jldoctest
@@ -174,10 +170,6 @@ ERROR: ParseError:
 # Error @ none:1:9
 println(9.8.7)
 #       └──┘ ── invalid numeric constant
-# Error @ none:1:13
-println(9.8.7)
-#           ╙ ── Expected `)`
-Stacktrace:
 [...]
 ```
 ```jldoctest
@@ -192,6 +184,7 @@ Stacktrace:
 """
 module ParseErrorSuccess_1x10 end
 # The JuliaSyntax swap in 1.10 changed the printing of parse errors quite considerably
+# (v"1.10.0-DEV.1520" <= VERSION < v"1.10.0-beta3") || (v"1.11.0-" < VERSION < v"1.11.0-DEV.293")
 ParseErrorSuccess() = (VERSION >= v"1.10.0-DEV.1520") ? ParseErrorSuccess_1x10 : ParseErrorSuccess_1x00
 
 """


### PR DESCRIPTION
This should fix the nightly test failures. It seems like the JuliaSyntax bump (https://github.com/JuliaLang/julia/pull/50928) removed some parse error printing. Having `[...]` should test both old and new behavior.

But fixing up these tests every time printing changes is not really feasible either. One option would be to generate the docstring content dynamically, print it into a file, and then eval/include that back into `Main` (in particular for things like parse errors where we can't control the printing easily).

Note: the relevant Julia versions are `1.10.0-beta3` and `1.11.0-DEV.293`, for future reference.