### PR TITLE
Automatically get remote for Pkg.add(...) packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   **For upgrading:** The cases where an `@eval` results in a object that is not `nothing` or `::Markdown.MD`, the returned object should be reviewed. In case the resulting object is of some `Markdown` node type (e.g. `Markdown.Paragraph` or `Markdown.Table`), it can simply be wrapped in `Markdown.MD([...])` for block nodes, or `Markdown.MD([Markdown.Paragraph([...])])` for inline nodes. In other cases Documenter was likely not handling the returned object in a correct way, but please open an issue if this change has broken a previously working use case.
 
-* The handling of remote repository (e.g. GitHub) URLs has been overhauled. ([#1808], [#1881], [#2081])
+* The handling of remote repository (e.g. GitHub) URLs has been overhauled. ([#1808], [#1881], [#2081], [#2232])
 
   In addition to generating source and edit links for the main repository, Documenter can now also be configured to generate correct links for cases where some files are from a different repository (e.g. with vendored dependencies). There have also been changes and fixes to the way the automatic detection of source and edit links works.
 
@@ -1647,6 +1647,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2214]: https://github.com/JuliaDocs/Documenter.jl/issues/2214
 [#2215]: https://github.com/JuliaDocs/Documenter.jl/issues/2215
 [#2216]: https://github.com/JuliaDocs/Documenter.jl/issues/2216
+[#2232]: https://github.com/JuliaDocs/Documenter.jl/issues/2232
 [#2236]: https://github.com/JuliaDocs/Documenter.jl/issues/2236
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 IOCapture = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
@@ -15,8 +16,10 @@ LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 MarkdownAST = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+RegistryInstances = "2792f1a3-b283-48e8-9a74-f99dce5104f3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
@@ -32,6 +35,7 @@ julia = "1.6"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [targets]
-test = ["Random"]
+test = ["Random", "UUIDs"]

--- a/docs/src/lib/remote-links.md
+++ b/docs/src/lib/remote-links.md
@@ -34,8 +34,7 @@ To handle those cases, the `remotes` keyword to [`makedocs`](@ref) can be used t
 The local directory is assumed to correspond to the root of the Git repository, and any subpath within that directory is then resolved to the corresponding path in the remote repository.
 If there are nested `remotes` configured, Documenter will use the one that matches first as it walks up the directory tree from the original path.
 
-As the common case is a locally checked out Git repository cloned from GitHub, Documenter will also try to determine such remotes automatically.
-This is done regardless whether any additional remotes have been specified with `remotes` or not.
+As the common cases are a locally checked out Git repository (added with `Pkg.develop` to the docs environment), or a released package which is hosted on GitHub (`Pkg.add`ed to the environment), Documenter will also try to determine such remotes automatically.
 
 * When Documenter walks up the directory tree, it checks whether the directory is a root of a Git repository (by looking for the presence of a `.git` directory or file).
   Once it finds a valid local repository root, it tries to read its [`origin` remote URL](https://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes).
@@ -44,6 +43,13 @@ This is done regardless whether any additional remotes have been specified with 
     In this case, the remote should be configured explicitly with `remotes`.
 
 You can think of it as Documenter automatically populating `remotes` with any cloned GitHub repositories it finds.[^3]
+
+For released packages (those added using `Pkg.add(...)` rather than `Pkg.develop(...)`), the version and repository can be determined from the package metadata, but a commit hash is not readily available.
+In this case, Documenter will guess that a tag `v$VERSION` exists in the repository on GitHub.
+Note that these tags are created automatically by the widely used JuliaRegistries/TagBot action.
+Since this is sometimes not the case, and could cause dead or incorrect links, setting the `linkcheck` keyword to `true` to [`makedocs`](@ref) will check these guessed links have an existing target and that the existing target matches the published package.
+(Note this will also all other external links from your documentation.)
+Note that enabling this option can cause documentation builds to fail due to network errors or intermittent downtime of external services.
 
 !!! note
 

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -44,7 +44,7 @@ const NO_KEY_ENV = Dict(
 
 # Names of possible internal errors
 const ERROR_NAMES = [:autodocs_block, :cross_references, :docs_block, :doctest,
-                     :eval_block, :example_block, :footnote, :githubcheck, :linkcheck,
+                     :eval_block, :example_block, :footnote, :linkcheck_remotes, :linkcheck,
                      :meta_block, :missing_docs, :parse_error, :setup_block]
 
 """

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -14,11 +14,14 @@ $(EXPORTS)
 module Documenter
 
 import AbstractTrees
+import Downloads
 import IOCapture
 import Markdown
 using MarkdownAST: MarkdownAST, Node
 import REPL
 import Unicode
+import Pkg
+import RegistryInstances
 # Additional imported names
 using Test: @testset, @test
 using DocStringExtensions
@@ -41,8 +44,8 @@ const NO_KEY_ENV = Dict(
 
 # Names of possible internal errors
 const ERROR_NAMES = [:autodocs_block, :cross_references, :docs_block, :doctest,
-                     :eval_block, :example_block, :footnote, :linkcheck, :meta_block,
-                     :missing_docs, :parse_error, :setup_block]
+                     :eval_block, :example_block, :footnote, :githubcheck, :linkcheck,
+                     :meta_block, :missing_docs, :parse_error, :setup_block]
 
 """
     abstract type Plugin end

--- a/src/builder_pipeline.jl
+++ b/src/builder_pipeline.jl
@@ -234,6 +234,7 @@ function Selectors.runner(::Type{Builder.CheckDocument}, doc::Documenter.Documen
     missingdocs(doc)
     footnotes(doc)
     linkcheck(doc)
+    githubcheck(doc)
 end
 
 function Selectors.runner(::Type{Builder.Populate}, doc::Documenter.Document)

--- a/src/docchecks.jl
+++ b/src/docchecks.jl
@@ -342,11 +342,11 @@ function githubcheck(doc::Document)
         tag_guess = remote_repo.commit
         tag_ref = tag(repo, tag_guess)
         if tag_ref === nothing
-            @docerror(doc, :githubcheck, "githubcheck '$(repo)' error while getting tag '$(tag_guess)'. $(GITHUB_ERROR_ADVICE)")
+            @docerror(doc, :linkcheck_remotes, "linkcheck (remote) '$(repo)' error while getting tag '$(tag_guess)'. $(GITHUB_ERROR_ADVICE)")
             return
         end
         if tag_ref["object"]["type"] != "commit"
-            @docerror(doc, :githubcheck, "githubcheck '$(repo)' tag '$(tag_guess)' does not point to a commit. $(GITHUB_ERROR_ADVICE)")
+            @docerror(doc, :linkcheck_remotes, "linkcheck (remote) '$(repo)' tag '$(tag_guess)' does not point to a commit. $(GITHUB_ERROR_ADVICE)")
             return
         end
         commit_sha = tag_ref["object"]["sha"]
@@ -355,8 +355,8 @@ function githubcheck(doc::Document)
         if string(tree_hash) != actual_tree_hash
             @docerror(
                 doc,
-                :githubcheck,
-                "githubcheck '$(repo)' tag '$(tag_guess)' points to tree hash $(actual_tree_hash), but package entry has $(tree_hash). $(GITHUB_ERROR_ADVICE)"
+                :linkcheck_remotes,
+                "linkcheck (remote) '$(repo)' tag '$(tag_guess)' points to tree hash $(actual_tree_hash), but package entry has $(tree_hash). $(GITHUB_ERROR_ADVICE)"
             )
         end
     end

--- a/src/docchecks.jl
+++ b/src/docchecks.jl
@@ -254,3 +254,110 @@ end
 
 linkcheck_ismatch(r::String, url) = (url == r)
 linkcheck_ismatch(r::Regex, url) = occursin(r, url)
+
+# Automatic Pkg.add() GitHub remote check
+# ---------------------------------------
+
+function gh_get_json(path)
+    io = IOBuffer()
+    url = "https://api.github.com$(path)"
+    @debug "request: GET $url"
+    resp = Downloads.request(
+        url,
+        output=io,
+        headers=Dict(
+            "Accept" => "application/vnd.github.v3+json",
+            "X-GitHub-Api-Version" => "2022-11-28"
+        )
+    )
+    return resp.status, JSON.parse(String(take!(io)))
+end
+
+function tag(repo, tag_ref)
+    status, result = gh_get_json("/repos/$(repo)/git/ref/tags/$(tag_ref)")
+    if status == 404
+        return nothing
+    elseif status != 200
+        error("Unexpected error code $(status) '$(repo)' while getting tag '$(tag_ref)'.")
+    end
+    if result["object"]["type"] == "tag"
+        status, result = gh_get_json("/repos/$(repo)/git/tags/$(result["object"]["sha"])")
+        if status == 404
+            return nothing
+        elseif status != 200
+            error("Unexpected error code $(status) '$(repo)' while getting tag '$(tag_ref)'.")
+        end
+    end
+    return result
+end
+
+function gitcommit(repo, commit_tag)
+    status, result = gh_get_json("/repos/$(repo)/git/commits/$(commit_tag)")
+    if status != 200
+        error("Unexpected error code $(status) '$(repo)' while getting commit '$(commit_tag)'.")
+    end
+    return result
+end
+
+GITHUB_ERROR_ADVICE = (
+    "This means automatically finding the source URL link for this package failed. " *
+    "Please add the source URL link manually to the `remotes` field " *
+    "in `makedocs` or install the package using `Pkg.develop()``."
+)
+
+function githubcheck(doc::Document)
+    if !doc.user.linkcheck
+        return
+    end
+    # When we add GitHub links based on packages which have been added with
+    # Pkg.add(), we don't have much git information, so we simply use a guessed
+    # tag based on the version `v$VERSION`, as this tag is added by the popular
+    # TagBot action.
+    #
+    # This check uses the GitHub API to check whether the tag exists, and if
+    # so, whether the tree hash matches the tree hash of the package entry
+    # in the manifest.
+    src_to_uuid = get_src_to_uuid(doc)
+    for remote_repo in doc.user.remotes
+        if !(remote_repo.remote isa Remotes.GitHub)
+            continue
+        end
+        if !(remote_repo.root in keys(src_to_uuid))
+            continue
+        end
+        uuid = src_to_uuid[remote_repo.root]
+        repo_info = uuid_to_repo(doc, uuid)
+        if repo_info === nothing
+            continue
+        end
+        if remote_repo.remote != repo_info[1] || remote_repo.commit != repo_info[2]
+            continue
+        end
+        # Looks like it's been guessed -- let's check if it matches the
+        # tree hash from the package entry
+        uuid_to_version_info = get_uuid_to_version_info(doc)
+        tree_hash = uuid_to_version_info[uuid][2]
+        remote = remote_repo.remote
+        repo = remote.user * "/" * remote.repo
+        tag_guess = remote_repo.commit
+        tag_ref = tag(repo, tag_guess)
+        if tag_ref === nothing
+            @docerror(doc, :githubcheck, "githubcheck '$(repo)' error while getting tag '$(tag_guess)'. $(GITHUB_ERROR_ADVICE)")
+            return
+        end
+        if tag_ref["object"]["type"] != "commit"
+            @docerror(doc, :githubcheck, "githubcheck '$(repo)' tag '$(tag_guess)' does not point to a commit. $(GITHUB_ERROR_ADVICE)")
+            return
+        end
+        commit_sha = tag_ref["object"]["sha"]
+        git_commit = gitcommit(repo, commit_sha)
+        actual_tree_hash = git_commit["tree"]["sha"]
+        if string(tree_hash) != actual_tree_hash
+            @docerror(
+                doc,
+                :githubcheck,
+                "githubcheck '$(repo)' tag '$(tag_guess)' points to tree hash $(actual_tree_hash), but package entry has $(tree_hash). $(GITHUB_ERROR_ADVICE)"
+            )
+        end
+    end
+end

--- a/src/documents.jl
+++ b/src/documents.jl
@@ -343,6 +343,8 @@ struct Internal
     indexnodes    :: Vector{IndexNode}
     locallinks :: IdDict{MarkdownAST.Link, String}
     errors::Set{Symbol}
+    src_to_uuid::Dict{String, Base.UUID} # These two are used to cache information from Pkg
+    uuid_to_version_info::Dict{Base.UUID, Tuple{VersionNumber, String}}
 end
 
 # Document.
@@ -451,7 +453,9 @@ function Document(plugins = nothing;
         [],
         [],
         Dict{Markdown.Link, String}(),
-        Set{Symbol}()
+        Set{Symbol}(),
+        Dict{String, String}(),
+        Dict{String, Tuple{String, String}}()
     )
 
     plugin_dict = Dict{DataType, Plugin}()
@@ -688,13 +692,74 @@ function lt_remotepair(r1::RemoteRepository, r2::RemoteRepository)
     return length(r1.root) > length(r2.root)
 end
 
+function build_dep_info_dicts(doc::Document)
+    for (uuid, dep) in pairs(Pkg.dependencies())
+        doc.internal.src_to_uuid[dep.source] = uuid
+        if dep.version === nothing || dep.tree_hash === nothing
+            continue
+        end
+        doc.internal.uuid_to_version_info[uuid] = (dep.version, dep.tree_hash)
+    end
+end
+
+function get_src_to_uuid(doc::Document)
+    if isempty(doc.internal.src_to_uuid)
+        build_dep_info_dicts(doc)
+    end
+    return doc.internal.src_to_uuid
+end
+
+function get_uuid_to_version_info(doc::Document)
+    if isempty(doc.internal.uuid_to_version_info)
+        build_dep_info_dicts(doc)
+    end
+    return doc.internal.uuid_to_version_info
+end
+
+function get_pkginfo(uuid)
+    for registry in RegistryInstances.reachable_registries()
+        for (registry_uuid, pkg) in registry.pkgs
+            if registry_uuid == uuid
+                return RegistryInstances.registry_info(pkg)
+            end
+        end
+    end
+end
+
+function uuid_to_repo(doc, uuid)
+    pkginfo = get_pkginfo(uuid)
+    uuid_to_version_info = get_uuid_to_version_info(doc)
+    if !(uuid in keys(uuid_to_version_info))
+        return nothing
+    end
+    version = uuid_to_version_info[uuid][1]
+    if pkginfo === nothing
+        @debug "package not found in registries" uuid
+        return nothing
+    end
+    remote = parse_remote_url(pkginfo.repo)
+    if !(remote isa Remotes.GitHub)
+        @debug "could not get hash from repo -- only GitHub supported for now" pkginfo.repo
+        return nothing
+    end
+    tag_guess = "v" * string(version)
+    return (remote, tag_guess)
+end
+
+
 """
     $(SIGNATURES)
 
 Returns the the the remote that contains the file, and the relative path of the
 file within the repo (or `nothing, nothing` if the file is not in a known repo).
 """
-function relpath_from_remote_root(remotes::Vector{RemoteRepository}, path::AbstractString)
+function relpath_from_remote_root(doc::Union{Document, Nothing}, path::AbstractString)
+    remotes = doc.user.remotes
+    if remotes === nothing
+        # It's possible that doc.user.remotes is set to nothing, in which case
+        # we are not able to determine remote links.
+        return nothing
+    end
     ispath(path) || error("relpath_from_repo_root called with nonexistent path: $path")
     isabspath(path) || error("relpath_from_repo_root called with non-absolute path: $path")
     # We want to expand the path properly, including symlinks, so we call realpath()
@@ -726,11 +791,26 @@ function relpath_from_remote_root(remotes::Vector{RemoteRepository}, path::Abstr
                 # and `continue`-ing if we detect that. But let's not add that complexity now.
                 # TODO: the RemoteRepository() call may throw -- we should handle this more gracefully
                 remoteref = RemoteRepository(directory, remote)
-                @debug "relpath_from_remote_root: adding remote" remoteref
+                @debug "relpath_from_remote_root: adding .git directory -based remote" remoteref
                 addremote!(remotes, remoteref)
                 root_remote = remoteref
             end
             return true
+        end
+        # Finally, we can try figuring out the remote from information
+        # obtainable through Pkg
+        src_to_uuid = get_src_to_uuid(doc)
+        if haskey(src_to_uuid, directory)
+            uuid = src_to_uuid[directory]
+            repo_info = uuid_to_repo(doc, uuid)
+
+            if repo_info !== nothing
+                remoteref = RemoteRepository(directory, repo_info[1], repo_info[2])
+                @debug "relpath_from_remote_root: adding pkg registry -based remote" remoteref
+                addremote!(remotes, remoteref)
+                root_remote = remoteref
+                return true
+            end
         end
         return false
     end
@@ -743,9 +823,6 @@ function relpath_from_remote_root(remotes::Vector{RemoteRepository}, path::Abstr
         return (; repo = root_remote, relpath = relpath(path, root_directory))
     end
 end
-relpath_from_remote_root(doc::Document, path::AbstractString) = relpath_from_remote_root(doc.user.remotes, path)
-# It's possible that doc.user.remotes is set to nothing, in which case we are not able to determine remote links.
-relpath_from_remote_root(doc::Nothing, path::AbstractString) = nothing
 
 # Determines the Edit URL for a local path.
 #  - rev: indicates a Git revision; if omitted, the current repo commit is used.

--- a/src/documents.jl
+++ b/src/documents.jl
@@ -753,7 +753,7 @@ end
 Returns the the the remote that contains the file, and the relative path of the
 file within the repo (or `nothing, nothing` if the file is not in a known repo).
 """
-function relpath_from_remote_root(doc::Union{Document, Nothing}, path::AbstractString)
+function relpath_from_remote_root(doc::Document, path::AbstractString)
     remotes = doc.user.remotes
     if remotes === nothing
         # It's possible that doc.user.remotes is set to nothing, in which case

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -487,7 +487,7 @@ Stores the memoized results of [`getremote`](@ref).
 """
 const GIT_REMOTE_CACHE = Dict{String,Union{Remotes.Remote,Nothing}}()
 
-function parse_remote_url(remote)
+function parse_remote_url(remote::AbstractString)
     # TODO: we only match for GitHub repositories automatically. Could we engineer a
     # system where, if there is a user-created Remote, the user could also define a
     # matching function here that tries to interpret other URLs?

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -487,6 +487,15 @@ Stores the memoized results of [`getremote`](@ref).
 """
 const GIT_REMOTE_CACHE = Dict{String,Union{Remotes.Remote,Nothing}}()
 
+function parse_remote_url(remote)
+    # TODO: we only match for GitHub repositories automatically. Could we engineer a
+    # system where, if there is a user-created Remote, the user could also define a
+    # matching function here that tries to interpret other URLs?
+    m = match(LibGit2.GITHUB_REGEX, remote)
+    isnothing(m) && return nothing
+    return Remotes.GitHub(m[2], m[3])
+end
+
 """
 $(TYPEDSIGNATURES)
 
@@ -507,12 +516,7 @@ function getremote(dir::AbstractString)
             @debug "git config --get remote.origin.url failed" exception=(e, catch_backtrace())
             ""
         end
-        # TODO: we only match for GitHub repositories automatically. Could we engineer a
-        # system where, if there is a user-created Remote, the user could also define a
-        # matching function here that tries to interpret other URLs?
-        m = match(LibGit2.GITHUB_REGEX, remote)
-        isnothing(m) && return nothing
-        return Remotes.GitHub(m[2], m[3])
+        return parse_remote_url(remote)
     end
 end
 

--- a/test/docchecks.jl
+++ b/test/docchecks.jl
@@ -71,6 +71,7 @@ end
 @testset "doc checks" begin
     if haskey(ENV, "DOCUMENTER_TEST_ONLINE_LINKCHECK")
         include("online_linkcheck.jl")
+        include("online_githubcheck.jl")
     else
         @info "Online linkchecks skipped (DOCUMENTER_TEST_ONLINE_LINKCHECK not set)"
     end

--- a/test/online_githubcheck.jl
+++ b/test/online_githubcheck.jl
@@ -1,0 +1,58 @@
+module OnlineGithubCheckTests
+using Documenter: Documenter, MarkdownAST, AbstractTrees, render, expand, walk_navpages, githubcheck
+using Documenter.HTMLWriter: render_article, HTMLContext, HTML
+using Markdown
+using Test
+
+include("repolink_helpers.jl")
+
+@testset "Online githubcheck" begin
+    @testset "Success" begin
+        src = convert(
+            MarkdownAST.Node,
+            md"""
+            ```@meta
+            CurrentModule = Main.DocCheckTests.OnlineGithubCheckTests.TestHelperModule
+            ```
+            ```@docs
+            MarkdownAST.Node
+            ```
+            """
+        )
+        doc, html = render_expand_doc(src)
+
+        # Links to repo
+        re = r"<a[^>]+ href=['\"]?https://github.com/JuliaDocs/MarkdownAST.jl"
+        @test occursin(re, string(html))
+
+        # No error on check
+        @test githubcheck(doc) === nothing
+        @test doc.internal.errors == Set{Symbol}()
+    end
+
+    @testset "Failure" begin
+        src = convert(
+            MarkdownAST.Node,
+            md"""
+            ```@meta
+            CurrentModule = Main.DocCheckTests.OnlineGithubCheckTests.TestHelperModule
+            ```
+            This doc will not pass the checks because this version isn't tagged
+            ```@docs
+            RegistryInstances
+            ```
+            """
+        )
+        doc, html = render_expand_doc(src)
+
+        # Links to repo
+        re = r"<a[^>]+ href=['\"]?https://github.com/GunnarFarneback/RegistryInstances.jl"
+        @test occursin(re, string(html))
+
+        # Gets an error on check
+        @test_logs (:error,) @test githubcheck(doc) === nothing
+        @test doc.internal.errors == Set{Symbol}([:githubcheck])
+    end
+end
+
+end

--- a/test/online_githubcheck.jl
+++ b/test/online_githubcheck.jl
@@ -51,7 +51,7 @@ include("repolink_helpers.jl")
 
         # Gets an error on check
         @test_logs (:error,) @test githubcheck(doc) === nothing
-        @test doc.internal.errors == Set{Symbol}([:githubcheck])
+        @test doc.internal.errors == Set{Symbol}([:linkcheck_remotes])
     end
 end
 

--- a/test/repolink_helpers.jl
+++ b/test/repolink_helpers.jl
@@ -1,0 +1,22 @@
+module TestHelperModule
+    import MarkdownAST
+    import RegistryInstances
+end
+
+
+function render_expand_doc(src, kwargs...)
+    doc = Documenter.Document(;
+        sitename="sitename",
+        modules=[TestHelperModule, TestHelperModule.MarkdownAST, TestHelperModule.RegistryInstances],
+        pages=["testpage" => "testpage.md"],
+        linkcheck=true
+    )
+    doc.blueprint.pages["testpage.md"] = Documenter.Page("", "", "", [], Documenter.Globals(), src)
+    for navnode in walk_navpages(doc.user.pages, nothing, doc)
+        push!(doc.internal.navtree, navnode)
+    end
+    expand(doc)
+    ctx = HTMLContext(doc, HTML())
+    html = render_article(ctx, doc.internal.navtree[1])
+    return doc, html
+end

--- a/test/repolinks.jl
+++ b/test/repolinks.jl
@@ -5,7 +5,9 @@
 module RepoLinkTests
 using Test
 using Random: randstring
-using Documenter: Documenter, Remotes, git, edit_url, source_url
+using Documenter: Documenter, Remotes, git, edit_url, source_url, MarkdownAST, walk_navpages, expand
+using Documenter.HTMLWriter: render_article, HTMLContext, HTML
+using Markdown
 include("TestUtilities.jl"); using Main.TestUtilities
 
 function init_git_repo(f, path;
@@ -226,5 +228,44 @@ end
 )
 
 rm(tmproot, recursive=true, force=true)
+
+include("repolink_helpers.jl")
+
+@testset "Pkg.add() guesses github tag" begin
+    src = convert(
+        MarkdownAST.Node,
+        md"""
+        ```@meta
+        CurrentModule = Main.RepoLinkTests.TestHelperModule
+        ```
+        ```@docs
+        MarkdownAST.Node
+        ```
+        """
+    )
+    doc, html = render_expand_doc(src)
+
+    # Links to repo
+    re = r"<a[^>]+ href=['\"]?https://github.com/JuliaDocs/MarkdownAST.jl"
+    @test occursin(re, string(html))
+
+    src = convert(
+        MarkdownAST.Node,
+        md"""
+        ```@meta
+        CurrentModule = Main.RepoLinkTests.TestHelperModule
+        ```
+        This will result in a 404 because this version isn't tagged
+        ```@docs
+        RegistryInstances
+        ```
+        """
+    )
+    doc, html = render_expand_doc(src)
+
+    # Links to repo
+    re = r"<a[^>]+ href=['\"]?https://github.com/GunnarFarneback/RegistryInstances.jl"
+    @test occursin(re, string(html))
+end
 
 end


### PR DESCRIPTION
This will only work for nicely tagged packages hosted on GitHub for now. It works by getting the repository URL and tree hash from data in the registry and getting the version number from the manifest. The GitHub API is then used to get a commit id from a tag corresponding to the version v$VERSION. These tags are the type created by the widely used `JuliaRegistries/TagBot`. This is robust against the tag being incorrect (e.g. if it was created manually but incorrectly) since the package tree hash is checked against the tree hash of the commit.

I think it would be nice to have this before 0.28 / 1.0.0 since everyone's missing remotes will start erroring then.

Happy to give this another pass if need be to try and address any concerns.