### PR TITLE
Ignore size of release notes page in manual

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -31,7 +31,7 @@ makedocs(
             analytics = "UA-136089579-2",
             highlights = ["yaml"],
             ansicolor = true,
-            size_threshold_ignore = ["release-notes/index.html"],
+            size_threshold_ignore = ["release-notes.md"],
         )
     end,
     build = ("pdf" in ARGS) ? "build-pdf" : "build",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -31,6 +31,7 @@ makedocs(
             analytics = "UA-136089579-2",
             highlights = ["yaml"],
             ansicolor = true,
+            size_threshold_ignore = ["release-notes/index.html"],
         )
     end,
     build = ("pdf" in ARGS) ? "build-pdf" : "build",


### PR DESCRIPTION
The page is actually pretty close to the threshold limit, so let's make use our new options :slightly_smiling_face: 

```
┌ Warning: Generated HTML over size_threshold_warn limit: release-notes/index.html
│     Generated file size: 184759 (bytes)
│     size_threshold_warn: 102400 (bytes)
│     size_threshold:      204800 (bytes)
└ @ Documenter.HTMLWriter ~/work/Documenter.jl/Documenter.jl/src/html/HTMLWriter.jl:1733
```