### PR TITLE
Improve size threshold warning

### DIFF
--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -1769,10 +1769,11 @@ function write_html(ctx::HTMLContext, navnode::Documenter.NavNode, page_html::DO
     isdir(dirname(path)) || mkpath(dirname(path))
     file_size = open(io -> write(io, take!(buf)), path; write=true)
     size_threshold_msg(var::Symbol) = """
-    Generated HTML over $(var) limit: $(page_path)
+    Generated HTML over $(var) limit: $(navnode.page)
         Generated file size: $(file_size) (bytes)
         size_threshold_warn: $(ctx.settings.size_threshold_warn) (bytes)
-        size_threshold:      $(ctx.settings.size_threshold) (bytes)"""
+        size_threshold:      $(ctx.settings.size_threshold) (bytes)
+        HTML file:           $(page_path)"""
     if navnode.page in ctx.settings.size_threshold_ignore
         if file_size > ctx.settings.size_threshold_warn
             @debug """


### PR DESCRIPTION
Previously, it would show just the HTML file path, which is not useful when you want to e.g. set size_threshold_ignore. Now it shows the page mane, but also separately prints the path to the HTML.

```
┌ Warning: Generated HTML over size_threshold_warn limit: index.md
│     Generated file size: 127617 (bytes)
│     size_threshold_warn: 102400 (bytes)
│     size_threshold:      9223372036854775807 (bytes)
│     HTML file:           index.html
└ @ Documenter.HTMLWriter ~/juliadocs/Documenter/src/html/HTMLWriter.jl:1788
```