### PR TITLE
Throw an error if makedocs() gets passed invalid kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   **For upgrading:** If you are passing any plugin objects to `makedocs` (positionally), pass them via the `plugins` keyword instead.
 
-* `makedocs` will now throw an error if it gets passed an unsupported keyword argument.
+* `makedocs` will now throw an error if it gets passed an unsupported keyword argument. ([#2259])
 
   **For upgrading:** Remove the listed keyword arguments from the `makedocs` call. If the keyword was previously valid, consult this CHANGELOG for upgrade instructions.
 
@@ -1643,6 +1643,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2134]: https://github.com/JuliaDocs/Documenter.jl/issues/2134
 [#2141]: https://github.com/JuliaDocs/Documenter.jl/issues/2141
 [#2142]: https://github.com/JuliaDocs/Documenter.jl/issues/2142
+[#2143]: https://github.com/JuliaDocs/Documenter.jl/issues/2143
 [#2145]: https://github.com/JuliaDocs/Documenter.jl/issues/2145
 [#2147]: https://github.com/JuliaDocs/Documenter.jl/issues/2147
 [#2153]: https://github.com/JuliaDocs/Documenter.jl/issues/2153
@@ -1662,7 +1663,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2216]: https://github.com/JuliaDocs/Documenter.jl/issues/2216
 [#2232]: https://github.com/JuliaDocs/Documenter.jl/issues/2232
 [#2236]: https://github.com/JuliaDocs/Documenter.jl/issues/2236
+[#2245]: https://github.com/JuliaDocs/Documenter.jl/issues/2245
+[#2247]: https://github.com/JuliaDocs/Documenter.jl/issues/2247
+[#2249]: https://github.com/JuliaDocs/Documenter.jl/issues/2249
 [#2252]: https://github.com/JuliaDocs/Documenter.jl/issues/2252
+[#2259]: https://github.com/JuliaDocs/Documenter.jl/issues/2259
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   **For upgrading:** If you are passing any plugin objects to `makedocs` (positionally), pass them via the `plugins` keyword instead.
 
+* `makedocs` will now throw an error if it gets passed an unsupported keyword argument.
+
+  **For upgrading:** Remove the listed keyword arguments from the `makedocs` call. If the keyword was previously valid, consult this CHANGELOG for upgrade instructions.
+
 ### Added
 
 * Doctest filters can now be specified as regex/substitution pairs, i.e. `r"..." => s"..."`, in order to control the replacement (which defaults to the empty string, `""`). ([#1989], [#1271])

--- a/src/documents.jl
+++ b/src/documents.jl
@@ -389,8 +389,15 @@ function Document(;
         others...
     )
 
+    if !isempty(others)
+        msg = "makedocs() got passed invalid keyword arguments:"
+        for (k, v) in others
+            msg *= string("\n  ", k, " = ", repr(v))
+        end
+        throw(ArgumentError(msg))
+    end
+
     warnonly = reduce_warnonly(warnonly) # convert warnonly to Symbol[]
-    check_kwargs(others)
 
     if !isa(format, AbstractVector)
         format = Writer[format]

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -198,21 +198,6 @@ function update_linenumbernodes!(x::LineNumberNode, newfile, lineshift)
 end
 
 
-# Checking arguments.
-
-"""
-Prints a formatted warning to the user listing unrecognised keyword arguments.
-"""
-function check_kwargs(kws)
-    isempty(kws) && return
-    out = IOBuffer()
-    println(out, "Unknown keywords:\n")
-    for (k, v) in kws
-        println(out, "  ", k, " = ", v)
-    end
-    @warn(String(take!(out)))
-end
-
 # Finding submodules.
 
 const ModVec = Union{Module, Vector{Module}}

--- a/test/doctests/doctests.jl
+++ b/test/doctests/doctests.jl
@@ -143,7 +143,7 @@ rfile(filename) = joinpath(@__DIR__, "stdouts", filename)
 @testset "doctesting" begin
     # So, we have 4 doctests: 2 in a docstring, 2 in an .md file. One of either pair is
     # OK, other is broken. Here we first test all possible combinations of these doctest
-    # with strict = true to make sure that the doctests are indeed failing.
+    # to make sure that the doctests are indeed failing.
     #
     # Some tests are broken due to https://github.com/JuliaDocs/Documenter.jl/issues/974
     run_makedocs(["working.md"]) do result, success, backtrace, output

--- a/test/doctests/fix/tests.jl
+++ b/test/doctests/fix/tests.jl
@@ -40,10 +40,10 @@ function test_doctest_fix(dir)
     @debug "Running doctest/fix doctests with doctest=:fix"
     @quietly makedocs(sitename="-", modules = [Foo], source = srcdir, build = builddir, doctest = :fix)
 
-    # test that strict = true works
+    # check that the doctests are passing now
     include(joinpath(srcdir, "src.jl")); @eval import .Foo
     @debug "Running doctest/fix doctests with doctest=true"
-    @quietly makedocs(sitename="-", modules = [Foo], source = srcdir, build = builddir, strict = true)
+    @quietly makedocs(sitename="-", modules = [Foo], source = srcdir, build = builddir)
 
     # also test that we obtain the expected output
     @test normalize_line_endings(index_md) == normalize_line_endings(joinpath(@__DIR__, "fixed.md"))


### PR DESCRIPTION
Noticed when testing with a few manuals that we actually allow passing invalid kwargs. In particular for this upgrade cycle, I think it's useful if we error when users pass kwargs that don't exist anymore (like `strict`).