### PR TITLE
Make at-eval type error a docerror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   **For upgrading:** To keep using the Markdown backend, refer to the [DocumenterMarkdown package](https://github.com/JuliaDocs/DocumenterMarkdown.jl). That package might not immediately support the latest Documenter version, however.
 
-* `@eval` blocks now require the last expression to be either `nothing` or of type `Markdown.MD`, with other cases now issuing an `:eval_block` error, and falling back to a text representation of the object. ([#1919])
+* `@eval` blocks now require the last expression to be either `nothing` or of type `Markdown.MD`, with other cases now issuing an `:eval_block` error, and falling back to a text representation of the object. ([#1919], [#2260])
 
   **For upgrading:** The cases where an `@eval` results in a object that is not `nothing` or `::Markdown.MD`, the returned object should be reviewed. In case the resulting object is of some `Markdown` node type (e.g. `Markdown.Paragraph` or `Markdown.Table`), it can simply be wrapped in `Markdown.MD([...])` for block nodes, or `Markdown.MD([Markdown.Paragraph([...])])` for inline nodes. In other cases Documenter was likely not handling the returned object in a correct way, but please open an issue if this change has broken a previously working use case. The error can be ignored by passing `:eval_block` to the `warnonly` keyword.
 
@@ -1668,6 +1668,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2249]: https://github.com/JuliaDocs/Documenter.jl/issues/2249
 [#2252]: https://github.com/JuliaDocs/Documenter.jl/issues/2252
 [#2259]: https://github.com/JuliaDocs/Documenter.jl/issues/2259
+[#2260]: https://github.com/JuliaDocs/Documenter.jl/issues/2260
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   **For upgrading:** To keep using the Markdown backend, refer to the [DocumenterMarkdown package](https://github.com/JuliaDocs/DocumenterMarkdown.jl). That package might not immediately support the latest Documenter version, however.
 
-* `@eval` blocks now require the last expression to be either `nothing` or of type `Markdown.MD`, with other cases now issuing a warning and falling back to a text representation in a code block. ([#1919])
+* `@eval` blocks now require the last expression to be either `nothing` or of type `Markdown.MD`, with other cases now issuing an `:eval_block` error, and falling back to a text representation of the object. ([#1919])
 
-  **For upgrading:** The cases where an `@eval` results in a object that is not `nothing` or `::Markdown.MD`, the returned object should be reviewed. In case the resulting object is of some `Markdown` node type (e.g. `Markdown.Paragraph` or `Markdown.Table`), it can simply be wrapped in `Markdown.MD([...])` for block nodes, or `Markdown.MD([Markdown.Paragraph([...])])` for inline nodes. In other cases Documenter was likely not handling the returned object in a correct way, but please open an issue if this change has broken a previously working use case.
+  **For upgrading:** The cases where an `@eval` results in a object that is not `nothing` or `::Markdown.MD`, the returned object should be reviewed. In case the resulting object is of some `Markdown` node type (e.g. `Markdown.Paragraph` or `Markdown.Table`), it can simply be wrapped in `Markdown.MD([...])` for block nodes, or `Markdown.MD([Markdown.Paragraph([...])])` for inline nodes. In other cases Documenter was likely not handling the returned object in a correct way, but please open an issue if this change has broken a previously working use case. The error can be ignored by passing `:eval_block` to the `warnonly` keyword.
 
 * The handling of remote repository (e.g. GitHub) URLs has been overhauled. ([#1808], [#1881], [#2081], [#2232])
 

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -591,19 +591,19 @@ function Selectors.runner(::Type{Expanders.EvalBlocks}, node, page, doc)
         else
             # TODO: we could handle the cases where the user provides some of the Markdown library
             # objects, like Paragraph.
-            @warn """
+            @docerror(doc, :eval_block, """
             Invalid type of object in @eval in $(Documenter.locrepr(page.source))
             ```$(x.info)
             $(x.code)
             ```
-            Evaluate to `$(typeof(result))`, should be one of
+            Evaluated to `$(typeof(result))`, but should be one of
              - Nothing
              - Markdown.MD
-            Falling back to code block representation.
+            Falling back to textual code block representation.
 
-            If you are seeing this warning after upgrading Documenter and this used to work,
+            If you are seeing this warning/error after upgrading Documenter and this used to work,
             please open an issue on the Documenter issue tracker.
-            """
+            """)
             MarkdownAST.@ast MarkdownAST.Document() do
                 MarkdownAST.CodeBlock("", sprint(show, MIME"text/plain"(), result))
             end

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -422,7 +422,7 @@ examples_html_local_doc = if "html-local" in EXAMPLE_BUILDS
             footer = nothing,
         ),
         # TODO: example_block failure only happens on windows, so that's not actually expected
-        warnonly = [:doctest, :footnote, :cross_references, :linkcheck, :example_block],
+        warnonly = [:doctest, :footnote, :cross_references, :linkcheck, :example_block, :eval_block],
     )
 else
     @info "Skipping build: HTML/local"

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -657,7 +657,7 @@ examples_latex_doc = if "latex" in EXAMPLE_BUILDS
         ],
         doctest = false,
         debug = true,
-        warnonly = [:footnote, :cross_references, :example_block],
+        warnonly = [:footnote, :cross_references, :example_block, :eval_block],
     )
 else
     @info "Skipping build: LaTeXWriter/latex"
@@ -741,7 +741,7 @@ examples_latex_texonly_doc = if "latex_texonly" in EXAMPLE_BUILDS
         ],
         doctest = false,
         debug = true,
-        warnonly = [:footnote, :cross_references, :example_block],
+        warnonly = [:footnote, :cross_references, :example_block, :eval_block],
     )
 else
     @info "Skipping build: LaTeXWriter/latex_texonly"


### PR DESCRIPTION
Makes the warning if an `@eval` block fails a `@docerror` (#1919). Point being that if users do start running into this, their docs will not look correct, and so this should fail the build (unless disabled with `warnonly = :eval_block`.