### PR TITLE
Add backticks to size_threshold_msg

### DIFF
--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -1769,11 +1769,11 @@ function write_html(ctx::HTMLContext, navnode::Documenter.NavNode, page_html::DO
     isdir(dirname(path)) || mkpath(dirname(path))
     file_size = open(io -> write(io, take!(buf)), path; write=true)
     size_threshold_msg(var::Symbol) = """
-    Generated HTML over $(var) limit: $(navnode.page)
+    Generated HTML over `$(var)` limit: `$(navnode.page)`
         Generated file size: $(file_size) (bytes)
-        size_threshold_warn: $(ctx.settings.size_threshold_warn) (bytes)
-        size_threshold:      $(ctx.settings.size_threshold) (bytes)
-        HTML file:           $(page_path)"""
+        `size_threshold_warn`: $(ctx.settings.size_threshold_warn) (bytes)
+        `size_threshold`:      $(ctx.settings.size_threshold) (bytes)
+        HTML file:           `$(page_path)`"""
     if navnode.page in ctx.settings.size_threshold_ignore
         if file_size > ctx.settings.size_threshold_warn
             @debug """


### PR DESCRIPTION
before
![image](https://github.com/JuliaDocs/Documenter.jl/assets/7318249/2bfe5c3b-1482-4e18-bbf1-83874fc305be)

after
![image](https://github.com/JuliaDocs/Documenter.jl/assets/7318249/e1c0c960-383e-4af2-9c19-95ec2685679a)
