### PR TITLE
fix DocTestFilter = nothing (redo #1696)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+* Fix an error occurring with `DocTestFilters = nothing` in `@meta` blocks. ([#2273], [#1696])
+
 ## Version [v1.0.1] - 2023-09-18
 
 ### Fixed

--- a/src/doctests.jl
+++ b/src/doctests.jl
@@ -386,8 +386,8 @@ function debug_report(; result, expected_filtered, evaluated, evaluated_filtered
 end
 
 function collect_doctest_filters(doc::Documenter.Document, meta::Dict)
-    meta_block_filters = get(meta, :DocTestFilters, [])
-    meta_block_filters == nothing && meta_block_filters == []
+    meta_block_filters = get(Vector{Any}, meta, :DocTestFilters)
+    meta_block_filters === nothing && (meta_block_filters = [])
     doctest_local_filters = get(meta[:LocalDocTestArguments], :filter, [])
     [doc.user.doctestfilters; meta_block_filters; doctest_local_filters]
 end

--- a/test/examples/src/index.md
+++ b/test/examples/src/index.md
@@ -151,6 +151,15 @@ foobuu
 ```
 
 ```@meta
+DocTestFilters = nothing
+```
+
+```jldoctest
+julia> print("foobar")
+foobar
+```
+
+```@meta
 DocTestFilters = []
 ```
 


### PR DESCRIPTION
Setting `DocTestFilter = nothing` in a meta block fails with Documenter 1.0.1 since the changes from #1696 were lost in the refactor.

```julia
┌ Error: Doctesting failed
│   exception =
│    Invalid doctest filter:
│    nothing :: Nothing
│    Stacktrace:
│      [1] error(s::String)
│        @ Base ./error.jl:35
│      [2] filter_doctests(filters::Vector{Any}, strings::Tuple{SubString{String}, String})
│        @ Documenter ~/.julia/packages/Documenter/Meee1/src/doctests.jl:281
│      [3] checkresult(sandbox::Module, result::Documenter.Result, meta::Dict{Symbol, Any}, doc::Documenter.Document)
│        @ Documenter ~/.julia/packages/Documenter/Meee1/src/doctests.jl:328
...
```
This PR re-adds the changes from #1696 and adds a test.