### PR TITLE
hosting.md: recommend current codecov/codecov-action version

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -296,7 +296,7 @@ are uploaded to Codecov:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
 ```
 
 ## `docs/Project.toml`


### PR DESCRIPTION
Version 1 is deprecated and may not even work anymore