### PR TITLE
Fix debug logging for doctest filtering

### DIFF
--- a/src/doctests.jl
+++ b/src/doctests.jl
@@ -328,7 +328,7 @@ function checkresult(sandbox::Module, result::Result, meta::Dict, doc::Documente
         filteredstr, filteredoutput = filter_doctests(filters, (str, output))
         @debug debug_report(
             result=result, filters = filters, expected_filtered = filteredoutput,
-            evaluated = rstrip(str), evaluated_filtered = filteredoutput
+            evaluated = rstrip(str), evaluated_filtered = filteredstr
         )
         if filteredstr != filteredoutput
             if doc.user.doctest === :fix


### PR DESCRIPTION
While debugging a doctest filter with `ENV["JULIA_DEBUG"] = "Documenter"` I noticed that the "Evaluated output (filtered)" was clearly not derived from the "Evaluated output". I think this here is the cause.