### PR TITLE
Add an implementation of Remote for GitLab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Added `Remotes.GitLab` for specifying a `Remote` hosted on gitlab.com or a self-hosted GitLab instance.
+* Added `Remotes.GitLab` for specifying a `Remote` hosted on gitlab.com or a self-hosted GitLab instance. ([#2279])
 
 ## Version [v1.0.1] - 2023-09-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## In-Development
+
+### Added
+
+* Added `Remotes.GitLab` for specifying a `Remote` hosted on gitlab.com or a self-hosted GitLab instance.
+
 ## Version [v1.0.1] - 2023-09-18
 
 ### Fixed

--- a/docs/src/lib/remote-links.md
+++ b/docs/src/lib/remote-links.md
@@ -53,7 +53,7 @@ Note that enabling this option can cause documentation builds to fail due to net
 
 !!! note
 
-    The [`Remotes` API](@ref remotes-api) can be used to implement the methods to compute the remote URLs (for now, Documenter only [supports GitHub natively](@ref Remotes.GitHub)).
+    The [`Remotes` API](@ref remotes-api) can be used to implement the methods to compute the remote URLs (for now, Documenter only supports [GitHub](@ref Remotes.GitHub) and [GitLab](@ref Remotes.GitLab) natively).
 
 [^1]: There is an exception to this: links to Julia `Base` module source files.
       But Documenter already known how to handle those correctly, and they are really only relevant to the Julia main manual build.
@@ -83,6 +83,7 @@ The rules are as follows:
 ```@docs
 Documenter.Remotes
 Documenter.Remotes.GitHub
+Documenter.Remotes.GitLab
 ```
 
 The following types and functions and relevant when creating custom

--- a/test/remotes.jl
+++ b/test/remotes.jl
@@ -1,7 +1,7 @@
 module RemoteTests
 using Test
 using Documenter
-using .Remotes: repofile, repourl, issueurl, URL, GitHub
+using .Remotes: repofile, repourl, issueurl, URL, GitHub, GitLab
 
 @testset "RepositoryRemote" begin
     let r = URL("https://github.com/FOO/BAR/blob/{commit}{path}#{line}")
@@ -66,6 +66,34 @@ using .Remotes: repofile, repourl, issueurl, URL, GitHub
         @test repofile(r, "mybranch", "src/foo.jl", 5:5) == "https://github.com/JuliaDocs/Documenter.jl/blob/mybranch/src/foo.jl#L5"
         @test repofile(r, "mybranch", "src/foo.jl", 5:8) == "https://github.com/JuliaDocs/Documenter.jl/blob/mybranch/src/foo.jl#L5-L8"
         @test issueurl(r, "123") == "https://github.com/JuliaDocs/Documenter.jl/issues/123"
+    end
+
+    # GitLab remote
+    let r = GitLab("JuliaDocs", "Documenter.jl")
+        @test repourl(r) == "https://gitlab.com/JuliaDocs/Documenter.jl"
+        @test repofile(r, "mybranch", "src/foo.jl") == "https://gitlab.com/JuliaDocs/Documenter.jl/-/tree/mybranch/src/foo.jl"
+        @test repofile(r, "mybranch", "src/foo.jl", 5) == "https://gitlab.com/JuliaDocs/Documenter.jl/-/tree/mybranch/src/foo.jl#L5"
+        @test repofile(r, "mybranch", "src/foo.jl", 5:5) == "https://gitlab.com/JuliaDocs/Documenter.jl/-/tree/mybranch/src/foo.jl#L5"
+        @test repofile(r, "mybranch", "src/foo.jl", 5:8) == "https://gitlab.com/JuliaDocs/Documenter.jl/-/tree/mybranch/src/foo.jl#L5-L8"
+        @test issueurl(r, "123") == "https://gitlab.com/JuliaDocs/Documenter.jl/-/issues/123"
+    end
+
+    let r = GitLab("my-gitlab.com", "JuliaDocs", "Documenter.jl")
+        @test repourl(r) == "https://my-gitlab.com/JuliaDocs/Documenter.jl"
+        @test repofile(r, "mybranch", "src/foo.jl") == "https://my-gitlab.com/JuliaDocs/Documenter.jl/-/tree/mybranch/src/foo.jl"
+        @test repofile(r, "mybranch", "src/foo.jl", 5) == "https://my-gitlab.com/JuliaDocs/Documenter.jl/-/tree/mybranch/src/foo.jl#L5"
+        @test repofile(r, "mybranch", "src/foo.jl", 5:5) == "https://my-gitlab.com/JuliaDocs/Documenter.jl/-/tree/mybranch/src/foo.jl#L5"
+        @test repofile(r, "mybranch", "src/foo.jl", 5:8) == "https://my-gitlab.com/JuliaDocs/Documenter.jl/-/tree/mybranch/src/foo.jl#L5-L8"
+        @test issueurl(r, "123") == "https://my-gitlab.com/JuliaDocs/Documenter.jl/-/issues/123"
+    end
+
+    let r = GitLab("JuliaDocs/Documenter.jl")
+        @test repourl(r) == "https://gitlab.com/JuliaDocs/Documenter.jl"
+        @test repofile(r, "mybranch", "src/foo.jl") == "https://gitlab.com/JuliaDocs/Documenter.jl/-/tree/mybranch/src/foo.jl"
+        @test repofile(r, "mybranch", "src/foo.jl", 5) == "https://gitlab.com/JuliaDocs/Documenter.jl/-/tree/mybranch/src/foo.jl#L5"
+        @test repofile(r, "mybranch", "src/foo.jl", 5:5) == "https://gitlab.com/JuliaDocs/Documenter.jl/-/tree/mybranch/src/foo.jl#L5"
+        @test repofile(r, "mybranch", "src/foo.jl", 5:8) == "https://gitlab.com/JuliaDocs/Documenter.jl/-/tree/mybranch/src/foo.jl#L5-L8"
+        @test issueurl(r, "123") == "https://gitlab.com/JuliaDocs/Documenter.jl/-/issues/123"
     end
 end
 


### PR DESCRIPTION
We use a self-hosted GitLab at work. I thought you might be interested in merging in an implementation of Remote for GitLab. This is my stab at it. I'm happy to make modifications!

One thing I'm not sure about is the constructor. The number of variations seems confusing to me. And it is odd that you can't specify the host when you use the slash separated version of the repo. Maybe this warrants a keyword argument constructor?