### PR TITLE
Fix in-line math output in HTMLWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+* Fixed display of inline LaTeX math `$ ... $` in HTMLWriter ([#2281])
+
 ## Version [v1.0.1] - 2023-09-18
 
 ### Fixed
@@ -1683,6 +1689,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2259]: https://github.com/JuliaDocs/Documenter.jl/issues/2259
 [#2260]: https://github.com/JuliaDocs/Documenter.jl/issues/2260
 [#2269]: https://github.com/JuliaDocs/Documenter.jl/issues/2269
+[#2281]: https://github.com/JuliaDocs/Documenter.jl/issues/2281
 [JuliaLang/julia#29344]: https://github.com/JuliaLang/julia/issues/29344
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* Fixed display of inline LaTeX math `$ ... $` in HTMLWriter ([#2281])
+* Fixed display of inline LaTeX math `$ ... $` from `show` methods in HTMLWriter. ([#2280], [#2281])
 * Fixed a crash in GitHub remote link checking when `remotes = nothing`. ([#2274], [#2285])
 
 ## Version [v1.0.1] - 2023-09-18

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -2395,7 +2395,7 @@ function domify(dctx::DCtx, node::Node, d::Dict{MIME,Any})
         latex = d[MIME"text/latex"()]
         # Make sure to match multiline strings!
         m_bracket = match(r"\s*\\\[(.*)\\\]\s*"s, latex)
-        m_dollars = match(r"\s*\$\$(.*)\$\$\s*"s, latex)
+        m_dollars = match(r"\s*\$\$?(.*?)\$?\$\s*"s, latex)
         out = if m_bracket === nothing && m_dollars === nothing
             Documenter.mdparse(latex; mode = :single)
         else

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -2389,17 +2389,15 @@ function domify(dctx::DCtx, node::Node, d::Dict{MIME,Any})
     end
     # Check for some 'fallback' MIMEs, defaulting to 'text/plain' if we can't find any of them.
     return if haskey(d, MIME"text/latex"())
-        # If the show(io, ::MIME"text/latex", x) output is already wrapped in \[ ... \] or $$ ... $$, we
-        # unwrap it first, since when we output Markdown.LaTeX objects we put the correct
-        # delimiters around it anyway.
         latex = d[MIME"text/latex"()]
-        # Make sure to match multiline strings!
-        m_bracket = match(r"\s*\\\[(.*)\\\]\s*"s, latex)
-        m_dollars = match(r"\s*\$\$?(.*?)\$?\$\s*"s, latex)
-        out = if m_bracket === nothing && m_dollars === nothing
+        # If the show(io, ::MIME"text/latex", x) output is already wrapped in
+        # \[ ... \] or $$ ... $$, we unwrap it first, since when we output
+        # Markdown.LaTeX objects we put the correct delimiters around it anyway.
+        has_math, latex = _strip_latex_math_delimiters(latex)
+        out = if !has_math
             Documenter.mdparse(latex; mode = :single)
         else
-            [MarkdownAST.@ast MarkdownAST.DisplayMath(m_bracket !== nothing ? m_bracket[1] : m_dollars[1])]
+            [MarkdownAST.@ast MarkdownAST.DisplayMath(latex)]
         end
         domify(dctx, out)
     elseif haskey(d, MIME"text/markdown"())
@@ -2413,6 +2411,21 @@ function domify(dctx::DCtx, node::Node, d::Dict{MIME,Any})
     else
         error("this should never happen.")
     end
+end
+
+function _strip_latex_math_delimiters(latex::AbstractString)
+    # Make sure to match multiline strings!
+    m_bracket = match(r"\s*\\\[(.*)\\\]\s*"s, latex)
+    if m_bracket !== nothing
+        return true, m_bracket[1]
+    end
+    # This regex matches the strings "$ ... $" and "$$ ... $$", but not
+    # strings with mis-matched dollar signs such as "$ ... $$" or "$$ ... $"
+    m_dollars = match(r"^\s*(\${1,2})([^\$]*)\1\s*$"s, latex)
+    if m_dollars !== nothing
+        return true, m_dollars[2]
+    end
+    return false, latex
 end
 
 function domify_show_image_binary(dctx::DCtx, filetype::AbstractString, d::Dict{MIME,Any})

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -2420,7 +2420,7 @@ function _strip_latex_math_delimiters(latex::AbstractString)
         return true, m_bracket[1]
     end
     # This regex matches the strings "$ ... $" and "$$ ... $$", but not
-    # strings with mis-matched dollar signs such as "$ ... $$" or "$$ ... $"
+    # strings with miss-matched dollar signs such as "$ ... $$" or "$$ ... $"
     m_dollars = match(r"^\s*(\${1,2})([^\$]*)\1\s*$"s, latex)
     if m_dollars !== nothing
         return true, m_dollars[2]

--- a/test/examples/src/man/tutorial.md
+++ b/test/examples/src/man/tutorial.md
@@ -551,6 +551,12 @@ LaTeXEquation("\\[\\left[\\begin{array}{rr} x & 2x \\\\ \n y & y \\end{array}\\r
 LaTeXEquation("\$\$\\begin{bmatrix} 1 & 2 \\\\ \n 3 & 4 \\end{bmatrix}\$\$")
 ```
 
+Inline-ish `text/latex` bytes:
+
+```@example showablelatex
+LaTeXEquation("\$ x_{1} + x_{2} \$")
+```
+
 ## Videos
 
 ![](https://dl8.webmfiles.org/big-buck-bunny_trailer.webm)

--- a/test/htmlwriter.jl
+++ b/test/htmlwriter.jl
@@ -315,6 +315,30 @@ end
                     @test _strip_latex_math_delimiters(input) == output
                 end
             end
+            # Test that mis-matched delimiters are not treated as math
+            # delimiters
+            for (left, right) in [
+                ("\\[", ""),
+                ("\$", ""),
+                ("\$\$", ""),
+                ("", "\\]"),
+                ("", "\$"),
+                ("", "\$\$"),
+                ("\$", "\\]"),
+                ("\$\$", "\$"),
+                ("\$", "\$\$"),
+            ]
+                for input in [
+                    content,
+                    "$left$content$right",
+                    " $left$content$right",
+                    "$left$content$right ",
+                    "\t$left$content$right  ",
+                    " \t$left$content$right\t\t",
+                ]
+                    @test _strip_latex_math_delimiters(input) == (false, input)
+                end
+            end
         end
     end
 end

--- a/test/htmlwriter.jl
+++ b/test/htmlwriter.jl
@@ -315,7 +315,7 @@ end
                     @test _strip_latex_math_delimiters(input) == output
                 end
             end
-            # Test that mis-matched delimiters are not treated as math
+            # Test that miss-matched delimiters are not treated as math
             # delimiters
             for (left, right) in [
                 ("\\[", ""),
@@ -341,4 +341,5 @@ end
             end
         end
     end
+end
 end


### PR DESCRIPTION
Before I add tests etc for #2280, is this something that would be considered? Or should all `MIME"text/latex"` outputs be display math?