### PR TITLE
give better file:lineno in the log

### DIFF
--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -299,7 +299,10 @@ function Selectors.runner(::Type{Expanders.MetaBlocks}, node, page, doc)
                     ```$(x.info)
                     $(x.code)
                     ```
-                    """, exception = err)
+                    """, exception = err,
+                    _file = joinpath(pwd(), page.source),
+                    _line = lines.first,
+                )
             end
         end
     end
@@ -374,7 +377,10 @@ function Selectors.runner(::Type{Expanders.DocsBlocks}, node, page, doc)
                 $(x.code)
                 ```
                 """,
-                exception = err)
+                exception = err,
+                _file = joinpath(pwd(), page.source),
+                _line = lines.first,
+            )
             push!(docsnodes, admonition)
             continue
         end
@@ -386,7 +392,10 @@ function Selectors.runner(::Type{Expanders.DocsBlocks}, node, page, doc)
                 ```$(x.info)
                 $(x.code)
                 ```
-                """)
+                """,
+                _file = joinpath(pwd(), page.source),
+                _line = lines.first,
+            )
             push!(docsnodes, admonition)
             continue
         end
@@ -400,7 +409,10 @@ function Selectors.runner(::Type{Expanders.DocsBlocks}, node, page, doc)
                 ```$(x.info)
                 $(x.code)
                 ```
-                """)
+                """,
+                _file = joinpath(pwd(), page.source),
+                _line = lines.first,
+            )
             push!(docsnodes, admonition)
             continue
         end
@@ -421,7 +433,10 @@ function Selectors.runner(::Type{Expanders.DocsBlocks}, node, page, doc)
                 ```$(x.info)
                 $(x.code)
                 ```
-                """)
+                """,
+                _file = joinpath(pwd(), page.source),
+                _line = lines.first,
+            )
             push!(docsnodes, admonition)
             continue
         end
@@ -470,7 +485,11 @@ function Selectors.runner(::Type{Expanders.AutoDocsBlocks}, node, page, doc)
                     ```$(x.info)
                     $(x.code)
                     ```
-                    """, exception = err)
+                    """,
+                    exception = err,
+                    _file = joinpath(pwd(), page.source),
+                    _line = lines.first,
+                )
             end
         end
     end
@@ -511,7 +530,11 @@ function Selectors.runner(::Type{Expanders.AutoDocsBlocks}, node, page, doc)
                       warnonly = [:autodocs_block]
 
                     However, the relevant docstrings will then not be included by the @autodocs block.
-                    """, exception = err)
+                    """,
+                        exception = err,
+                        _file = joinpath(pwd(), page.source),
+                        _line = lines.first,
+                    )
                     continue # skip this docstring
                 end
                 if category in order && included
@@ -562,7 +585,11 @@ function Selectors.runner(::Type{Expanders.AutoDocsBlocks}, node, page, doc)
                     ```$(x.info)
                     $(x.code)
                     ```
-                    """)
+                    """,
+                    _file = joinpath(pwd(),
+                    page.source),
+                    _line = lines.first,
+                )
                 continue
             end
             markdown::Markdown.MD = Documenter.DocSystem.parsedoc(docstr)
@@ -585,7 +612,10 @@ function Selectors.runner(::Type{Expanders.AutoDocsBlocks}, node, page, doc)
             ```$(x.info)
             $(x.code)
             ```
-            """)
+            """,
+            _file = joinpath(pwd(), page.source),
+            _line = lines.first,
+        )
     end
 end
 
@@ -621,7 +651,11 @@ function Selectors.runner(::Type{Expanders.EvalBlocks}, node, page, doc)
                     ```$(x.info)
                     $(x.code)
                     ```
-                    """, exception = (err, bt))
+                    """,
+                    exception = (err, bt),
+                    _file = joinpath(pwd(), page.source),
+                    _line = lines.first,
+                )
             end
         end
         result = if isnothing(result)
@@ -643,7 +677,10 @@ function Selectors.runner(::Type{Expanders.EvalBlocks}, node, page, doc)
 
             If you are seeing this warning/error after upgrading Documenter and this used to work,
             please open an issue on the Documenter issue tracker.
-            """)
+            """,
+                _file = joinpath(pwd(), page.source),
+                _line = lines.first,
+            )
             MarkdownAST.@ast MarkdownAST.Document() do
                 MarkdownAST.CodeBlock("", sprint(show, MIME"text/plain"(), result))
             end
@@ -749,7 +786,11 @@ function Selectors.runner(::Type{Expanders.ExampleBlocks}, node, page, doc)
                     ```$(x.info)
                     $(x.code)
                     ```
-                    """, exception = (c.value, bt))
+                    """,
+                    exception = (c.value, bt),
+                    _file = joinpath(pwd(), page.source),
+                    _line = lines.first,
+                )
                 return
             end
         end
@@ -898,7 +939,10 @@ function Selectors.runner(::Type{Expanders.SetupBlocks}, node, page, doc)
             ```$(x.info)
             $(x.code)
             ```
-            """, exception=(err, bt))
+            """,
+            exception = (err, bt),
+            _file = joinpath(pwd(), page.source),
+            _line = lines.first,)
     end
     node.element = Documenter.SetupNode(x.info, x.code)
 end


### PR DESCRIPTION
Log now prints:
```
└ @ Documenter ~/src/ClimaCore.jl/docs/src/api.md:210
```
instead of
```
└ @ Documenter ~/src/Documenter/src/utilities/utilities.jl:44
```

which makes it easier to jump to in my editor (can ctrl-click to go there)