### PR TITLE
Add KaTeX example configuration example to docs

### DIFF
--- a/docs/src/man/latex.md
+++ b/docs/src/man/latex.md
@@ -169,11 +169,12 @@ mathengine = MathJax3(Dict(
     ),
 ))
 ```
+
 The syntax is slightly different if using KaTeX, the following example is what you might include in your `makedocs` function:
 
 ```julia
 makedocs(
-format = Documenter.HTML(; mathengine=
+    format = Documenter.HTML(; mathengine=
         Documenter.KaTeX(
             Dict(:delimiters => [
                 Dict(:left => raw"$",   :right => raw"$",   display => false),
@@ -191,4 +192,5 @@ format = Documenter.HTML(; mathengine=
     )
 )
 ```
+
 [`MathJax2`](@ref), [`MathJax3`](@ref) and [`KaTeX`](@ref) are available types for `mathengine`.

--- a/docs/src/man/latex.md
+++ b/docs/src/man/latex.md
@@ -169,5 +169,26 @@ mathengine = MathJax3(Dict(
     ),
 ))
 ```
+The syntax is slightly different if using KaTeX, the following example is what you might include in your `makedocs` function:
 
+```julia
+makedocs(
+format = Documenter.HTML(; mathengine=
+        Documenter.KaTeX(
+            Dict(:delimiters => [
+                Dict(:left => raw"$",   :right => raw"$",   display => false),
+                Dict(:left => raw"$$",  :right => raw"$$",  display => true),
+                Dict(:left => raw"\[",  :right => raw"\]",  display => true),
+                ],
+                :macros => Dict("\\RR" => "\\mathbb{R}",
+                    raw"\Xi" => raw"X_{i}",
+                    raw"\Ru" => raw"R_{\mathrm{univ.}}",
+                    raw"\Pstd" => raw"P_{\mathrm{std}}",
+                    raw"\Tstd" => raw"T_{\mathrm{std}}",
+                ),
+            )
+        )
+    )
+)
+```
 [`MathJax2`](@ref), [`MathJax3`](@ref) and [`KaTeX`](@ref) are available types for `mathengine`.


### PR DESCRIPTION
Added an example of how to set custom macros if using KaTeX. 
Also lacking was an example of how this is fed into `makedocs`