### PR TITLE
Warn on unsupported arguments in contents, index, autodocs, and meta blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * `id` anchors may now start with a numeric digit. ([#744]), ([#2325])
+* Documenter now warns when it encounters invalid keys in the various key-value at-blocks. ([#2306], [#2324])
 
 ### Fixed
 

--- a/src/documents.jl
+++ b/src/documents.jl
@@ -96,6 +96,13 @@ struct IndexNode <: AbstractDocumenterBlock
             source  = error("missing value for `source` in `IndexNode`."),
             others...
         )
+        if !isempty(others)
+            @warn(
+                "In file $source: the following unsupported keyword " *
+                "arguments have been set in the `@index` node:\n" *
+                join([string(k, " = ", v) for (k, v) in others], "\n"),
+            )
+        end
         new(Pages, Modules, Order, build, source, [], codeblock)
     end
 end
@@ -120,6 +127,13 @@ struct ContentsNode <: AbstractDocumenterBlock
         )
         if Depth isa Integer
             Depth = 1:Depth
+        end
+        if !isempty(others)
+            @warn(
+                "In file $source: the following unsupported keyword " *
+                "arguments have been set in the `@contents` node:\n" *
+                join([string(k, " = ", v) for (k, v) in others], "\n"),
+            )
         end
         new(Pages, first(Depth), last(Depth), build, source, [], codeblock)
     end

--- a/test/errors/src/index.md
+++ b/test/errors/src/index.md
@@ -9,10 +9,12 @@ parse error
 
 ```@meta
 CurrentModule = NonExistentModule
+draft = true  # invalid keyword
 ```
 
 ```@autodocs
 Modules = [NonExistentModule]
+pages = []  # invalid keyword
 ```
 
 ```@eval
@@ -21,6 +23,14 @@ NonExistentModule
 
 ```@docs
 # comment in a @docs block
+```
+
+```@index
+foo = 1
+```
+
+```@contents
+foo = 1
 ```
 
 [`foo(x::Foo)`](@ref) creates an [`UndefVarError`](@ref) when `eval`d


### PR DESCRIPTION
Closes #2306

I don't know the best way to test this. I also decided to warn, rather than error, because doing so might break working builds if they have added some additional arguments in there, intentionally or otherwise.