### PR TITLE
Fix slugify removing leading numeric digits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
-### Added
+### Changed
 
 * `id` anchors may now start with a numeric digit. ([#744]), ([#2325])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+### Added
+
+* `id` anchors may now start with a numeric digit. ([#744]), ([#2325])
+
 ### Fixed
 
 * Enabled text wrapping in docstring header on smaller screens. ([#2293], [#2307])
@@ -1289,6 +1293,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#631]: https://github.com/JuliaDocs/Documenter.jl/issues/631
 [#697]: https://github.com/JuliaDocs/Documenter.jl/issues/697
 [#706]: https://github.com/JuliaDocs/Documenter.jl/issues/706
+[#744]: https://github.com/JuliaDocs/Documenter.jl/issues/744
 [#756]: https://github.com/JuliaDocs/Documenter.jl/issues/756
 [#764]: https://github.com/JuliaDocs/Documenter.jl/issues/764
 [#774]: https://github.com/JuliaDocs/Documenter.jl/issues/774
@@ -1729,6 +1734,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2300]: https://github.com/JuliaDocs/Documenter.jl/issues/2300
 [#2307]: https://github.com/JuliaDocs/Documenter.jl/issues/2307
 [#2317]: https://github.com/JuliaDocs/Documenter.jl/issues/2317
+[#2323]: https://github.com/JuliaDocs/Documenter.jl/issues/2325
 [JuliaLang/julia#29344]: https://github.com/JuliaLang/julia/issues/29344
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -107,9 +107,12 @@ Slugify a string into a suitable URL.
 """
 function slugify(s::AbstractString)
     s = replace(s, r"\s+" => "-")
+    # Before HTML5, id could not start with a number
+    s = replace(s, r"^\d+" => "")
     s = replace(s, r"&" => "-and-")
     s = replace(s, r"[^\p{L}\p{P}\d\-]+" => "")
     s = strip(replace(s, r"\-\-+" => "-"), '-')
+    return s
 end
 slugify(object) = string(object) # Non-string slugifying doesn't do anything.
 

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -107,7 +107,6 @@ Slugify a string into a suitable URL.
 """
 function slugify(s::AbstractString)
     s = replace(s, r"\s+" => "-")
-    s = replace(s, r"^\d+" => "")
     s = replace(s, r"&" => "-and-")
     s = replace(s, r"[^\p{L}\p{P}\d\-]+" => "")
     s = strip(replace(s, r"\-\-+" => "-"), '-')

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -107,8 +107,6 @@ Slugify a string into a suitable URL.
 """
 function slugify(s::AbstractString)
     s = replace(s, r"\s+" => "-")
-    # Before HTML5, id could not start with a number
-    s = replace(s, r"^\d+" => "")
     s = replace(s, r"&" => "-and-")
     s = replace(s, r"[^\p{L}\p{P}\d\-]+" => "")
     s = strip(replace(s, r"\-\-+" => "-"), '-')

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -716,10 +716,12 @@ end
             "my-heading" => "my-heading",
             "documenter.jl/abc" => "documenter.jl/abc",
             "https://documenter.jl/abc" => "https://documenter.jl/abc",
-            "2nd" => "2nd",
-            "123" => "123",
+            # Leading numbers are stripped
+            "2nd" => "nd",
+            "2nd-2" => "nd-2",
+            "123a" => "a",
             # Spaces get replaced by -
-            "2nd feature" => "2nd-feature",
+            "2nd feature" => "nd-feature",
             # & gets replaced by -and-
             "a & b" => "a-and-b",
             # Multiple -- are reduced

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -718,7 +718,8 @@ end
             "https://documenter.jl/abc" => "https://documenter.jl/abc",
             "2nd" => "2nd",
             "2nd-2" => "2nd-2",
-            "123a" => "123",
+            "123" => "123",
+            "123a" => "123a",
             # Spaces get replaced by -
             "2nd feature" => "2nd-feature",
             # & gets replaced by -and-

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -716,19 +716,18 @@ end
             "my-heading" => "my-heading",
             "documenter.jl/abc" => "documenter.jl/abc",
             "https://documenter.jl/abc" => "https://documenter.jl/abc",
-            # Leading numbers are stripped
-            "2nd" => "nd",
-            "2nd-2" => "nd-2",
-            "123a" => "a",
+            "2nd" => "2nd",
+            "2nd-2" => "2nd-2",
+            "123a" => "123",
             # Spaces get replaced by -
-            "2nd feature" => "nd-feature",
+            "2nd feature" => "2nd-feature",
             # & gets replaced by -and-
             "a & b" => "a-and-b",
             # Multiple -- are reduced
             "a---b" => "a-b",
             # Leading and trailing - are stripped
             "-a---b-" => "a-b",
-            # A combinnation of things
+            # A combination of things
             "   a & b" => "a-and-b",
             "--a & b" => "a-and-b",
             # Non letter, punctuation, digit, or `-` characters are removed

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -706,6 +706,35 @@ end
         @test remove_common_backtrace([1,2,3], [1,2,3]) == []
         @test remove_common_backtrace([1,2,3], [0,1,2,3]) == []
     end
+
+    @testset "slugify" begin
+        for (test, answer) in [
+            # Nonstrings get converted to strings
+            1 => "1",
+            # Good strings stay good
+            "a" => "a",
+            "my-heading" => "my-heading",
+            "documenter.jl/abc" => "documenter.jl/abc",
+            "https://documenter.jl/abc" => "https://documenter.jl/abc",
+            "2nd" => "2nd",
+            "123" => "123",
+            # Spaces get replaced by -
+            "2nd feature" => "2nd-feature",
+            # & gets replaced by -and-
+            "a & b" => "a-and-b",
+            # Multiple -- are reduced
+            "a---b" => "a-b",
+            # Leading and trailing - are stripped
+            "-a---b-" => "a-b",
+            # A combinnation of things
+            "   a & b" => "a-and-b",
+            "--a & b" => "a-and-b",
+            # Non letter, punctuation, digit, or `-` characters are removed
+            "a\0a" => "aa"
+        ]
+            @test Documenter.slugify(test) == answer
+        end
+    end
 end
 
 end


### PR DESCRIPTION
Closes https://github.com/JuliaDocs/Documenter.jl/issues/744.

I don't know if there was a good reason for this? It looks very intentional.