### PR TITLE
Throw a consistent error object from makedocs on user errors

### DIFF
--- a/docs/src/lib/internals/documenter.md
+++ b/docs/src/lib/internals/documenter.md
@@ -7,4 +7,5 @@ Documenter.user_host_upstream
 Documenter.find_object
 Documenter.xrefname
 Documenter.crossref
+Documenter.DocumenterBuildException
 ```

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -31,6 +31,7 @@ doctest
 DocMeta
 DocMeta.getdocmeta
 DocMeta.setdocmeta!
+Documenter.DocumenterError
 ```
 
 ## DocumenterTools

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -65,6 +65,14 @@ abstract type Plugin end
 
 abstract type Writer end
 
+"""
+    abstract type DocumenterBuildException <: Exception
+
+Internal abstract supertype for all the exceptions that get propagated to the user as
+[`DocumenterError`](@ref)s.
+"""
+abstract type DocumenterBuildException <: Exception end
+
 include("utilities/DOM.jl")
 include("utilities/JSDependencies.jl")
 include("utilities/MDFlatten.jl")

--- a/src/builder_pipeline.jl
+++ b/src/builder_pipeline.jl
@@ -250,13 +250,23 @@ function Selectors.runner(::Type{Builder.RenderDocument}, doc::Documenter.Docume
     fatal_errors = filter(is_strict(doc), doc.internal.errors)
     c = length(fatal_errors)
     if c > 0
-        error("`makedocs` encountered $(c > 1 ? "errors" : "an error") ["
-        * join(Ref(":") .* string.(fatal_errors), ", ")
-        * "] -- terminating build before rendering.")
+        msg = string(
+            "`makedocs` encountered $(c > 1 ? "errors" : "an error") [",
+            join(Ref(":") .* string.(fatal_errors), ", "),
+            "] -- terminating build before rendering."
+        )
+        throw(DocCheckError(msg))
     else
         @info "RenderDocument: rendering document."
         Documenter.render(doc)
     end
+end
+
+struct DocCheckError <: DocumenterBuildException
+    msg::String
+end
+function Base.showerror(io::IO, e::DocCheckError)
+    println(io, "DocCheckError: $(e.msg)")
 end
 
 Selectors.runner(::Type{Builder.DocumentPipeline}, doc::Documenter.Document) = nothing


### PR DESCRIPTION
Inspired by https://github.com/JuliaDocs/DocumenterCitations.jl/issues/59#issuecomment-1789365651:

> I agree it's not great that Documenter shows a Stacktrace when it fails in strict mode. It makes it look like an internal error.

The doccheck error would now print as:

```
ERROR: LoadError: DocumenterError (makedocs): Documenter build failed to complete.
Underlying exception:
DocCheckError: `makedocs` encountered errors [:cross_references, :linkcheck] -- terminating build before rendering.
Please check the error logs above as well.
Stacktrace:
 [1] makedocs(; debug::Bool, format::Documenter.HTMLWriter.HTML, kwargs::Base.Pairs{Symbol, Any, NTuple{7, Symbol}, NamedTuple{(:sitename, :build, :remotes, :pagesonly, :pages, :warnonly, :linkcheck), Tuple{String, String, Dict{String, Tuple{Documenter.Remotes.GitHub, String}}, Bool, Vector{String}, Vector{Symbol}, Bool}}})
   @ Documenter ~/juliadocs/Documenter/src/makedocs.jl:263
 [2] makedocs
   @ ~/juliadocs/Documenter/src/makedocs.jl:248 [inlined]
 [3] top-level scope
   @ ./timing.jl:273
in expression starting at /home/mortenpi/juliadocs/testbuild/make.jl:109

caused by: DocCheckError: `makedocs` encountered errors [:cross_references, :linkcheck] -- terminating build before rendering.

Stacktrace:
 [1] runner(#unused#::Type{Documenter.Builder.RenderDocument}, doc::Documenter.Document)
   @ Documenter ~/juliadocs/Documenter/src/builder_pipeline.jl:258
 [2] dispatch(#unused#::Type{Documenter.Builder.DocumentPipeline}, x::Documenter.Document)
   @ Documenter.Selectors ~/juliadocs/Documenter/src/utilities/Selectors.jl:170
 [3] #79
   @ ~/juliadocs/Documenter/src/makedocs.jl:257 [inlined]
 [4] withenv(::Documenter.var"#79#81"{Documenter.Document}, ::Pair{String, Nothing}, ::Vararg{Pair{String, Nothing}})
   @ Base ./env.jl:197
 [5] #78
   @ ~/juliadocs/Documenter/src/makedocs.jl:256 [inlined]
 [6] cd(f::Documenter.var"#78#80"{Documenter.Document}, dir::String)
   @ Base.Filesystem ./file.jl:112
 [7] makedocs(; debug::Bool, format::Documenter.HTMLWriter.HTML, kwargs::Base.Pairs{Symbol, Any, NTuple{7, Symbol}, NamedTuple{(:sitename, :build, :remotes, :pagesonly, :pages, :warnonly, :linkcheck), Tuple{String, String, Dict{String, Tuple{Documenter.Remotes.GitHub, String}}, Bool, Vector{String}, Vector{Symbol}, Bool}}})
   @ Documenter ~/juliadocs/Documenter/src/makedocs.jl:255
 [8] makedocs
   @ ~/juliadocs/Documenter/src/makedocs.jl:248 [inlined]
 [9] top-level scope
   @ ./timing.jl:273
```

I was hoping it would clean things up a bit (the main error stracktrace just shows `makedocs` -- best we can do I think). But the `caused by` might be confusing now.. and it's kinda duplicated in the `showerror` I added. We could get rid of it by `throw`ing outside of the `catch`, but it feels like it would be good to somehow retain some information about the inner error. Leaving this as a draft for now -- would appreciate any thoughts on this!

cc @goerz 