### PR TITLE
Improve the warning for an unexpected dollar sign in a Markdown file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* `id` anchors may now start with a numeric digit. ([#744]), ([#2325])
+* `id` anchors may now start with a numeric digit. ([#744], [#2325])
+* Documenter prints a more informative warning now if there is unexpected Julia interpolation in the Markdown (e.g. from errant `$` signs). ([#2288], [#2327])
 
 ### Fixed
 

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -2212,10 +2212,17 @@ function domify(dctx::DCtx, node::Node, t::MarkdownAST.Table)
 end
 
 function domify(dctx::DCtx, node::Node, e::MarkdownAST.JuliaValue)
-    @warn """
-    Unexpected Julia interpolation of type $(typeof(e.ref)) in the Markdown.
-    """ value = e.ref
-    string(e.ref)
+    @warn("""
+    Unexpected Julia interpolation in the Markdown. This probably means that you
+    have an unbalanced or un-escaped \$ in the text.
+
+    To write the dollar sign, escape it with `\\\$`
+
+    We don't have the file or line number available, but we got given the value:
+
+    `$(e.ref)` which is of type `$(typeof(e.ref))`
+    """)
+    return string(e.ref)
 end
 
 function domify(dctx::DCtx, node::Node, f::MarkdownAST.FootnoteLink)

--- a/src/latex/LaTeXWriter.jl
+++ b/src/latex/LaTeXWriter.jl
@@ -791,10 +791,17 @@ latex(io::Context, node::Node, ::Documenter.MetaNode) = _println(io, "\n")
 latex(io::Context, node::Node, ::Documenter.SetupNode) = nothing
 
 function latex(io::Context, node::Node, value::MarkdownAST.JuliaValue)
-    @warn """
-    Unexpected Julia interpolation of type $(typeof(value.ref)) in the Markdown.
-    """ value = value.ref
-    latexesc(io, string(value.ref))
+    @warn("""
+    Unexpected Julia interpolation in the Markdown. This probably means that you
+    have an unbalanced or un-escaped \$ in the text.
+
+    To write the dollar sign, escape it with `\\\$`
+
+    We don't have the file or line number available, but we got given the value:
+
+    `$(value.ref)` which is of type `$(typeof(value.ref))`
+    """)
+    return latexesc(io, string(value.ref))
 end
 
 # TODO: Implement SoftBreak, Backslash (but they don't appear in standard library Markdown conversions)


### PR DESCRIPTION
I was looking into https://github.com/JuliaDocs/Documenter.jl/issues/2288

The issue is that by the time we notice the value, we've lost the original source file and line information.

@mortenpi might have some ideas for how to get it back?

cc @kellertuer