### PR TITLE
Don't catch RepoCommitError in repo_commit

### DIFF
--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -458,6 +458,7 @@ function repo_commit(repository_root::AbstractString)
                 ))
             end
         catch e
+            isa(e, RepoCommitError) && rethrow(e)
             throw(RepoCommitError(repository_root, "`git rev-parse --show-toplevel` failed", e, catch_backtrace()))
         end
         try


### PR DESCRIPTION
Noticed in https://github.com/JuliaLang/julia/pull/47105. Probably a better pattern for this, but this fixes the immediate "issue".