### PR TITLE
1341 latex engines

### DIFF
--- a/src/latex/LaTeXWriter.jl
+++ b/src/latex/LaTeXWriter.jl
@@ -48,10 +48,10 @@ considered to be deprecated), or to an empty string if `TRAVIS_TAG` is unset.
 
 See [Other Output Formats](@ref) for more information.
 """
-struct LaTeX <: Documenter.Writer
+mutable struct LaTeX <: Documenter.Writer
     platform::String
-    version::String
-    tectonic::Union{Cmd,String,Nothing}
+    const version::String
+    const tectonic::Union{Cmd,String,Nothing}
     function LaTeX(;
             platform = "native",
             version  = get(ENV, "TRAVIS_TAG", ""),

--- a/src/latex/LaTeXWriter.jl
+++ b/src/latex/LaTeXWriter.jl
@@ -56,7 +56,7 @@ struct LaTeX <: Documenter.Writer
             platform = "native",
             version  = get(ENV, "TRAVIS_TAG", ""),
             tectonic = nothing)
-        platform ∈ ("native", "tectonic", "docker", "none") || throw(ArgumentError("unknown platform: $platform"))
+        platform ∈ ("native", "latexmk","texify", "tectonic", "docker", "none") || throw(ArgumentError("unknown platform: $platform"))
         return new(platform, string(version), tectonic)
     end
 end

--- a/src/latex/LaTeXWriter.jl
+++ b/src/latex/LaTeXWriter.jl
@@ -177,6 +177,17 @@ const DOCKER_IMAGE_TAG = "0.1"
 
 function compile_tex(doc::Documenter.Document, settings::LaTeX, fileprefix::String)
     if settings.platform == "native"
+        @info "LaTeXWriter: attempting to find native platform."
+        native_platform = hastex()
+        if !isempty(native_platform)
+            @info "LaTeXWriter: found native platform $native_platform."
+            settings.platform = native_platform
+            return compile_tex(doc,settings,fileprefix)
+        else
+            @error "LaTeXWriter: no native platform found."
+            return false
+        end
+    elseif settings.platform == "latexmk"
         Sys.which("latexmk") === nothing && (@error "LaTeXWriter: latexmk command not found."; return false)
         @info "LaTeXWriter: using latexmk to compile tex."
         try
@@ -186,6 +197,18 @@ function compile_tex(doc::Documenter.Document, settings::LaTeX, fileprefix::Stri
             logs = cp(pwd(), mktempdir(; cleanup=false); force=true)
             @error "LaTeXWriter: failed to compile tex with latexmk. " *
                    "Logs and partial output can be found in $(Documenter.locrepr(logs))" exception = err
+            return false
+        end
+    elseif settings.platform == "texify"
+        @info "LaTeXWriter: using texify to compile tex."
+        texify = Sys.which("texify")
+        isnothing(texify) && (@error "LaTeXWriter: texify command not found."; return false)
+        try
+            piperun(`$(texify) -p -b --engine=luatex --tex-option=--shell-escape $(fileprefix).tex`, clearlogs=true)
+            return true
+        catch err
+            logs = cp(pwd(), mktempdir(; cleanup = false); force = true)
+            @error "LaTeXWriter: failed to compile tex with texify. " * "Logs and partial output can be found in $(Documenter.locrepr(logs))" exception = err
             return false
         end
     elseif settings.platform == "tectonic"

--- a/src/latex/LaTeXWriter.jl
+++ b/src/latex/LaTeXWriter.jl
@@ -87,7 +87,14 @@ _hash(x) = string(hash(x))
 const STYLE = joinpath(dirname(@__FILE__), "..", "..", "assets", "latex", "documenter.sty")
 const DEFAULT_PREAMBLE_PATH = joinpath(dirname(@__FILE__), "..", "..", "assets", "latex", "preamble.tex")
 
-hastex() = (try; success(`latexmk -version`); catch; false; end)
+hastex() = (
+    try
+        success(`latexmk -version`) && return "latexmk"
+        success(`texify --version`) && return "texify"
+    catch
+        return ""
+    end
+)
 
 const DOCUMENT_STRUCTURE = (
     "part",

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -20,7 +20,7 @@ else
     ["html", "html-meta-custom", "html-mathjax2-custom", "html-mathjax3", "html-mathjax3-custom",
     "html-local", "html-draft", "html-repo-git", "html-repo-nothing", "html-repo-error",
     "html-sizethreshold-defaults-fail", "html-sizethreshold-success", "html-sizethreshold-ignore-success", "html-sizethreshold-override-fail", "html-sizethreshold-ignore-success", "html-sizethreshold-ignore-fail",
-    "latex_texonly", "latex_simple_texonly", "latex_showcase_texonly", "html-pagesonly"]
+        "latex_texonly", "latex_simple_texonly", "latex_simple_native", "latex_simple_latexmk", "latex_simple_texify", "latex_showcase_texonly", "html-pagesonly"]
 end
 
 # Modules `Mod` and `AutoDocs`
@@ -703,6 +703,59 @@ else
     nothing
 end
 
+examples_latex_simple_native_doc = if "latex_simple_native" in EXAMPLE_BUILDS
+    @info("Building mock package docs: LaTeXWriter/latex_simple_native")
+    @quietly makedocs(
+        format=Documenter.LaTeX(platform="native", version=v"1.2.3"),
+        sitename="Documenter LaTeX Simple Native",
+        root=examples_root,
+        build="builds/latex_simple_native",
+        source="src.latex_simple",
+        pages=["Main section" => ["index.md"]],
+        doctest=false,
+        debug=true,
+    )
+else
+    @info "Skipping build: LaTeXWriter/latex_simple_native"
+    @debug "Controlling variables:" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
+    nothing
+end
+
+examples_latex_simple_texify_doc = if "latex_simple_latexmk" in EXAMPLE_BUILDS
+    @info("Building mock package docs: LaTeXWriter/latex_simple_latexmk")
+    @quietly makedocs(
+        format=Documenter.LaTeX(platform="latexmk", version=v"1.2.3"),
+        sitename="Documenter LaTeX Simple LaTeXMk",
+        root=examples_root,
+        build="builds/latex_simple_latexmk",
+        source="src.latex_simple",
+        pages=["Main section" => ["index.md"]],
+        doctest=false,
+        debug=true,
+    )
+else
+    @info "Skipping build: LaTeXWriter/latex_simple_latekmk"
+    @debug "Controlling variables:" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
+    nothing
+end
+
+examples_latex_simple_texify_doc = if "latex_simple_texify" in EXAMPLE_BUILDS
+    @info("Building mock package docs: LaTeXWriter/latex_simple_texify")
+    @quietly makedocs(
+        format = Documenter.LaTeX(platform="texify", version = v"1.2.3"),
+        sitename = "Documenter LaTeX Simple Texify",
+        root  = examples_root,
+        build = "builds/latex_simple_texify",
+        source = "src.latex_simple",
+        pages = ["Main section" => ["index.md"]],
+        doctest = false,
+        debug = true,
+    )
+else
+    @info "Skipping build: LaTeXWriter/latex_simple_texify"
+    @debug "Controlling variables:" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
+    nothing
+end
 
 examples_latex_texonly_doc = if "latex_texonly" in EXAMPLE_BUILDS
     @info("Building mock package docs: LaTeXWriter/latex_texonly")


### PR DESCRIPTION
Adds `texify` as a latex engine to allow compilation when `latexmk` is not available, and makes `native` decide automatically which is available between `latexmk` and `texify`.

Partially fixes #1341 