### PR TITLE
docs: explicitly note previews aren't cleaned up and fix up markdown

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -380,8 +380,9 @@ You also need to make sure that you have `gh-pages branch` and `/ (root)` select
 settings](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site),
 so that GitHub would actually serve the contents as a website.
 
-**Cleaning up `gh-pages`.**
-Note that the `gh-pages` branch can become very large, especially when `push_preview` is
+### Cleaning up `gh-pages`
+
+The `gh-pages` branch can become very large, especially when `push_preview` is
 enabled to build documentation for each pull request. To clean up the branch and remove
 stale documentation previews, a GitHub Actions workflow like the following can be used.
 
@@ -424,10 +425,9 @@ jobs:
 _This workflow was based on [CliMA/ClimaTimeSteppers.jl](https://github.com/CliMA/ClimaTimeSteppers.jl/blob/0660ace688b4f4b8a86d3c459ab62ccf01d7ef31/.github/workflows/DocCleanup.yml) (Apache License 2.0)._
 
 The `permissions:` line above is described in the
-[GitHub Docs][https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#assigning-permissions-to-a-specific-job];
+[GitHub Docs](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#assigning-permissions-to-a-specific-job);
 an alternative is to give GitHub workflows write permissions under the repo settings, e.g.,
 `https://github.com/<USER>/<REPO>.jl/settings/actions`.
-
 
 ## Woodpecker CI
 

--- a/src/deploydocs.jl
+++ b/src/deploydocs.jl
@@ -281,7 +281,7 @@ end
     git_push(
         root, tmp, repo;
         branch="gh-pages", dirname="", target="site", sha="", devurl="dev",
-        deploy_config, folder,
+        deploy_config, subfolder
     )
 
 Handles pushing changes to the remote documentation branch.

--- a/src/deploydocs.jl
+++ b/src/deploydocs.jl
@@ -144,6 +144,11 @@ deployed. It defaults to the value of `repo`.
     On GitHub Actions, `GITHUB_TOKEN` must be present for previews to work, even if
     `DOCUMENTER_KEY` ise being used to deploy.
 
+!!! note
+    Previews generated are NOT automatically cleaned up. This can be done manually or
+    automated. A GitHub Actions workflow for automating the same can be found
+    [here](@ref "Cleaning up `gh-pages`").
+
 **`deps`** can be set to a function or a callable object and gets called during deployment,
 and is usually used to install additional dependencies. By default, nothing gets executed.
 


### PR DESCRIPTION
I'm opening this PR because I couldn't readily find information about the PR previews being cleaned up (while browsing the `deploydocs` API) and think this will be more helpful in making it more easily available to users.

The following are the changes proposed in this PR.

* Add a note to the `deploydocs` docstring explicitly stating that the
previews generated aren't automatically cleaned up and link to the
respective section of the documentation that has a GHA workflow for the
same.
* Fix typos and markdown