### PR TITLE
Revert "Disable coveralls submission in online linkcheck (#2347)"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -164,11 +164,11 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           file: lcov.info
-      #- name: Submit coverage to Coveralls
-      #  uses: coverallsapp/github-action@v2
-      #  with:
-      #    github-token: ${{ secrets.GITHUB_TOKEN }}
-      #    path-to-lcov: lcov.info
+      - name: Submit coverage to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: lcov.info
 
   linkcheck-manual:
     name: "Linkcheck: Documenter manual"


### PR DESCRIPTION
This reverts commit ae0188b2df02bc0e3f51f649832017abfccea3b3. It looks like it's not the online linkcheck coverage that's causing this: https://github.com/JuliaDocs/Documenter.jl/actions/runs/7014868146/job/19083261526

X-ref: #2343