### PR TITLE
ci: set Coveralls jobs `continue-on-failure: true`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           file: lcov.info
       - name: Submit coverage to Coveralls
+        continue-on-error: true # TODO: https://github.com/JuliaDocs/Documenter.jl/issues/2343
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -71,6 +72,7 @@ jobs:
         with:
           file: lcov.info
       - name: Submit coverage to Coveralls
+        continue-on-error: true # TODO: https://github.com/JuliaDocs/Documenter.jl/issues/2343
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -114,6 +116,7 @@ jobs:
         with:
           file: lcov.info
       - name: Submit coverage to Coveralls
+        continue-on-error: true # TODO: https://github.com/JuliaDocs/Documenter.jl/issues/2343
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -165,6 +168,7 @@ jobs:
         with:
           file: lcov.info
       - name: Submit coverage to Coveralls
+        continue-on-error: true # TODO: https://github.com/JuliaDocs/Documenter.jl/issues/2343
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hopefully avoids failing the job when that step fails. Workaround for https://github.com/JuliaDocs/Documenter.jl/issues/2343.