### PR TITLE
Fix handling of remote URLs for standard libraries, tag 1.2.2

### DIFF
--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -390,10 +390,6 @@ If `path` is a directory, it may itself already be a root.
 The predicate `f` gets called with absolute paths to directories and must return `true`
 if the directory is a "root". An example predicate is `is_git_repo_root` that checks if
 the directory is a Git repository root.
-
-The `dbdir` keyword argument specifies the name of the directory we are searching for to
-determine if this is a repository or not. If there is a file called `dbdir`, then it's
-contents is checked under the assumption that it is a Git worktree or a submodule.
 """
 function find_root_parent(f, path)
     ispath(path) || throw(ArgumentError("find_root_parent called with non-existent path\n path: $path"))

--- a/test/base_assumptions.jl
+++ b/test/base_assumptions.jl
@@ -1,0 +1,11 @@
+module BaseAssumptionTests
+
+@test "Julia Base assumptions" begin
+    # To handle source URLs to standard library files, we need to fix up the paths to
+    # standard library objects (which generally point to /cache/..., for the pre-built
+    # binaries).
+    @test isdefined(Base, :fixup_stdlib_path)
+    @test hasmethod(Base.fixup_stdlib_path, (String,))
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,7 @@ end
     @quietly include("plugins/make.jl")
 
     # Unit tests for module internals.
+    include("base_assumptions.jl")
     include("except.jl")
     include("utilities.jl")
 


### PR DESCRIPTION
These changes are necessary to fix the generation of source URLs for standard libraries in the Julia manual.

* In `relpath_from_remote_root` we no longer expand symlinks in the docstring metadata filepaths. This is because for normal builds, the standard libraries in `usr/share/julia/stdlib/...` are symlinked to `stdlib/`, and this way we can handle both the CI build and normal build the same way. At the same time, it also doesn't seem important for the packages, since I wouldn't expect there to be any symlinks there normally.
* In the CI builds, the filepaths in the docstring metadata for standard libraries are actually the `/cache/*` ones. So if the path doesn't exists, we'll call `Base.fixup_stdlib_path` on it, to see if that allows us to find the actual source path.

X-ref: https://github.com/JuliaLang/julia/pull/47105#issuecomment-1842130476