### PR TITLE
Fix `version` hiding the version selection menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+* Fixed the `version` parameter to `makedocs` inadvertently hiding the version selection menu ([#2385])
+
+
 ## Version [v1.2.1] - 2023-12-02
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Documenter"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.2.1"
+version = "1.2.2-dev"
 
 [deps]
 ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -17,10 +17,10 @@ keyword arguments: `analytics`, `assets`, `canonical`, `disable_git`, `edit_link
 
 # Experimental keywords
 
-**`version`** specifies the version string of the current version which will be the
-selected option in the version selector. If this is left empty (default) the version
-selector will be hidden. The special value `git-commit` sets the value in the output to
-`git:{commit}`, where `{commit}` is the first few characters of the current commit hash.
+**`version`** specifies the version string of the current version. The special value
+`git-commit` sets the value in the output to `git:{commit}`, where `{commit}` is the first
+few characters of the current commit hash. This is not currently used, but may be shown as
+part of the of the rendered HTML in a future version.
 
 # `HTML` `Plugin` options
 
@@ -1130,11 +1130,6 @@ function render_sidebar(ctx, navnode)
         vs_label = span[".docs-label.button.is-static.is-size-7"]("Version")
         vs_label = div[".control"](vs_label)
         vs_select = select["#documenter-version-selector"]
-        if !isempty(ctx.doc.user.version)
-            vs_class = "$(vs_class).visible"
-            opt = option[:value => "#", :selected => "selected", ](ctx.doc.user.version)
-            vs_select = vs_select(opt)
-        end
         vs_select = div[".select.is-fullwidth.is-size-7"](vs_select)
         vs_select = div[".docs-selector.control.is-expanded"](vs_select)
         push!(navmenu.nodes, div[vs_class](vs_label, vs_select))


### PR DESCRIPTION
This fixes the issue with the version menu disappearing when someone specifies `version` in `makedocs`.

This PR is pretty minimal and hopefully uncontroversial. It would be great if we could merge/release this, as the underlying issue breaks https://github.com/JuliaDocs/DocumenterInterLinks.jl/blob/master/src/write_inventory.jl

I've adapted the documentation to say that `version` is not currently used in the `HTMLWriter`. If I add the inventory writing to Documenter later, that would become the first instance of where it *is* used (it gets written into the inventory).

Maybe we can also use `version` in other ways. The `LaTeXWriter` `version` parameter should probably fall back to the `version` in `makedocs` (without removing `LaTeXWriter`'s `version`, as that would be a breaking change).

I'd also still be in favor of showing a non-empty `version` in the sidebar and/or the footer, but those things would go into a separate PR, as they might be more controversial.

Closes #2385 