### PR TITLE
Support scheme definition for GitLab remotes

### DIFF
--- a/test/remotes.jl
+++ b/test/remotes.jl
@@ -87,6 +87,15 @@ using .Remotes: repofile, repourl, issueurl, URL, GitHub, GitLab
         @test issueurl(r, "123") == "https://my-gitlab.com/JuliaDocs/Documenter.jl/-/issues/123"
     end
 
+    let r = GitLab("http://my-gitlab.com", "JuliaDocs", "Documenter.jl")
+        @test repourl(r) == "http://my-gitlab.com/JuliaDocs/Documenter.jl"
+        @test repofile(r, "mybranch", "src/foo.jl") == "http://my-gitlab.com/JuliaDocs/Documenter.jl/-/tree/mybranch/src/foo.jl"
+        @test repofile(r, "mybranch", "src/foo.jl", 5) == "http://my-gitlab.com/JuliaDocs/Documenter.jl/-/tree/mybranch/src/foo.jl#L5"
+        @test repofile(r, "mybranch", "src/foo.jl", 5:5) == "http://my-gitlab.com/JuliaDocs/Documenter.jl/-/tree/mybranch/src/foo.jl#L5"
+        @test repofile(r, "mybranch", "src/foo.jl", 5:8) == "http://my-gitlab.com/JuliaDocs/Documenter.jl/-/tree/mybranch/src/foo.jl#L5-L8"
+        @test issueurl(r, "123") == "http://my-gitlab.com/JuliaDocs/Documenter.jl/-/issues/123"
+    end
+
     let r = GitLab("JuliaDocs/Documenter.jl")
         @test repourl(r) == "https://gitlab.com/JuliaDocs/Documenter.jl"
         @test repofile(r, "mybranch", "src/foo.jl") == "https://gitlab.com/JuliaDocs/Documenter.jl/-/tree/mybranch/src/foo.jl"


### PR DESCRIPTION
GitLab is fairly easy to self-host. Although best practice, this also means that the scheme over which GitLab is served is not guaranteed to be `https`. For this reason, the provided `host` should be allowed to define what scheme the GitLab instance is being hosted under and respect that in generated links.

The same applies to ports and potentially paths, but those are already supported given the current mechanism (provided no trailing slash is included in the `host`).

One benefit of this approach is that it also allows a full "base" URL to be provided as the host, e.g. the `CI_SERVER_URL` predefined variable within GitLab CI environments[^1].

According to RFC3986[^2], URI schemes should be matched case-insensitively, which this approach does. It also prescribes that only lowercase schemes should be produced, which this chooses to not do to keep the implementation simpler. If this is something that should be changed, I do have the implementation ready to go locally and can easily amend this PR.

[^1]: https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
[^2]: https://datatracker.ietf.org/doc/html/rfc3986#section-3.1