### PR TITLE
Add support for `CollapsedDocStrings` in `@meta` block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* Added support for a `DocStringsCollapsed` key in every page's `@meta` block. Setting `DocStringsCollapsed = true` for a particular page essentially clicks the "Collapse all docstrings" in the navigation bar after the page loads, collapsing all docstrings on that page. This can make API documentation pages much more readable. ([#2282], [#2394])
+
 ### Changed
 
 * The search in the HTML output is now case-insensitive. ([#2373], [#2374])
@@ -1756,6 +1760,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2279]: https://github.com/JuliaDocs/Documenter.jl/issues/2279
 [#2280]: https://github.com/JuliaDocs/Documenter.jl/issues/2280
 [#2281]: https://github.com/JuliaDocs/Documenter.jl/issues/2281
+[#2282]: https://github.com/JuliaDocs/Documenter.jl/issues/2282
 [#2285]: https://github.com/JuliaDocs/Documenter.jl/issues/2285
 [#2288]: https://github.com/JuliaDocs/Documenter.jl/issues/2288
 [#2293]: https://github.com/JuliaDocs/Documenter.jl/issues/2293
@@ -1780,8 +1785,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2373]: https://github.com/JuliaDocs/Documenter.jl/issues/2373
 [#2374]: https://github.com/JuliaDocs/Documenter.jl/issues/2374
 [#2375]: https://github.com/JuliaDocs/Documenter.jl/issues/2375
+[#2394]: https://github.com/JuliaDocs/Documenter.jl/pull/2394
 [#2406]: https://github.com/JuliaDocs/Documenter.jl/issues/2406
 [#2408]: https://github.com/JuliaDocs/Documenter.jl/issues/2408
+[#2375]: https://github.com/JuliaDocs/Documenter.jl/issues/2375
+[#2375]: https://github.com/JuliaDocs/Documenter.jl/issues/2375
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Added support for a `DocStringsCollapsed` key in every page's `@meta` block. Setting `DocStringsCollapsed = true` for a particular page essentially clicks the "Collapse all docstrings" in the navigation bar after the page loads, collapsing all docstrings on that page. This can make API documentation pages much more readable. ([#2282], [#2394])
+* Added support for a `CollapsedDocStrings` key in every page's `@meta` block. Setting `CollapsedDocStrings = true` for a particular page essentially clicks the "Collapse all docstrings" in the navigation bar after the page loads, collapsing all docstrings on that page. This can make API documentation pages much more readable. ([#2282], [#2394])
 
 ### Changed
 

--- a/assets/html/js/collapse.js
+++ b/assets/html/js/collapse.js
@@ -29,9 +29,10 @@ $(document).on("click", ".docstring header", function () {
   });
 });
 
-$(document).on("click", ".docs-article-toggle-button", function () {
+$(document).on("click", ".docs-article-toggle-button", function (event) {
   let articleToggleTitle = "Expand docstring";
   let navArticleToggleTitle = "Expand all docstrings";
+  let animationSpeed = event.noToggleAnimation ? 0 : 400;
 
   debounce(() => {
     if (isExpanded) {
@@ -42,7 +43,7 @@ $(document).on("click", ".docs-article-toggle-button", function () {
 
       isExpanded = false;
 
-      $(".docstring section").slideUp();
+      $(".docstring section").slideUp(animationSpeed);
     } else {
       $(this).removeClass("fa-chevron-down").addClass("fa-chevron-up");
       $(".docstring-article-toggle-button")
@@ -53,7 +54,7 @@ $(document).on("click", ".docs-article-toggle-button", function () {
       articleToggleTitle = "Collapse docstring";
       navArticleToggleTitle = "Collapse all docstrings";
 
-      $(".docstring section").slideDown();
+      $(".docstring section").slideDown(animationSpeed);
     }
 
     $(this).prop("title", navArticleToggleTitle);

--- a/assets/html/js/metadata.js
+++ b/assets/html/js/metadata.js
@@ -1,11 +1,13 @@
 // libraries: jquery
 // arguments: $
 
-let meta = $("div[data-docstringscollapsed]").data();
+$(document).ready(function () {
+  let meta = $("div[data-docstringscollapsed]").data();
 
-if (meta.docstringscollapsed) {
-  $("#documenter-article-toggle-button").trigger({
-    type: "click",
-    noToggleAnimation: true,
-  });
-}
+  if (meta.docstringscollapsed) {
+    $("#documenter-article-toggle-button").trigger({
+      type: "click",
+      noToggleAnimation: true,
+    });
+  }
+});

--- a/assets/html/js/metadata.js
+++ b/assets/html/js/metadata.js
@@ -4,5 +4,8 @@
 let meta = $("div[data-docstringscollapsed]").data();
 
 if (meta.docstringscollapsed) {
-  $("#documenter-article-toggle-button").click();
+  $("#documenter-article-toggle-button").trigger({
+    type: "click",
+    noToggleAnimation: true,
+  });
 }

--- a/assets/html/js/metadata.js
+++ b/assets/html/js/metadata.js
@@ -1,0 +1,8 @@
+// libraries: jquery
+// arguments: $
+
+let meta = $("div[data-docstringscollapsed]").data();
+
+if (meta.docstringscollapsed) {
+  $("#documenter-article-toggle-button").click();
+}

--- a/docs/src/lib/internals/anchors.md
+++ b/docs/src/lib/internals/anchors.md
@@ -1,3 +1,7 @@
+```@meta
+DocStringsCollapsed = true
+```
+
 # Anchors
 
 ```@autodocs

--- a/docs/src/lib/internals/anchors.md
+++ b/docs/src/lib/internals/anchors.md
@@ -1,5 +1,5 @@
 ```@meta
-DocStringsCollapsed = true
+CollapsedDocStrings = true
 ```
 
 # Anchors

--- a/docs/src/lib/internals/builder.md
+++ b/docs/src/lib/internals/builder.md
@@ -1,3 +1,7 @@
+```@meta
+DocStringsCollapsed = true
+```
+
 # Builder
 
 ```@autodocs

--- a/docs/src/lib/internals/builder.md
+++ b/docs/src/lib/internals/builder.md
@@ -1,5 +1,5 @@
 ```@meta
-DocStringsCollapsed = true
+CollapsedDocStrings = true
 ```
 
 # Builder

--- a/docs/src/lib/internals/docchecks.md
+++ b/docs/src/lib/internals/docchecks.md
@@ -1,5 +1,5 @@
 ```@meta
-DocStringsCollapsed = true
+CollapsedDocStrings = true
 ```
 
 # DocChecks

--- a/docs/src/lib/internals/docchecks.md
+++ b/docs/src/lib/internals/docchecks.md
@@ -1,3 +1,7 @@
+```@meta
+DocStringsCollapsed = true
+```
+
 # DocChecks
 
 ```@autodocs

--- a/docs/src/lib/internals/docmeta.md
+++ b/docs/src/lib/internals/docmeta.md
@@ -1,5 +1,5 @@
 ```@meta
-DocStringsCollapsed = true
+CollapsedDocStrings = true
 ```
 
 # DocMeta

--- a/docs/src/lib/internals/docmeta.md
+++ b/docs/src/lib/internals/docmeta.md
@@ -1,3 +1,7 @@
+```@meta
+DocStringsCollapsed = true
+```
+
 # DocMeta
 
 ```@docs

--- a/docs/src/lib/internals/docsystem.md
+++ b/docs/src/lib/internals/docsystem.md
@@ -1,3 +1,7 @@
+```@meta
+DocStringsCollapsed = true
+```
+
 # DocSystem
 
 ```@autodocs

--- a/docs/src/lib/internals/docsystem.md
+++ b/docs/src/lib/internals/docsystem.md
@@ -1,5 +1,5 @@
 ```@meta
-DocStringsCollapsed = true
+CollapsedDocStrings = true
 ```
 
 # DocSystem

--- a/docs/src/lib/internals/doctests.md
+++ b/docs/src/lib/internals/doctests.md
@@ -1,5 +1,5 @@
 ```@meta
-DocStringsCollapsed = true
+CollapsedDocStrings = true
 ```
 
 # DocTests

--- a/docs/src/lib/internals/doctests.md
+++ b/docs/src/lib/internals/doctests.md
@@ -1,3 +1,7 @@
+```@meta
+DocStringsCollapsed = true
+```
+
 # DocTests
 
 ```@autodocs

--- a/docs/src/lib/internals/documenter.md
+++ b/docs/src/lib/internals/documenter.md
@@ -1,3 +1,7 @@
+```@meta
+DocStringsCollapsed = true
+```
+
 # Documenter
 
 ```@docs

--- a/docs/src/lib/internals/documenter.md
+++ b/docs/src/lib/internals/documenter.md
@@ -1,5 +1,5 @@
 ```@meta
-DocStringsCollapsed = true
+CollapsedDocStrings = true
 ```
 
 # Documenter

--- a/docs/src/lib/internals/documentertools.md
+++ b/docs/src/lib/internals/documentertools.md
@@ -1,5 +1,5 @@
 ```@meta
-DocStringsCollapsed = true
+CollapsedDocStrings = true
 ```
 
 # DocumenterTools

--- a/docs/src/lib/internals/documentertools.md
+++ b/docs/src/lib/internals/documentertools.md
@@ -1,3 +1,7 @@
+```@meta
+DocStringsCollapsed = true
+```
+
 # DocumenterTools
 
 ```@docs

--- a/docs/src/lib/internals/documents.md
+++ b/docs/src/lib/internals/documents.md
@@ -1,3 +1,7 @@
+```@meta
+DocStringsCollapsed = true
+```
+
 # Documents
 
 ```@autodocs

--- a/docs/src/lib/internals/documents.md
+++ b/docs/src/lib/internals/documents.md
@@ -1,5 +1,5 @@
 ```@meta
-DocStringsCollapsed = true
+CollapsedDocStrings = true
 ```
 
 # Documents

--- a/docs/src/lib/internals/dom.md
+++ b/docs/src/lib/internals/dom.md
@@ -1,3 +1,7 @@
+```@meta
+DocStringsCollapsed = true
+```
+
 # DOM
 
 ```@autodocs

--- a/docs/src/lib/internals/dom.md
+++ b/docs/src/lib/internals/dom.md
@@ -1,5 +1,5 @@
 ```@meta
-DocStringsCollapsed = true
+CollapsedDocStrings = true
 ```
 
 # DOM

--- a/docs/src/lib/internals/expanders.md
+++ b/docs/src/lib/internals/expanders.md
@@ -1,5 +1,5 @@
 ```@meta
-DocStringsCollapsed = true
+CollapsedDocStrings = true
 ```
 
 # Expanders

--- a/docs/src/lib/internals/expanders.md
+++ b/docs/src/lib/internals/expanders.md
@@ -1,3 +1,7 @@
+```@meta
+DocStringsCollapsed = true
+```
+
 # Expanders
 
 ```@autodocs

--- a/docs/src/lib/internals/jsdependencies.md
+++ b/docs/src/lib/internals/jsdependencies.md
@@ -1,3 +1,7 @@
+```@meta
+DocStringsCollapsed = true
+```
+
 # JSDependencies
 
 ```@autodocs

--- a/docs/src/lib/internals/jsdependencies.md
+++ b/docs/src/lib/internals/jsdependencies.md
@@ -1,5 +1,5 @@
 ```@meta
-DocStringsCollapsed = true
+CollapsedDocStrings = true
 ```
 
 # JSDependencies

--- a/docs/src/lib/internals/mdflatten.md
+++ b/docs/src/lib/internals/mdflatten.md
@@ -1,3 +1,7 @@
+```@meta
+DocStringsCollapsed = true
+```
+
 # MDFlatten
 
 ```@autodocs

--- a/docs/src/lib/internals/mdflatten.md
+++ b/docs/src/lib/internals/mdflatten.md
@@ -1,5 +1,5 @@
 ```@meta
-DocStringsCollapsed = true
+CollapsedDocStrings = true
 ```
 
 # MDFlatten

--- a/docs/src/lib/internals/selectors.md
+++ b/docs/src/lib/internals/selectors.md
@@ -1,3 +1,7 @@
+```@meta
+DocStringsCollapsed = true
+```
+
 # Selectors
 
 ```@autodocs

--- a/docs/src/lib/internals/selectors.md
+++ b/docs/src/lib/internals/selectors.md
@@ -1,5 +1,5 @@
 ```@meta
-DocStringsCollapsed = true
+CollapsedDocStrings = true
 ```
 
 # Selectors

--- a/docs/src/lib/internals/textdiff.md
+++ b/docs/src/lib/internals/textdiff.md
@@ -1,3 +1,7 @@
+```@meta
+DocStringsCollapsed = true
+```
+
 # TextDiff
 
 ```@autodocs

--- a/docs/src/lib/internals/textdiff.md
+++ b/docs/src/lib/internals/textdiff.md
@@ -1,5 +1,5 @@
 ```@meta
-DocStringsCollapsed = true
+CollapsedDocStrings = true
 ```
 
 # TextDiff

--- a/docs/src/lib/internals/utilities.md
+++ b/docs/src/lib/internals/utilities.md
@@ -1,3 +1,7 @@
+```@meta
+DocStringsCollapsed = true
+```
+
 # Utilities
 
 ```@autodocs

--- a/docs/src/lib/internals/utilities.md
+++ b/docs/src/lib/internals/utilities.md
@@ -1,5 +1,5 @@
 ```@meta
-DocStringsCollapsed = true
+CollapsedDocStrings = true
 ```
 
 # Utilities

--- a/docs/src/lib/internals/writers.md
+++ b/docs/src/lib/internals/writers.md
@@ -1,3 +1,7 @@
+```@meta
+DocStringsCollapsed = true
+```
+
 # Writers
 
 ```@autodocs

--- a/docs/src/lib/internals/writers.md
+++ b/docs/src/lib/internals/writers.md
@@ -1,5 +1,5 @@
 ```@meta
-DocStringsCollapsed = true
+CollapsedDocStrings = true
 ```
 
 # Writers

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -284,7 +284,7 @@ page. Currently recognised keys:
 - `Description`: a page-specific description that gets displayed in search engines and
   link previews. Overrides the site-wide description in [`makedocs`](@ref). 
 - `Draft`: boolean for overriding the global draft mode for the page.
-- `DocStringsCollapsed`: if `true`, collapse all docstrings after loading the page (experimental).
+- `DocStringsCollapsed`: for output formats that support this (i.e. only [`HTML`](@ref Documenter.HTML) currently), if set to `true`, render all docstrings as collapsed by default.
 
 Example:
 

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -284,6 +284,7 @@ page. Currently recognised keys:
 - `Description`: a page-specific description that gets displayed in search engines and
   link previews. Overrides the site-wide description in [`makedocs`](@ref). 
 - `Draft`: boolean for overriding the global draft mode for the page.
+- `DocStringsCollapsed`: if `true`, collapse all docstrings after loading the page (experimental).
 
 Example:
 

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -282,9 +282,9 @@ page. Currently recognised keys:
   but if the source is something else (for example if the `.md` page is generated as part of
   the doc build) this can be set, either as a local link, or an absolute url.
 - `Description`: a page-specific description that gets displayed in search engines and
-  link previews. Overrides the site-wide description in [`makedocs`](@ref). 
+  link previews. Overrides the site-wide description in [`makedocs`](@ref).
 - `Draft`: boolean for overriding the global draft mode for the page.
-- `DocStringsCollapsed`: for output formats that support this (i.e. only [`HTML`](@ref Documenter.HTML) currently), if set to `true`, render all docstrings as collapsed by default.
+- `CollapsedDocStrings`: for output formats that support this (i.e. only [`HTML`](@ref Documenter.HTML) currently), if set to `true`, render all docstrings as collapsed by default.
 
 Example:
 
@@ -365,7 +365,7 @@ As with `@index` if `Pages` is not provided then all pages are included. The def
             "Subsection" => SUBSECTION_PAGES,
         ...
     ```
-    
+
     That variable will exist in the `Main` module and can be reused in the `@contents` and other blocks, e.g.
 
     ````markdown
@@ -373,7 +373,7 @@ As with `@index` if `Pages` is not provided then all pages are included. The def
     Pages = Main.SUBSECTION_PAGES
     ```
     ````
-    
+
     Documenter will then list the contents of the "Subsection" pages, and they will always appear in the same order as they are in the sidebar.
 
 ## `@example` block

--- a/docs/src/showcase.md
+++ b/docs/src/showcase.md
@@ -1,3 +1,7 @@
+```@meta
+DocStringsCollapsed = true
+```
+
 # Showcase
 
 This page showcases the various page elements that are supported by Documenter.
@@ -211,23 +215,23 @@ Lists can also be included in other blocks that can contain block level items
 
 ## Tables
 
-| object | implemented |      value |
-|--------|-------------|------------|
-| `A`    |      ✓      |      10.00 |
-| `BB`   |      ✓      | 1000000.00 |
+| object | implemented | value      |
+| ------ | ----------- | ---------- |
+| `A`    | ✓           | 10.00      |
+| `BB`   | ✓           | 1000000.00 |
 
 With explicit alignment.
 
 | object | implemented |      value |
-| :---   |    :---:    |       ---: |
+| :----- | :---------: | ---------: |
 | `A`    |      ✓      |      10.00 |
 | `BB`   |      ✓      | 1000000.00 |
 
 Tables that are too wide should become scrollable.
 
-| object | implemented |      value |
-| :---   |    :---:    |       ---: |
-| `A`    |      ✓      |      10.00 |
+| object                 |                 implemented                  |                                                      value |
+| :--------------------- | :------------------------------------------: | ---------------------------------------------------------: |
+| `A`                    |                      ✓                       |                                                      10.00 |
 | `BBBBBBBBBBBBBBBBBBBB` | ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓ | 1000000000000000000000000000000000000000000000000000000.00 |
 
 

--- a/docs/src/showcase.md
+++ b/docs/src/showcase.md
@@ -1,7 +1,3 @@
-```@meta
-DocStringsCollapsed = true
-```
-
 # Showcase
 
 This page showcases the various page elements that are supported by Documenter.

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -293,7 +293,7 @@ function Selectors.runner(::Type{Expanders.MetaBlocks}, node, page, doc)
         # wants to hide. We should probably warn, but it is common enough that
         # we will silently skip for now.
         if Documenter.isassign(ex)
-            if !(ex.args[1] in (:CurrentModule, :DocTestSetup, :DocTestFilters, :EditURL, :Description, :Draft))
+            if !(ex.args[1] in (:CurrentModule, :DocTestSetup, :DocTestFilters, :EditURL, :Description, :Draft, :DocStringsCollapsed))
                 source = Documenter.locrepr(page.source, lines)
                 @warn(
                     "In $source: `@meta` block has an unsupported " *

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -293,7 +293,7 @@ function Selectors.runner(::Type{Expanders.MetaBlocks}, node, page, doc)
         # wants to hide. We should probably warn, but it is common enough that
         # we will silently skip for now.
         if Documenter.isassign(ex)
-            if !(ex.args[1] in (:CurrentModule, :DocTestSetup, :DocTestFilters, :EditURL, :Description, :Draft, :DocStringsCollapsed))
+            if !(ex.args[1] in (:CurrentModule, :DocTestSetup, :DocTestFilters, :EditURL, :Description, :Draft, :CollapsedDocStrings))
                 source = Documenter.locrepr(page.source, lines)
                 @warn(
                     "In $source: `@meta` block has an unsupported " *

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -837,7 +837,7 @@ function render_page(ctx, navnode)
     article = render_article(ctx, navnode)
     footer = render_footer(ctx, navnode)
     meta_divs = DOM.Node[]
-    if get(getpage(ctx, navnode).globals.meta, :DocStringsCollapsed, false)
+    if get(getpage(ctx, navnode).globals.meta, :CollapsedDocStrings, false)
         # if DocStringsCollapse = true in `@meta`, we let JavaScript click the
         # collapse button after that page has loaded.
         @tags script

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -836,7 +836,17 @@ function render_page(ctx, navnode)
     navbar = render_navbar(ctx, navnode, true)
     article = render_article(ctx, navnode)
     footer = render_footer(ctx, navnode)
-    htmldoc = render_html(ctx, navnode, head, sidebar, navbar, article, footer)
+    meta_divs = DOM.Node[]
+    if get(getpage(ctx, navnode).globals.meta, :DocStringsCollapsed, false)
+        # if DocStringsCollapse = true in `@meta`, we let JavaScript click the
+        # collapse button after that page has loaded.
+        @tags script
+        push!(
+            meta_divs,
+            div[Symbol("data-docstringscollapsed") => "true"]()
+        )
+    end
+    htmldoc = render_html(ctx, navnode, head, sidebar, navbar, article, footer, meta_divs)
     write_html(ctx, navnode, htmldoc)
 end
 

--- a/test/examples/src/lib/functions.md
+++ b/test/examples/src/lib/functions.md
@@ -1,6 +1,7 @@
 
 ```@meta
 CurrentModule = Main.Mod
+DocStringsCollapsed = true
 ```
 
 # Function Index

--- a/test/examples/src/lib/functions.md
+++ b/test/examples/src/lib/functions.md
@@ -1,7 +1,7 @@
 
 ```@meta
 CurrentModule = Main.Mod
-DocStringsCollapsed = true
+CollapsedDocStrings = true
 ```
 
 # Function Index

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -172,9 +172,9 @@ end
             @test occursin("expanded_setup", issue_491)
             @test occursin("<p>expanded_raw</p>", issue_491)
 
-            # DocStringsCollapsed
+            # CollapsedDocStrings
             if name == "html"
-                # The `index.md` page does not have `DocStringsCollapsed` in
+                # The `index.md` page does not have `CollapsedDocStrings` in
                 # its `@meta` block, ...
                 @test !occursin("<div data-docstringscollapsed=\"true\">", index_html)
                 # but the `lib/functions.md` page does, ...

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -172,6 +172,17 @@ end
             @test occursin("expanded_setup", issue_491)
             @test occursin("<p>expanded_raw</p>", issue_491)
 
+            # DocStringsCollapsed
+            if name == "html"
+                # The `index.md` page does not have `DocStringsCollapsed` in
+                # its `@meta` block, ...
+                @test !occursin("<div data-docstringscollapsed=\"true\">", index_html)
+                # but the `lib/functions.md` page does, ...
+                functions_html = read(joinpath(build_dir, "lib", "functions", "index.html"), String)
+                # so it should have the JS that clicks the toggle button.
+                @test occursin("<div data-docstringscollapsed=\"true\">", functions_html)
+            end
+
             # .documenter-siteinfo.json
             @testset ".documenter-siteinfo.json" begin
                 siteinfo_json_file = joinpath(build_dir, ".documenter-siteinfo.json")


### PR DESCRIPTION
Setting `DocStringsCollapsed = true` in the `@meta` block of a particular page essentially clicks the "Collapse all docstrings" in the navigation bar after the page loads, collapsing all docstrings on that page.

I think the approach of just having JavaScript click the collapse button is the right one here: First, I'm not sure that it would be possible to write out the page in a collapsed state, or at least not without doing some pretty gnarly rewrites of the `HTMLWriter`. More importantly, rendering the page expanded and then collapsing it with JavaScript seems like the right thing to do from an accessibility standpoint: We'd want the page to still be useful without JavaScript. I've been known to access API documentation in the terminal with `w3m`, so not relying on JavaScript to render the core content is something I actually care about. Screenreaders probably also wouldn't like if all docstrings initially rendered as `hidden`.

Closes #2282