### PR TITLE
Suggest using julia-actions/cache in the hosting documentation

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -199,6 +199,7 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1.6'
+      - uses: julia-actions/cache@v1
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy


### PR DESCRIPTION
This should speed up builds, in my case the time to build the docs went from ~2 minutes to ~50s.