### PR TITLE
HTMLWriter: allow extra attributes for external asset links, default to no-referrer policy

### DIFF
--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -619,11 +619,13 @@ mutable struct HTMLContext
     search_index_js :: String
     search_navnode :: Documenter.NavNode
     atexample_warnings::Vector{AtExampleFallbackWarning}
+    external_link_attribs :: Vector{Pair{Symbol,String}}
 
     HTMLContext(doc, settings=nothing) = new(
         doc, settings, [], "", "", "", [], "",
         Documenter.NavNode("search", "Search", nothing),
         AtExampleFallbackWarning[],
+        [:referrerpolicy => "no-referrer"]
     )
 end
 
@@ -958,13 +960,19 @@ function render_head(ctx, navnode)
 
         # Stylesheets.
         map(css_links) do each
-            link[:href => each, :rel => "stylesheet", :type => "text/css"]
+            link[
+                :href => each,
+                :rel => "stylesheet",
+                :type => "text/css",
+                ctx.external_link_attribs...
+            ]
         end,
 
         script("documenterBaseURL=\"$(relhref(src, "."))\""),
         script[
             :src => RD.requirejs_cdn,
-            Symbol("data-main") => relhref(src, ctx.documenter_js)
+            Symbol("data-main") => relhref(src, ctx.documenter_js),
+            ctx.external_link_attribs...
         ],
         script[:src => relhref(src, ctx.search_index_js)],
 


### PR DESCRIPTION
Should close #2391. cc @mortenpi 

( I don't expect this code to stay for very long, but it's a simple fix that may hold for at least as long as the #2159 isn't fixed. )