### PR TITLE
Reduce debounce to make search about 2x faster

### DIFF
--- a/assets/html/js/search.js
+++ b/assets/html/js/search.js
@@ -163,7 +163,7 @@ let filters = [...new Set(data.map((x) => x.category))];
 var modal_filters = make_modal_body_filters(filters);
 var filter_results = [];
 
-$(document).on("keydown", ".documenter-search-input", function (event) {
+$(document).on("input", ".documenter-search-input", function (event) {
   // Adding a debounce to prevent disruptions from super-speed typing!
   debounce(() => update_search(filter_results), 100);
 });

--- a/assets/html/js/search.js
+++ b/assets/html/js/search.js
@@ -163,9 +163,9 @@ let filters = [...new Set(data.map((x) => x.category))];
 var modal_filters = make_modal_body_filters(filters);
 var filter_results = [];
 
-$(document).on("keyup", ".documenter-search-input", function (event) {
+$(document).on("keydown", ".documenter-search-input", function (event) {
   // Adding a debounce to prevent disruptions from super-speed typing!
-  debounce(() => update_search(filter_results), 300);
+  debounce(() => update_search(filter_results), 100);
 });
 
 $(document).on("click", ".search-filter", function () {
@@ -176,7 +176,7 @@ $(document).on("click", ".search-filter", function () {
   }
 
   // Adding a debounce to prevent disruptions from crazy clicking!
-  debounce(() => get_filters(), 300);
+  debounce(() => get_filters(), 100);
 });
 
 /**


### PR DESCRIPTION
On docs.julialang.com, the time between pressing typing the final character of the search query and seeing search results is about 457ms (N=1). 300ms of that is waiting for the debounce to decide the user is done typing and start the search process. After this PR, the total delay drops to 249ms (N=1). I measured delay by taking a slow motion video of my fingers on the keyboard and the display on the screen so this is an "all inclusive" timing. On docs.julialang.org this speeds up searches by 1.8x, and on smaller search domains (e.g. most packages) the speedup may be a bit larger, approaching 3x.

This should not result in overwhelming the browser on fast typing. Faster than 10 chars/s will simply wait for the final character and then 100 more ms. Slower than 10 chars/s the search should be able to handle.

It is possible to do much more intelligent/clever debouncing that, for example, dynamically adjusts the debouncing delay based on observed typing speed and observed search runtime. That seems like an interesting project to pursue, but for now, this PR is quite simple and gives substantial performance gains.

I also switched keyup to keydown to shave a few extra milliseconds off the latency. Once a user presses a key down in the search bar, they are committed to performing a search for the new term, so we might as well start the clock a bit earlier.