### PR TITLE
Remove search debounce (2x+ speedup)

### DIFF
--- a/assets/html/js/search.js
+++ b/assets/html/js/search.js
@@ -164,8 +164,7 @@ var modal_filters = make_modal_body_filters(filters);
 var filter_results = [];
 
 $(document).on("keyup", ".documenter-search-input", function (event) {
-  // Adding a debounce to prevent disruptions from super-speed typing!
-  debounce(() => update_search(filter_results), 300);
+  update_search(filter_results);
 });
 
 $(document).on("click", ".search-filter", function () {
@@ -175,20 +174,8 @@ $(document).on("click", ".search-filter", function () {
     $(this).addClass("search-filter-selected");
   }
 
-  // Adding a debounce to prevent disruptions from crazy clicking!
-  debounce(() => get_filters(), 300);
+  get_filters();
 });
-
-/**
- * A debounce function, takes a function and an optional timeout in milliseconds
- *
- * @function callback
- * @param {number} timeout
- */
-function debounce(callback, timeout = 300) {
-  clearTimeout(timer);
-  timer = setTimeout(callback, timeout);
-}
 
 /**
  * Make/Update the search component


### PR DESCRIPTION
I tested this locally with about 30 seconds of typing at a rate of 30 characters per second (60 if you count the backspace as a character) when using both short and long queries on the docs.julialang.org search target. I noticed no disruptions that the comments warn about. I was testing on chromium as that browser allows me to edit javascript live, it would be nice to also test on another browser and to hear why @Hetarth02 chose to include these debounces in the first place to make sure this doesn't create instability or performance issues, especially on slow computers and/or mobile (though folks don't type particularly quickly on mobile)

```julia
julia> run(`xdotool getmouselocation`)
x:226 y:386 screen:0 window:8388797
Process(`xdotool getmouselocation`, ProcessExited(0))

julia> function f(n)
           run(`xdotool mousemove 226 386`)
           run(`xdotool click 1`)
           for i in 1:n
               run(`xdotool key $(rand('a':'z'))`)
               run(`xdotool key BackSpace`)
           end
       end
f (generic function with 1 method)

julia> f(1000)
```

This should make search at least 2x faster and, I'd extrapolate, sometimes more than 10x faster (e.g. when there are very few search terms or for packages with small indexes). It entirely removes the 300ms wait between when the user finishes typing and when we begin gathering search results.

Fixes #2411 
Supersedes & closes #2407 