### PR TITLE
Do not test against Julia-nightly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,6 @@ jobs:
         version:
           - '1.6'
           - '1'
-          - 'nightly'
         os:
           - ubuntu-latest
           - macos-latest


### PR DESCRIPTION
I don't think we should test against nightly. It fails all the time, and marks all PRs as broken without providing any useful information.

It seems better to manually test against an upcoming version of Julia when there is a release candidate.