### PR TITLE
Add `/docs` project to installation instructions

### DIFF
--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -14,6 +14,17 @@ From the Julia REPL, type `]` to enter the Pkg REPL mode and run
 pkg> add Documenter
 ```
 
+It is generally recommended to install Documenter into a documentation-specific project stored
+in the `/docs` subdirectory of your package. To do this, navigate to your package's root folder
+and do
+
+```
+pkg> activate docs
+
+(docs) pkg> add Documenter
+```
+
+This will create `Project.toml` and `Manifest.toml` files in the `/docs` subdirectory. 
 
 ## Setting up the Folder Structure
 

--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -14,9 +14,8 @@ From the Julia REPL, type `]` to enter the Pkg REPL mode and run
 pkg> add Documenter
 ```
 
-It is generally recommended to install Documenter into a documentation-specific project stored
-in the `/docs` subdirectory of your package. To do this, navigate to your package's root folder
-and do
+For package documentation, the standard approach is to install Documenter into a documentation-specific project stored in the `docs/` subdirectory of your package.
+To do this, navigate to your package's root folder and do
 
 ```
 pkg> activate docs

--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -18,7 +18,7 @@ For package documentation, the standard approach is to install Documenter into a
 To do this, navigate to your package's root folder and do
 
 ```
-pkg> activate docs
+pkg> activate docs/
 
 (docs) pkg> add Documenter
 ```

--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -23,7 +23,11 @@ pkg> activate docs/
 (docs) pkg> add Documenter
 ```
 
-This will create `Project.toml` and `Manifest.toml` files in the `/docs` subdirectory. 
+This will create `Project.toml` and `Manifest.toml` files in the `docs/` subdirectory. 
+
+Note that for packages, you also likely need to have your package that you are documenting as a  ["dev dependency"](https://pkgdocs.julialang.org/v1/managing-packages/#developing) of the `docs/` environment.
+
+See also [the Pkg.jl documentation on working with project environments](https://pkgdocs.julialang.org/v1/environments/).
 
 ## Setting up the Folder Structure
 


### PR DESCRIPTION
This stumped me when I tried to get going with Documenter - happy for suggestions on tweaking the wording.