### PR TITLE
See what happens with `version` in `makedocs`

### DIFF
--- a/assets/html/js/versions.js
+++ b/assets/html/js/versions.js
@@ -60,6 +60,6 @@ $(document).ready(function () {
 
   // only show the version selector if the selector has been populated
   if (version_selector_select.children("option").length > 0) {
-    version_selector.toggleClass("visible");
+    version_selector.addClass("visible");
   }
 });

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,6 +20,7 @@ Changelog.generate(
 
 makedocs(
     modules = [Documenter, DocumenterTools, DocumenterShowcase],
+    version = string(Documenter.DOCUMENTER_VERSION),
     format = if "pdf" in ARGS
         Documenter.LaTeX(platform = "docker")
     else


### PR DESCRIPTION
Ignore this. It's just to trigger CI and build a `preview` documentation so that I can check the behavior of `version` in `makedocs` in that context.