### PR TITLE
Fix theme selector picking the wrong entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Fix search filter toggle button styling in the HTML output. ([#2406], [#2408])
+* The theme selector for the HTML output now correctly picks `Automatic (OS)` if the user hasn't explicitly set the theme. ([#2414], [#2438])
 
 ## Version [v1.2.1] - 2023-12-02
 
@@ -1782,6 +1783,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2375]: https://github.com/JuliaDocs/Documenter.jl/issues/2375
 [#2406]: https://github.com/JuliaDocs/Documenter.jl/issues/2406
 [#2408]: https://github.com/JuliaDocs/Documenter.jl/issues/2408
+[#2414]: https://github.com/JuliaDocs/Documenter.jl/issues/2414
+[#2438]: https://github.com/JuliaDocs/Documenter.jl/issues/2438
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -873,8 +873,8 @@ function render_settings(ctx)
         label[".label"]("Theme"),
         div[".select"](
             select["#documenter-themepicker"](
+                option[:value=>"auto"]("Automatic (OS)"),
                 (option[:value=>theme](theme) for theme in THEMES)...,
-                option[:value=>"auto"]("Automatic (OS)")
             )
         )
     )


### PR DESCRIPTION
This is a bit sneaky.. I think there is a JS logic problem here too. But we pick the first entry in the dropdown if the theme is unset, and so if we make `Automatic (OS)` the first entry, everything looks fine.

Fix #2414.