### PR TITLE
Refactor `crossref`/`xref` for resolving `@ref` links

### DIFF
--- a/docs/src/lib/internals/crossref.md
+++ b/docs/src/lib/internals/crossref.md
@@ -1,0 +1,10 @@
+```@meta
+CollapsedDocStrings = true
+```
+
+# Crossrefs
+
+```@autodocs
+Modules = [Documenter, Documenter.XRefResolvers]
+Pages = ["cross_references.jl"]
+```

--- a/docs/src/lib/internals/deploydocs.md
+++ b/docs/src/lib/internals/deploydocs.md
@@ -2,13 +2,10 @@
 CollapsedDocStrings = true
 ```
 
-# Documenter
+# Deploydocs
 
 ```@docs
 Documenter.gitrm_copy
 Documenter.git_push
 Documenter.user_host_upstream
-Documenter.find_object
-Documenter.xrefname
-Documenter.crossref
 ```


### PR DESCRIPTION
This is a pure refactoring of the `crossref` function and related functions used for resolving `@ref` links in `cross_references.jl`.

It only affects internal code and should have no user-facing effects, other than maybe a slightly different format of the error message when an `@ref` link cannot be resolved. The refactoring simplifies the flow of logic, which previously used a lot of backtracking (["call `xref`, then figure out that the link actually isn't an `@ref`, and backtrack to `local_links!`"](https://github.com/JuliaDocs/Documenter.jl/blob/a6cdf2038d869ef8cb8d0cb697c82dbb6c4e987e/src/cross_references.jl#L131-L136)). It makes the previous [`basicxref `](https://github.com/JuliaDocs/Documenter.jl/blob/a6cdf2038d869ef8cb8d0cb697c82dbb6c4e987e/src/cross_references.jl#L179) obsolete. The logic for "basic" and "non-basic" links is now that both `[test](@ref slug)` and `[slug](@ref)` first get normalized to a `slug`, and then that `slug` gets resolved by the same function.

The main change is that all `@ref` links are now resolved with a `Selector`-based pipeline. The PR adds [full documentation to describe the internals of this](https://documenter.juliadocs.org/previews/PR2453/lib/internals/crossref/).

The motivation for the pipeline approach (apart from just cleaning up the code) is that it allows plugins to extend that pipeline, providing the ability to resolve `@ref` links that `Documenter` ordinarily would not be able to resolve.

The obvious candidate here is for [DocumenterInterLinks](https://github.com/JuliaDocs/DocumenterInterLinks.jl) to provide a fallback for resolving `@ref` links with links to external projects. This is by no means intended as a replacement  for the `@extref` links that are the core of `DocumenterInterLinks`. But it comes in handy if e.g. in the `QuantumControl.jl` documentation I want to include a particular single docstring of a re-exported function from `QuantumControlBase.jl`, and that function has `@ref`-links that resolve in `QuantumControlBase`. Maybe the `@ref` link is even to a section header in `QuantumControlBase`, and there would be no way to make that resolvable in `QuantumControl`.

I might also want to experiment a bit with extensions to the `@ref`-resolution that get around Documenter's restrictions that an `@ref` link to another docstring must have a local binding in the module where the link is defined. I regularly brush up against this, and end up having to import symbols just so that I can link to them. Sometimes that's not possible, as it would create circular references. So, I might want to define myself a (project-local) plugin that relaxes this to "look for bindings anywhere in the project".