### PR TITLE
Resolve `@ref` bindings in current module and `Main`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* A fully qualified `@ref` link now resolves in `Main` as well well as in the `CurrentModule`. For any package whose docstrings are included in the documentation, as long as that package is loaded in `make.jl`, `@ref` links to docstrings in the package will work from anywhere. This simplifies, e.g., linking between docstrings for packages that use sub-modules. ([#2470])
+* A fully qualified `@ref` link now resolves in `Main` as well, in addition to `CurrentModule`. For any package whose docstrings are included in the documentation, as long as that package is loaded in `make.jl`, fully qualified `@ref` links to docstrings in the package will work from anywhere. This simplifies, e.g., linking between docstrings for packages that use sub-modules. ([#2470])
 
 
 ## Version [v1.3.0] - 2024-03-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+* A fully qualified `@ref` link now resolves in `Main` as well well as in the `CurrentModule`. For any package whose docstrings are included in the documentation, as long as that package is loaded in `make.jl`, `@ref` links to docstrings in the package will work from anywhere. This simplifies, e.g., linking between docstrings for packages that use sub-modules. ([#2470])
+
+
 ## Version [v1.3.0] - 2024-03-01
 
 ### Added

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -179,7 +179,7 @@ noncanonical-block).
 ## `@ref` link
 
 Used in markdown links as the URL to tell Documenter to generate a cross-reference
-automatically. The text part of the link can be a docstring, header name, or GitHub PR/Issue
+automatically. The text part of the link can be a code object, header name, or GitHub PR/Issue
 number.
 
 ````markdown
@@ -200,13 +200,13 @@ makedocs
 
 Plain text in the "text" part of a link will either cross-reference a header, or, when it is
 a number preceded by a `#`, a GitHub issue/pull request. Text wrapped in backticks will
-cross-reference a docstring from a `@docs` block.
+cross-reference a docstring from a `@docs` or `@autodocs` block.
+
+The code enclosed in the backticks for such a reference will be evaluated first in the `CurrentModule`  given in the `@meta` block of the current page, and second in `Main`, i.e., the context of the `docs/make.jl` file. For `@ref` links inside a docstring, the `CurrentModule` is automatically set to the module containing the docstring.
 
 `@ref`s may refer to docstrings or headers on different pages as well as the current page
 using the same syntax.
 
-Note that depending on what the `CurrentModule` is set to, a docstring `@ref` may need to
-be prefixed by the module which defines it.
 
 ### Named `@ref`s
 

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -202,10 +202,15 @@ Plain text in the "text" part of a link will either cross-reference a header, or
 a number preceded by a `#`, a GitHub issue/pull request. Text wrapped in backticks will
 cross-reference a docstring from a `@docs` or `@autodocs` block.
 
-The code enclosed in the backticks for such a reference will be evaluated first in the `CurrentModule`  given in the `@meta` block of the current page, and second in `Main`, i.e., the context of the `docs/make.jl` file. For `@ref` links inside a docstring, the `CurrentModule` is automatically set to the module containing the docstring.
+The code enclosed in the backticks for such a reference will be evaluated in the
+`CurrentModule`  given in the `@meta` block of the current page (`Main` by default). For
+`@ref` links inside a docstring, the `CurrentModule` is automatically set to the module
+containing the docstring. A reference that is a fully qualified name will also be resolved
+in `Main`. That is, loading a package in `docs/make.jl` ensures that fully qualified `@ref`
+links work from anywhere.
 
-`@ref`s may refer to docstrings or headers on different pages as well as the current page
-using the same syntax.
+The `@ref` links may refer to docstrings or headers on different pages as well as the
+current page using the same syntax.
 
 
 ### Named `@ref`s

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -179,8 +179,7 @@ noncanonical-block).
 ## `@ref` link
 
 Used in markdown links as the URL to tell Documenter to generate a cross-reference
-automatically. The text part of the link can be a code object, header name, or GitHub PR/Issue
-number.
+automatically. The text part of the link can be a code object (between backticks), header name, or GitHub PR/Issue number (`#` followed by a number).
 
 ````markdown
 # Syntax

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -204,9 +204,10 @@ cross-reference a docstring from a `@docs` or `@autodocs` block.
 The code enclosed in the backticks for such a reference will be evaluated in the
 `CurrentModule`  given in the `@meta` block of the current page (`Main` by default). For
 `@ref` links inside a docstring, the `CurrentModule` is automatically set to the module
-containing the docstring. A reference that is a fully qualified name will also be resolved
-in `Main`. That is, loading a package in `docs/make.jl` ensures that fully qualified `@ref`
-links work from anywhere.
+containing the docstring.
+
+A reference that is a fully qualified name (e.g. ```[`Example.domath`](@ref)``` or `[domath](@ref Example.domath)`) will also be resolved in `Main`.
+That is, loading a package in `docs/make.jl` ensures that fully qualified `@ref` links work from anywhere.
 
 The `@ref` links may refer to docstrings or headers on different pages as well as the
 current page using the same syntax.

--- a/src/cross_references.jl
+++ b/src/cross_references.jl
@@ -288,12 +288,7 @@ function xref(node::MarkdownAST.Node, meta, page, doc)
             slug = first(node.children).element.code
         else
             # TODO: remove this hack (replace with mdflatten?)
-            ast = MarkdownAST.@ast MarkdownAST.Document() do
-                MarkdownAST.Paragraph() do
-                    MarkdownAST.copy_tree(node)
-                end
-            end
-            md = convert(Markdown.MD, ast)
+            md = _link_node_as_md(node)
             text = strip(sprint(Markdown.plain, Markdown.Paragraph(md.content[1].content[1].text)))
             slug = Documenter.slugify(text)
         end
@@ -310,13 +305,26 @@ function xref(node::MarkdownAST.Node, meta, page, doc)
     )
     # finalizer
     if xref_unresolved(node)
-        msg = "Cannot resolve @ref for '$slug' in $(Documenter.locrepr(page.source))."
+        md_str = strip(Markdown.plain(_link_node_as_md(node)))
+        msg = "Cannot resolve @ref for md$(repr(md_str)) in $(Documenter.locrepr(page.source))."
         if (length(errors) > 0)
             msg *= ("\n" * join([string("- ", err) for err in errors], "\n"))
         end
-        @docerror(doc, :cross_references, msg, node = node)
+        @docerror(doc, :cross_references, msg)
     end
     return nothing
+end
+
+
+# Helper to convert MarkdownAST link node to a Markdown.MD object
+function _link_node_as_md(node::MarkdownAST.Node)
+    @assert node.element isa  MarkdownAST.Link
+    document = MarkdownAST.@ast MarkdownAST.Document() do
+        MarkdownAST.Paragraph() do
+            MarkdownAST.copy_tree(node)
+        end
+    end
+    return convert(Markdown.MD, document)
 end
 
 
@@ -371,11 +379,14 @@ function docsxref(node::MarkdownAST.Node, code, meta, page, doc, errors)
     # Add the link to list of local uncheck links.
     doc.internal.locallinks[node.element] = node.element.destination
     if haskey(meta, :CurrentModule)
+        # CurrentModule can be set manually for `.md` pages. For a @ref that's
+        # inside a docstring, CurrentModule is automatically set to the module
+        # containing that docstring.
         modules = [meta[:CurrentModule], Main]
     else
         modules = [Main]
     end
-    for mod in modules
+    for (attempt, mod) in enumerate(modules)
         docref = find_docref(code, mod, page)
         if haskey(docref, :error)
             # We'll bail if the parsing of the docref wasn't successful
@@ -387,15 +398,24 @@ function docsxref(node::MarkdownAST.Node, code, meta, page, doc, errors)
             # Try to find a valid object that we can cross-reference.
             object = find_object(doc, binding, typesig)
             if object !== nothing
-                # Replace the `@ref` url with a path to the referenced docs.
-                docsnode = doc.internal.objects[object]
-                slug = Documenter.slugify(object)
-                pagekey = relpath(docsnode.page.build, doc.user.build)
-                page = doc.blueprint.pages[pagekey]
-                node.element = Documenter.PageLink(page, slug)
-                break  # stop after first mod with binding we can link to
+                if (attempt == 1) || startswith(code, string(binding.mod))
+                    # Replace the `@ref` url with a path to the referenced docs.
+                    docsnode = doc.internal.objects[object]
+                    slug = Documenter.slugify(object)
+                    pagekey = relpath(docsnode.page.build, doc.user.build)
+                    page = doc.blueprint.pages[pagekey]
+                    node.element = Documenter.PageLink(page, slug)
+                    break  # stop after first mod with binding we can link to
+                else
+                    # In the "fallback" attempt 2 in Main we abort if `code` is
+                    # not a fully qualified name (it must start with
+                    # `binding.mod`)
+                    @assert mod == Main
+                    msg = "Fallback resolution in $mod for `$code` -> `$(binding.mod).$(binding.var)` is only allowed for fully qualified names"
+                    push!(errors, msg)
+                end
             else
-                msg = "no docstring found in doc for binding $(binding.mod).$(binding.var)."
+                msg = "No docstring found in doc for binding `$(binding.mod).$(binding.var)`."
                 push!(errors, msg)
             end
         end

--- a/src/cross_references.jl
+++ b/src/cross_references.jl
@@ -366,33 +366,43 @@ end
 # Cross referencing docstrings.
 # -----------------------------
 
-function docsxref(node::MarkdownAST.Node, code, meta, page, doc, errors; docref = find_docref(code, meta, page))
+function docsxref(node::MarkdownAST.Node, code, meta, page, doc, errors)
     @assert node.element isa MarkdownAST.Link
     # Add the link to list of local uncheck links.
     doc.internal.locallinks[node.element] = node.element.destination
-    if haskey(docref, :error)
-        # We'll bail if the parsing of the docref wasn't successful
-        msg = "Exception trying to find docref for `$code`: $(docref.error)"
-        @debug msg exception = docref.exception  # shows the full backtrace
-        push!(errors, msg)
+    if haskey(meta, :CurrentModule)
+        modules = [meta[:CurrentModule], Main]
     else
-        binding, typesig = docref
-        # Try to find a valid object that we can cross-reference.
-        object = find_object(doc, binding, typesig)
-        if object !== nothing
-            # Replace the `@ref` url with a path to the referenced docs.
-            docsnode = doc.internal.objects[object]
-            slug = Documenter.slugify(object)
-            pagekey = relpath(docsnode.page.build, doc.user.build)
-            page = doc.blueprint.pages[pagekey]
-            node.element = Documenter.PageLink(page, slug)
+        modules = [Main]
+    end
+    for mod in modules
+        docref = find_docref(code, mod, page)
+        if haskey(docref, :error)
+            # We'll bail if the parsing of the docref wasn't successful
+            msg = "Exception trying to find docref for `$code`: $(docref.error)"
+            @debug msg exception = docref.exception  # shows the full backtrace
+            push!(errors, msg)
         else
-            push!(errors, "no doc found for reference '[`$code`](@ref)' in $(Documenter.locrepr(page.source)).")
+            binding, typesig = docref
+            # Try to find a valid object that we can cross-reference.
+            object = find_object(doc, binding, typesig)
+            if object !== nothing
+                # Replace the `@ref` url with a path to the referenced docs.
+                docsnode = doc.internal.objects[object]
+                slug = Documenter.slugify(object)
+                pagekey = relpath(docsnode.page.build, doc.user.build)
+                page = doc.blueprint.pages[pagekey]
+                node.element = Documenter.PageLink(page, slug)
+                break  # stop after first mod with binding we can link to
+            else
+                msg = "no docstring found in doc for binding $(binding.mod).$(binding.var)."
+                push!(errors, msg)
+            end
         end
     end
 end
 
-function find_docref(code, meta, page)
+function find_docref(code, mod, page)
     # Parse the link text and find current module.
     keyword = Symbol(strip(code))
     local ex
@@ -403,10 +413,9 @@ function find_docref(code, meta, page)
             ex = Meta.parse(code)
         catch err
             isa(err, Meta.ParseError) || rethrow(err)
-            return (error = "unable to parse the reference '[`$code`](@ref)' in $(Documenter.locrepr(page.source)).", exception = nothing)
+            return (error = "unable to parse the reference `$code` in $(Documenter.locrepr(page.source)).", exception = nothing)
         end
     end
-    mod = get(meta, :CurrentModule, Main)
 
     # Find binding and type signature associated with the link.
     local binding
@@ -414,7 +423,7 @@ function find_docref(code, meta, page)
         binding = Documenter.DocSystem.binding(mod, ex)
     catch err
         return (
-            error = "unable to get the binding for '[`$code`](@ref)' in $(Documenter.locrepr(page.source)) from expression '$(repr(ex))' in module $(mod)",
+            error = "unable to get the binding for `$code` in module $(mod)",
             exception = (err, catch_backtrace()),
         )
         return
@@ -425,10 +434,9 @@ function find_docref(code, meta, page)
         typesig = Core.eval(mod, Documenter.DocSystem.signature(ex, rstrip(code)))
     catch err
         return (
-            error = "unable to evaluate the type signature for '[`$code`](@ref)' in $(Documenter.locrepr(page.source)) from expression '$(repr(ex))' in module $(mod)",
+            error = "unable to evaluate the type signature for `$code` in $(Documenter.locrepr(page.source)) in module $(mod)",
             exception = (err, catch_backtrace()),
         )
-        return
     end
 
     return (binding = binding, typesig = typesig)

--- a/test/docsxref/make.jl
+++ b/test/docsxref/make.jl
@@ -54,7 +54,7 @@ end
     end
     @test isnothing(captured.value)
     @test contains(
-        captured.output,
+        replace(captured.output, "src\\index" => "src/index"),
         """
         ┌ Warning: Cannot resolve @ref for md"[`AbstractSelector`](@ref)" in src/index.md.
         │ - No docstring found in doc for binding `Main.DocsReferencingMain.AbstractSelector`.
@@ -62,7 +62,7 @@ end
         """
     )
     @test contains(
-        captured.output,
+        replace(captured.output, "src\\page" => "src/page"),
         """
         ┌ Warning: Cannot resolve @ref for md"[`DocsReferencingMain.f`](@ref)" in src/page.md.
         │ - Exception trying to find docref for `DocsReferencingMain.f`: unable to get the binding for `DocsReferencingMain.f` in module Documenter.Selectors

--- a/test/docsxref/make.jl
+++ b/test/docsxref/make.jl
@@ -1,0 +1,93 @@
+module DocsXRefTests
+
+# Testing the fallback behavior implemented in
+# https://github.com/JuliaDocs/Documenter.jl/pull/2470
+
+using Test
+using Documenter
+using IOCapture
+
+isdefined(Main, :Documenter) || @eval Main import Documenter
+
+isdefined(Main, :AbstractSelector) || @eval Main using Documenter.Selectors: AbstractSelector
+
+isdefined(Main, :DocsReferencingMain) || @eval Main module DocsReferencingMain
+    export f, g
+
+    """This is the function `f`.
+
+    It references [`Documenter.Selectors.AbstractSelector`](@ref), which
+    resolves only because of a fallback to `Main`.
+
+    See also [`g`](@ref).
+    """
+    f(x) = x
+
+    """This is the function `g`
+
+    If references [`Main.AbstractSelector`](@ref), which should resolve,
+    unlike the non-fully-qualified [`AbstractSelector`](@ref) (even though
+    `AbstractSelector` is in `Main`)
+
+    See also [`f`](@ref).
+    """
+    g(x) = x
+end
+
+
+@testset "xrefs to Main" begin
+
+    kwargs = (
+        root = dirname(@__FILE__),
+        source = "src",
+        build = "build",
+        sitename = "DocsXRef",
+        warnonly = true,
+        format = Documenter.HTML(
+            prettyurls=false,
+            inventory_version="",
+        ),
+    )
+
+    captured = IOCapture.capture() do
+        makedocs(; kwargs...)
+    end
+    @test isnothing(captured.value)
+    @test contains(
+        captured.output,
+        """
+        ┌ Warning: Cannot resolve @ref for md"[`AbstractSelector`](@ref)" in src/index.md.
+        │ - No docstring found in doc for binding `Main.DocsReferencingMain.AbstractSelector`.
+        │ - Fallback resolution in Main for `AbstractSelector` -> `Documenter.Selectors.AbstractSelector` is only allowed for fully qualified names
+        """
+    )
+    @test contains(
+        captured.output,
+        """
+        ┌ Warning: Cannot resolve @ref for md"[`DocsReferencingMain.f`](@ref)" in src/page.md.
+        │ - Exception trying to find docref for `DocsReferencingMain.f`: unable to get the binding for `DocsReferencingMain.f` in module Documenter.Selectors
+        │ - Fallback resolution in Main for `DocsReferencingMain.f` -> `Main.DocsReferencingMain.f` is only allowed for fully qualified names
+        """
+    )
+    index_html = joinpath(dirname(@__FILE__), "build", "index.html")
+    @test isfile(index_html)
+    if isfile(index_html)
+        html = read(index_html, String)
+        @test contains(html, "<a href=\"index.html#Documenter.Selectors.AbstractSelector\"><code>AbstractSelector</code></a>")
+        @test contains(html, "<a href=\"index.html#Documenter.Selectors.AbstractSelector\"><code>Documenter.Selectors.AbstractSelector</code></a>")
+        @test contains(html, "<a href=\"index.html#Documenter.Selectors.AbstractSelector\"><code>Main.AbstractSelector</code></a>")
+        @test contains(html, "<a href=\"@ref\"><code>AbstractSelector</code></a>")
+    end
+    page_html = joinpath(dirname(@__FILE__), "build", "page.html")
+    @test isfile(page_html)
+    if isfile(page_html)
+        html = read(page_html, String)
+        @test contains(html, "<a href=\"index.html#Documenter.Selectors.AbstractSelector\"><code>AbstractSelector</code></a>")
+        @test contains(html, "<a href=\"@ref\"><code>DocsReferencingMain.f</code></a>")
+        @test contains(html, "<a href=\"index.html#Main.DocsReferencingMain.f\"><code>Main.DocsReferencingMain.f</code></a>")
+        @test contains(html, "<a href=\"index.html#Documenter.hide\"><code>Documenter.hide</code></a>")
+    end
+
+end
+
+end

--- a/test/docsxref/src/index.md
+++ b/test/docsxref/src/index.md
@@ -1,0 +1,15 @@
+# DocsXRefTests
+
+On the *page* (unlike in the `g` docstring) can link directly to [`AbstractSelector`](@ref) because the `CurrentModule` is `Main`.
+
+## API
+
+```@docs
+DocsReferencingMain.f
+DocsReferencingMain.g
+```
+
+```@docs
+Documenter.Selectors.AbstractSelector
+Documenter.hide
+```

--- a/test/docsxref/src/page.md
+++ b/test/docsxref/src/page.md
@@ -1,0 +1,9 @@
+```@meta
+CurrentModule = Documenter.Selectors
+```
+
+# Second page
+
+This page is in the context of `Documenters.Selectors`. Thus, we can directly link to [`AbstractSelector`](@ref), but we cannot link to [`DocsReferencingMain.f`](@ref). But if we use the fully qualified name, it works: [`Main.DocsReferencingMain.f`](@ref).
+
+We can also link to [`Documenter.hide`](@ref) because of the fallback to `Main`.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,10 @@ end
     @info "Building missingdocs/make.jl"
     include("missingdocs/make.jl")
 
+    # Test @ref fallback to Main for fully qualified names
+    @info "Building docsxref/make.jl"
+    include("docsxref/make.jl")
+
     # Error reporting.
     @info "Building errors/make.jl"
     @quietly include("errors/make.jl")


### PR DESCRIPTION
For any `@ref` link in a docstring to a code object, Documenter currently tries to find a binding for the code in the module where the docstring is defined. This often requires importing symbols only because they appear in a `@ref`. In some cases, this is not even possible, as it would create circular references. See also the very eloquent description in https://github.com/JuliaDocs/Documenter.jl/issues/2462#issuecomment-1956806650

With this change, Documenter now tries to find binding for `@ref` links in docstrings first in the local module, and then in `Main`, which is basically `docs/make.jl`. Thus, anything imported in `docs/make.jl` can be referenced anywhere.

Closes #2462