### PR TITLE
Document required GitHub Action permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added support for a `CollapsedDocStrings` key in every page's `@meta` block. Setting `CollapsedDocStrings = true` for a particular page essentially clicks the "Collapse all docstrings" in the navigation bar after the page loads, collapsing all docstrings on that page. This can make API documentation pages much more readable. ([#2282], [#2394], [#2459], [#2460])
 * Automatically write an `objects.inv` inventory file to be be included in every online deployment of the documentation. With the help of the [`DocumenterInterLinks` plugin](http://juliadocs.org/DocumenterInterLinks.jl/stable/), any other project using Documenter or [Sphinx](https://www.sphinx-doc.org/en/master/) can then externally link to any page, heading, or docstring in the documentation. ([#2366], [#2424])
 * Added a parameter `inventory_version` to the `HTML()` options that may be passed to `makedocs`. This option sets the `version` metadata field in the new `objects.inv` inventory file. In most cases, the project version for the inventory will be automatically detected from the main `Project.toml` file, respectively, during deployment in `deploydocs`, from the git tag of the release. Any project may still want to explicitly set `inventory_version` via, e.g., [`pkgversion(MyProject)`](https://docs.julialang.org/en/v1/base/base/#Base.pkgversion-Tuple{Module}) instead of relying on an auto-detected version. Projects with a non-standard setup (documentation-only-repos, monorepos) *should* modify their existing configuration to explicitly set `inventory_version`. ([#2449])
+* Added documentation on required GitHub Actions permissions. ([#2478])
 
 ### Changed
 
@@ -1810,6 +1811,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2459]: https://github.com/JuliaDocs/Documenter.jl/issues/2459
 [#2460]: https://github.com/JuliaDocs/Documenter.jl/issues/2460
 [#2461]: https://github.com/JuliaDocs/Documenter.jl/issues/2461
+[#2478]: https://github.com/JuliaDocs/Documenter.jl/issues/2478
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added support for a `CollapsedDocStrings` key in every page's `@meta` block. Setting `CollapsedDocStrings = true` for a particular page essentially clicks the "Collapse all docstrings" in the navigation bar after the page loads, collapsing all docstrings on that page. This can make API documentation pages much more readable. ([#2282], [#2394], [#2459], [#2460])
 * Automatically write an `objects.inv` inventory file to be be included in every online deployment of the documentation. With the help of the [`DocumenterInterLinks` plugin](http://juliadocs.org/DocumenterInterLinks.jl/stable/), any other project using Documenter or [Sphinx](https://www.sphinx-doc.org/en/master/) can then externally link to any page, heading, or docstring in the documentation. ([#2366], [#2424])
 * Added a parameter `inventory_version` to the `HTML()` options that may be passed to `makedocs`. This option sets the `version` metadata field in the new `objects.inv` inventory file. In most cases, the project version for the inventory will be automatically detected from the main `Project.toml` file, respectively, during deployment in `deploydocs`, from the git tag of the release. Any project may still want to explicitly set `inventory_version` via, e.g., [`pkgversion(MyProject)`](https://docs.julialang.org/en/v1/base/base/#Base.pkgversion-Tuple{Module}) instead of relying on an auto-detected version. Projects with a non-standard setup (documentation-only-repos, monorepos) *should* modify their existing configuration to explicitly set `inventory_version`. ([#2449])
-* Added documentation on required GitHub Actions permissions. ([#2478])
 
 ### Changed
 
@@ -1811,7 +1810,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2459]: https://github.com/JuliaDocs/Documenter.jl/issues/2459
 [#2460]: https://github.com/JuliaDocs/Documenter.jl/issues/2460
 [#2461]: https://github.com/JuliaDocs/Documenter.jl/issues/2461
-[#2478]: https://github.com/JuliaDocs/Documenter.jl/issues/2478
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -192,7 +192,7 @@ jobs:
   build:
     permissions:
       contents: write
-      statuses: write
+      pull_requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -266,6 +266,16 @@ to the configuration file, as showed in the [previous section](@ref GitHub-Actio
     You can only use `GITHUB_TOKEN` for authentication if the target repository
     of the deployment is the same as the current repository. In order to push
     elsewhere you should instead use a SSH deploy key.
+
+#### Permissions
+
+The following [GitHub Actions job or workflow permissions](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) are required to successfully use [`deploydocs`](#the-deploydocs-function):
+
+```yaml
+permissions:
+  contents: write
+  pull_requests: read  # Required when `push_preview=true`
+```
 
 ### Authentication: SSH Deploy Keys
 

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -274,7 +274,7 @@ The following [GitHub Actions job or workflow permissions](https://docs.github.c
 ```yaml
 permissions:
   contents: write
-  pull_requests: read  # Required when `push_preview=true`
+  pull_requests: read  # Required when using `push_preview=true`
 ```
 
 ### Authentication: SSH Deploy Keys

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -192,7 +192,7 @@ jobs:
   build:
     permissions:
       contents: write
-      pull_requests: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -274,7 +274,7 @@ The following [GitHub Actions job or workflow permissions](https://docs.github.c
 ```yaml
 permissions:
   contents: write
-  pull_requests: read  # Required when using `push_preview=true`
+  pull-requests: read  # Required when using `push_preview=true`
 ```
 
 ### Authentication: SSH Deploy Keys

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -268,17 +268,6 @@ to the configuration file, as showed in the [previous section](@ref GitHub-Actio
     of the deployment is the same as the current repository. In order to push
     elsewhere you should instead use a SSH deploy key.
 
-#### Permissions
-
-The following [GitHub Actions job or workflow permissions](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) are required to successfully use [`deploydocs`](#the-deploydocs-function):
-
-```yaml
-permissions:
-  contents: write
-  pull-requests: read  # Required when using `push_preview=true`
-  statuses: write  # Optional, used to report documentation build statuses
-```
-
 ### Authentication: SSH Deploy Keys
 
 It is also possible to authenticate using a SSH deploy key, just as described in
@@ -295,6 +284,17 @@ to the configuration file, as showed in the [previous section](@ref GitHub-Actio
 See GitHub's manual for
 [Encrypted secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions)
 for more information.
+
+### Permissions
+
+The following [GitHub Actions job or workflow permissions](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) are required to successfully use [`deploydocs`](#the-deploydocs-function):
+
+```yaml
+permissions:
+  contents: write  # Required when authenticating with `GITHUB_TOKEN`, not needed when authenticating with SSH deploy keys
+  pull-requests: read  # Required when using `push_preview=true`
+  statuses: write  # Optional, used to report documentation build statuses
+```
 
 ### Add code coverage from documentation builds
 

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -193,6 +193,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+      statuses: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -275,6 +276,7 @@ The following [GitHub Actions job or workflow permissions](https://docs.github.c
 permissions:
   contents: write
   pull-requests: read  # Required when using `push_preview=true`
+  statuses: write  # Optional, used to report documentation build statuses
 ```
 
 ### Authentication: SSH Deploy Keys


### PR DESCRIPTION
Adds documentation for the required GitHub Actions permissions for running `deploydocs`. As I tend to reference these permissions from my CI workflows it's nice having these be in their own section.

I determined the required permissions by starting off with no permissions and slowing adding permissions until I got a successful documentation deployment. There may be additional permissions required that my particular workflow didn't encounter. We can add those to this documentation as we discover them.

- Without `contents: write` rendered documentation cannot be pushed to the repo:
   ```
   remote: Write access to repository not granted.
   fatal: unable to access 'https://github.com/...': The requested URL returned error: 403
   ```
- Without `pull-requests: read` using `push_preview=true` will fail the following check resulting in preview documentation failing to be published (the CI job will still pass though)
   ```
   ✘ PR originates from the same repository
   ```
- Without: `statuses: write` the ["Create a commit status"](https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status) API call [used by Documenter.jl](https://github.com/JuliaDocs/Documenter.jl/blob/346c622bf7eb7bc70ab7de6481650285de599921/src/deployconfig.jl#L504C26-L504C54) will [silently fail](https://github.com/JuliaDocs/Documenter.jl/blob/346c622bf7eb7bc70ab7de6481650285de599921/src/deployconfig.jl#L444-L466). 