### PR TITLE
Consistency on `using` and qualified access

### DIFF
--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -862,22 +862,13 @@ end
 Constructs and writes the page referred to by the `navnode` to `.build`.
 """
 function render_page(ctx, navnode)
-    @tags div 
     head = render_head(ctx, navnode)
     sidebar = render_sidebar(ctx, navnode)
     navbar = render_navbar(ctx, navnode, true)
     article = render_article(ctx, navnode)
     footer = render_footer(ctx, navnode)
-    meta_divs = DOM.Node[]
-    if get(getpage(ctx, navnode).globals.meta, :CollapsedDocStrings, false)
-        # if DocStringsCollapse = true in `@meta`, we let JavaScript click the
-        # collapse button after that page has loaded.
-        push!(
-            meta_divs,
-            div[Symbol("data-docstringscollapsed") => "true"]()
-        )
-    end
-    htmldoc = render_html(ctx, head, sidebar, navbar, article, footer, meta_divs)
+    extras = render_extras(ctx, navnode)
+    htmldoc = render_html(ctx, head, sidebar, navbar, article, footer, extras)
     write_html(ctx, navnode, htmldoc)
 end
 
@@ -887,7 +878,7 @@ end
 """
 Renders the main `<html>` tag.
 """
-function render_html(ctx, head, sidebar, navbar, article, footer, scripts::Vector{DOM.Node}=DOM.Node[])
+function render_html(ctx, head, sidebar, navbar, article, footer, extras)
     @tags html body div
     DOM.HTMLDocument(
         html[:lang=>ctx.settings.lang](
@@ -899,7 +890,7 @@ function render_html(ctx, head, sidebar, navbar, article, footer, scripts::Vecto
                     render_settings(),
                 ),
             ),
-            scripts...
+            extras...
         )
     )
 end
@@ -1429,6 +1420,17 @@ function render_footer(ctx, navnode)
     end
 
     return nav[".docs-footer"](nav_children...)
+end
+
+function render_extras(ctx, navnode)
+    @tags div
+    meta_divs = DOM.Node[]
+    if get(getpage(ctx, navnode).globals.meta, :CollapsedDocStrings, false)
+        # if DocStringsCollapse = true in `@meta`, we let JavaScript click the
+        # collapse button after that page has loaded.
+        push!(meta_divs, div[Symbol("data-docstringscollapsed") => "true"]())
+    end
+    meta_divs
 end
 
 # Article (page contents)

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -862,7 +862,7 @@ end
 Constructs and writes the page referred to by the `navnode` to `.build`.
 """
 function render_page(ctx, navnode)
-    @tags html div body
+    @tags div 
     head = render_head(ctx, navnode)
     sidebar = render_sidebar(ctx, navnode)
     navbar = render_navbar(ctx, navnode, true)
@@ -872,7 +872,6 @@ function render_page(ctx, navnode)
     if get(getpage(ctx, navnode).globals.meta, :CollapsedDocStrings, false)
         # if DocStringsCollapse = true in `@meta`, we let JavaScript click the
         # collapse button after that page has loaded.
-        @tags script
         push!(
             meta_divs,
             div[Symbol("data-docstringscollapsed") => "true"]()
@@ -1124,7 +1123,7 @@ end
 NavMenuContext(ctx::HTMLContext, current::Documenter.NavNode) = NavMenuContext(ctx, current, [])
 
 function render_sidebar(ctx, navnode)
-    @tags a form img input nav div button select option span
+    @tags a img nav div button select option span
     src = get_url(ctx, navnode)
     navmenu = nav[".docs-sidebar"]
 
@@ -1437,7 +1436,7 @@ end
 
 function render_article(ctx, navnode)
     dctx = DCtx(ctx, navnode)
-    @tags article section ul li hr span a div p
+    @tags article section ul li a p
 
     # Build the page itself (and collect any footnotes)
     empty!(dctx.footnotes)
@@ -1752,7 +1751,7 @@ end
 function domify_doc(dctx::DCtx, node::Node)
     @assert node.element isa Documenter.DocsNode
     ctx = dctx.ctx
-    @tags a section footer div
+    @tags a section div
     # The `:results` field contains a vector of `Docs.DocStr` objects associated with
     # each markdown object. The `DocStr` contains data such as file and line info that
     # we need for generating correct source links.

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -73,7 +73,7 @@ using SHA: SHA
 using CodecZlib: ZlibCompressorStream
 using ANSIColoredPrinters: ANSIColoredPrinters
 
-using ..Documenter: Documenter, Remotes
+using ..Documenter: Documenter, Default, Remotes
 using ...JSDependencies: JSDependencies
 using ...DOM: DOM, @tags
 using ...MDFlatten: mdflatten
@@ -488,8 +488,8 @@ struct HTML <: Documenter.Writer
     function HTML(;
             prettyurls    :: Bool = true,
             disable_git   :: Bool = false,
-            repolink      :: Union{String, Nothing, Default} = Documenter.Default(nothing),
-            edit_link     :: Union{String, Symbol, Nothing, Default} = Documenter.Default(Documenter.git_remote_head_branch("HTML(edit_link = ...)", Documenter.currentdir())),
+            repolink      :: Union{String, Nothing, Default} = Default(nothing),
+            edit_link     :: Union{String, Symbol, Nothing, Default} = Default(Documenter.git_remote_head_branch("HTML(edit_link = ...)", Documenter.currentdir())),
             canonical     :: Union{String, Nothing} = nothing,
             assets        :: Vector = String[],
             analytics     :: String = "",
@@ -515,7 +515,7 @@ struct HTML <: Documenter.Writer
             inventory_version = nothing,
 
             # deprecated keywords
-            edit_branch   :: Union{String, Nothing, Default} = Documenter.Default(nothing),
+            edit_branch   :: Union{String, Nothing, Default} = Default(nothing),
         )
         collapselevel >= 1 || throw(ArgumentError("collapselevel must be >= 1"))
         if prerender


### PR DESCRIPTION
In this PR I tried to implement a consistent `using` approach. As can be seen, this requires qualified access for most things, with some exceptions (to not unnecessarily produce code churn).

My motivation for DocumenterEpub is that the code in HTMLWriter gets more readable/understandable (to me). This is of course a style question, so I can live with this being dropped.