### PR TITLE
Fix Woodpecker 0.15.x docs link

### DIFF
--- a/src/deployconfig.jl
+++ b/src/deployconfig.jl
@@ -934,9 +934,9 @@ pipeline:
 ```
 
 More about pipeline syntax is documented here: 
-- 0.15.x <https://web.archive.org/web/20240318223506/https://woodpecker-ci.org/docs/0.15/usage/pipeline-syntax> (the documentation is no longer available on the Woodpecker website)
-- 1.0.0 and onwards <https://woodpecker-ci.org/docs/1.0/usage/pipeline-syntax>
-- 2.0.0 <https://woodpecker-ci.org/docs/usage/workflow-syntax>
+- 0.15.x: [https://woodpecker-ci.org/docs/0.15/usage/pipeline-syntax (hosted at archive.org; the documentation is no longer available on the Woodpecker website)](https://web.archive.org/web/20240318223506/https://woodpecker-ci.org/docs/0.15/usage/pipeline-syntax)
+- 1.0.0 and onwards: <https://woodpecker-ci.org/docs/1.0/usage/pipeline-syntax>
+- 2.0.0: <https://woodpecker-ci.org/docs/usage/workflow-syntax>
 """
 struct Woodpecker <: DeployConfig
     woodpecker_ci_version::VersionNumber

--- a/src/deployconfig.jl
+++ b/src/deployconfig.jl
@@ -934,7 +934,7 @@ pipeline:
 ```
 
 More about pipeline syntax is documented here: 
-- 0.15.x <https://woodpecker-ci.org/docs/0.15/usage/pipeline-syntax>
+- 0.15.x <https://web.archive.org/web/20240318223506/https://woodpecker-ci.org/docs/0.15/usage/pipeline-syntax> (the documentation is no longer available on the Woodpecker website)
 - 1.0.0 and onwards <https://woodpecker-ci.org/docs/1.0/usage/pipeline-syntax>
 - 2.0.0 <https://woodpecker-ci.org/docs/usage/workflow-syntax>
 """


### PR DESCRIPTION
Causing linkcheck failures. Apparently they've removed the 0.15.x docs. It's still on archive.org for now, so might as well link there.