### PR TITLE
Set version to 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1337,6 +1337,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v1.2.1]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.2.1
 [v1.3.0]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.3.0
 [v1.4.0]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.4.0
+[v1.4.1]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.4.1
 [#198]: https://github.com/JuliaDocs/Documenter.jl/issues/198
 [#245]: https://github.com/JuliaDocs/Documenter.jl/issues/245
 [#487]: https://github.com/JuliaDocs/Documenter.jl/issues/487

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## Version [v1.4.1] - 2024-05-02
 
 ### Fixed
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Documenter"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"


### PR DESCRIPTION
## Pre-release

 - [x] Change the version number in `Project.toml`
   * If the release is breaking, increment MAJOR
   * If the release adds a new user-visible feature, increment MINOR
   * Otherwise (bug-fixes, documentation improvements), increment PATCH
 - [x] Update `CHANGELOG.md`, following the existing style (in particular, make sure that the change log for this version has the correct version number and date).
 - [x] Run `make changelog`, to make sure that all the issue references in `CHANGELOG.md` are up to date.
 - [x] Check that the commit messages in this PR do not contain `[ci skip]`
 - [ ] Run [regression-tests workflow](https://github.com/JuliaDocs/Documenter.jl/actions/workflows/regression-tests.yml) using a `workflow_dispatch` trigger to check for any changes that broke extensions: https://github.com/JuliaDocs/Documenter.jl/actions/runs/8915685555

## The release

 - [ ] After merging the pull request, tag the release. There are two options for this:

   1. [Comment `[at]JuliaRegistrator register` on the GitHub commit.](https://github.com/JuliaRegistries/Registrator.jl#via-the-github-app)
   2. Use [JuliaHub's package registration feature](https://help.juliahub.com/juliahub/stable/contribute/#registrator) to trigger the registration.

   Either of those should automatically publish a new version to the Julia registry.
 - Once registered, the `TagBot.yml` workflow should create a tag, and rebuild the documentation for this tag.
 - These steps can take quite a bit of time (1 hour or more), so don't be surprised if the new documentation takes a while to appear.