### PR TITLE
Combine results with AND

### DIFF
--- a/assets/html/js/search.js
+++ b/assets/html/js/search.js
@@ -326,6 +326,7 @@ function worker_function(documenterSearchIndex, documenterBaseURL, filters) {
         // Only return relevant results
         return result.score >= 1;
       },
+      combineWith: 'AND'
     });
 
     // Pre-filter to deduplicate and limit to 200 per category to the extent


### PR DESCRIPTION
This makes the search combine input with AND instead of the default OR, which means results get more refined the longer your search string is, not more varied.