### PR TITLE
Change search_index to be a JSON file

### DIFF
--- a/assets/html/js/search.js
+++ b/assets/html/js/search.js
@@ -65,12 +65,12 @@ update_search
 
 /////// SEARCH WORKER ///////
 
-function worker_function(documenterSearchIndex, documenterBaseURL, filters) {
+function worker_function(Index, documenterBaseURL, filters) {
   importScripts(
     "https://cdn.jsdelivr.net/npm/minisearch@6.1.0/dist/umd/index.min.js"
   );
 
-  let data = documenterSearchIndex.map((x, key) => {
+  let data = Index.map((x, key) => {
     x["id"] = key; // minisearch requires a unique for each object
     return x;
   });
@@ -360,13 +360,13 @@ function worker_function(documenterSearchIndex, documenterBaseURL, filters) {
 
 // `worker = Threads.@spawn worker_function(documenterSearchIndex)`, but in JavaScript!
 const filters = [
-  ...new Set(documenterSearchIndex["docs"].map((x) => x.category)),
+  ...new Set(documenterSearchIndex.map((x) => x.category)),
 ];
 const worker_str =
   "(" +
   worker_function.toString() +
   ")(" +
-  JSON.stringify(documenterSearchIndex["docs"]) +
+  JSON.stringify(documenterSearchIndex) +
   "," +
   JSON.stringify(documenterBaseURL) +
   "," +

--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -144,7 +144,7 @@ build/
 ├── index.html
 ├── search
 │   └── index.html
-└── search_index.js
+└── search_index.json
 ```
 
 !!! note

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -740,7 +740,7 @@ function render(doc::Documenter.Document, settings::HTML=HTML())
     end
 
     ctx = HTMLContext(doc, settings)
-    ctx.search_index_js = "search_index.js"
+    ctx.search_index_js = "search_index.json"
     ctx.themeswap_js = copy_asset("themeswap.js", doc)
     ctx.warner_js = copy_asset("warner.js", doc)
 
@@ -807,9 +807,8 @@ function render(doc::Documenter.Document, settings::HTML=HTML())
     all(size_limit_successes) || throw(HTMLSizeThresholdError())
 
     open(joinpath(doc.user.build, ctx.search_index_js), "w") do io
-        println(io, "var documenterSearchIndex = {\"docs\":")
         # convert Vector{SearchRecord} to a JSON string + do additional JS escaping
-        println(io, JSDependencies.json_jsescape(ctx.search_index), "\n}")
+        println(io, JSDependencies.json_jsescape(ctx.search_index))
     end
 
     write_inventory(doc, ctx)
@@ -994,7 +993,7 @@ function render_head(ctx, navnode)
             :src => RD.requirejs_cdn,
             Symbol("data-main") => relhref(src, ctx.documenter_js)
         ],
-        script[:src => relhref(src, ctx.search_index_js)],
+        #script[:src => relhref(src, ctx.search_index_js)],
 
         script[:src => relhref(src, "siteinfo.js")],
         script[:src => relhref(src, "../versions.js")],

--- a/src/utilities/JSDependencies.jl
+++ b/src/utilities/JSDependencies.jl
@@ -174,6 +174,15 @@ function writejs(io::IO, r::RequireJS)
     isempty(shim) ? write(io, '\n') : write(io, ",\n  shim: ", json_jsescape(shim, 2))
     write(io, "});\n")
 
+    fetchstring = """fetch("./search_index.json") // assuming docs is served from root
+    .then(result => result.json())
+    .then(json =>
+      {
+        documenterSearchIndex = json;
+      }
+    );\n"""
+    write(io, fetchstring)
+
     for s in r.snippets
         args = join(s.args, ", ") # Note: not string literals => no escaping
         deps = join(("\'$(jsescape(d))\'" for d in s.deps), ", ")


### PR DESCRIPTION
Not the best thing at the moment, because the fetch() function assumes site is served from / So it won't find search_index.json if site is project.com/docs instead of docs.project.com

I don't really know how to fix this.