### PR TITLE
HTML format: offline_version parameter

### DIFF
--- a/src/html/RD.jl
+++ b/src/html/RD.jl
@@ -120,7 +120,6 @@ module RD
 
     process_remote(dep, offline_version::Bool, build_path, origin_path=build_path) = offline_version ? _process(dep, build_path, origin_path) : dep
     _process(dep::RemoteLibrary, build_path, origin_path) = RemoteLibrary(dep.name, _process(dep.url, build_path, origin_path); deps = dep.deps, exports = dep.exports)
-    # hascurl() = (try; success(`curl --version`); catch err; false; end)
 
     function _download_file_content(url::AbstractString)
         cmd = `curl $url -s --output -`

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -477,7 +477,7 @@ else
 end
 
 # HTML: offline_version
-examples_html_local_doc = if "html-offline" in EXAMPLE_BUILDS
+examples_html_offline_doc = if "html-offline" in EXAMPLE_BUILDS
     @info("Building mock package docs: HTMLWriter / offline build")
     @quietly makedocs(
         debug = true,
@@ -501,7 +501,7 @@ examples_html_local_doc = if "html-offline" in EXAMPLE_BUILDS
         warnonly = [:doctest, :footnote, :cross_references, :linkcheck, :example_block, :eval_block],
     )
 else
-    @info "Skipping build: HTML/local"
+    @info "Skipping build: HTML/offline"
     @debug "Controlling variables:" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
     nothing
 end

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -18,7 +18,7 @@ EXAMPLE_BUILDS = if haskey(ENV, "DOCUMENTER_TEST_EXAMPLES")
     split(ENV["DOCUMENTER_TEST_EXAMPLES"])
 else
     ["html", "html-meta-custom", "html-mathjax2-custom", "html-mathjax3", "html-mathjax3-custom",
-    "html-local", "html-draft", "html-repo-git", "html-repo-nothing", "html-repo-error",
+    "html-local", "html-offline", "html-draft", "html-repo-git", "html-repo-nothing", "html-repo-error",
     "html-sizethreshold-defaults-fail", "html-sizethreshold-success", "html-sizethreshold-ignore-success", "html-sizethreshold-override-fail", "html-sizethreshold-ignore-success", "html-sizethreshold-ignore-fail",
     "latex_texonly", "latex_simple_texonly", "latex_showcase_texonly", "html-pagesonly"]
 end
@@ -472,6 +472,36 @@ examples_html_pagesonly_doc = if "html-pagesonly" in EXAMPLE_BUILDS
     )
 else
     @info "Skipping build: HTML/pagesonly"
+    @debug "Controlling variables:" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
+    nothing
+end
+
+# HTML: offline_version
+examples_html_local_doc = if "html-offline" in EXAMPLE_BUILDS
+    @info("Building mock package docs: HTMLWriter / offline build")
+    @quietly makedocs(
+        debug = true,
+        root  = examples_root,
+        build = "builds/html-offline",
+        doctestfilters = [r"Ptr{0x[0-9]+}"],
+        sitename = "Documenter example",
+        pages = htmlbuild_pages,
+        expandfirst = expandfirst,
+        repo = "https://dev.azure.com/org/project/_git/repo?path={path}&version={commit}{line}&lineStartColumn=1&lineEndColumn=1",
+        linkcheck = true,
+        linkcheck_ignore = [r"(x|y).md", "z.md", r":func:.*"],
+        format = Documenter.HTML(
+            assets = [
+                "assets/custom.css"
+            ],
+            offline_version = true,
+            footer = nothing,
+        ),
+        # TODO: example_block failure only happens on windows, so that's not actually expected
+        warnonly = [:doctest, :footnote, :cross_references, :linkcheck, :example_block, :eval_block],
+    )
+else
+    @info "Skipping build: HTML/local"
     @debug "Controlling variables:" EXAMPLE_BUILDS get(ENV, "DOCUMENTER_TEST_EXAMPLES", nothing)
     nothing
 end

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -423,6 +423,25 @@ end
         end
     end
 
+    
+    @testset "HTML: offline" begin
+        doc = Main.examples_html_offline_doc
+
+        @test isa(doc, Documenter.Documenter.Document)
+
+        let build_dir = joinpath(examples_root, "builds", "html-offline")
+
+            index_html = read(joinpath(build_dir, "index.html"), String)
+            @test occursin("<link href=\"assets/cdn/lato-font.min.css\" rel=\"stylesheet\" type=\"text/css\"/>", index_html)
+
+            # Assets
+            @test joinpath(build_dir, "assets", "documenter.js") |> isfile
+            @test joinpath(build_dir, "assets", "cdn", "lato-font.min.css") |> isfile
+            documenterjs = String(read(joinpath(build_dir, "assets", "documenter.js")))
+            @test occursin("'jquery': 'cdn/jquery.min'", documenterjs)
+        end
+    end
+
     @testset "HTML: pagesonly" begin
         doc = Main.examples_html_pagesonly_doc
 


### PR DESCRIPTION
Adresses JuliaLang/julia#19354 and one of the items on #212.

The general idea is to try to add a keyword parameter to the `HTML()` struct. By putting `format = Documenter.HTML(offline_version = true)` in the parameters of `makedocs`, the HTML output should come bundled with all the CDNs.

Here is a list of what I've done:
- added the keyword as a parameter of HTML
- when a remote dependency is used in the HTMLWriter, I call a function of RD in between, called `process_remote`. This function, depending on the user-given parameter will download the dependency using curl and write it in the right file, replacing the CDN url with a relative URL.
- for CSS font files, the URL inside are relative, so those files also need to be downloaded, this is done through the function `_process_downloaded_css` (with a regex)
- for my internal use, having font files as an asset behind an authenticated portal was not working. I had to actually write them as a base64 encoded string inline the CSS file. This might not be useful for everyone but it makes docs displayable when the website needs authentication even for assets (because a font file is always fetched in an [anonymous mode](https://www.w3.org/TR/css-fonts-3/#font-fetching-requirements)).
- a limited test of the offline_version build. The rest of those functions is hard to test because this depends on curl.

I might have missed some dependencies or could improve some of the functions signature, would gladly take some feedback!