### PR TITLE
Hint on registering generated documentation with DocumentationGeneratorRegistry

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -441,6 +441,16 @@ The `permissions:` line above is described in the
 an alternative is to give GitHub workflows write permissions under the repo settings, e.g.,
 `https://github.com/<USER>/<REPO>.jl/settings/actions`.
 
+## JuliaHub
+
+JuliaHub provides an [overview on registered Julia packages](https://https://juliahub.com/ui/Packages).
+It tries to build package documentation on it's own, if this fails, a stripped down version of the documentation
+is generated which just consists of the README and the docstrings of the package. 
+In order to point JuliaHub to the documentation already hosted e.g. on the `gh-pages` branch
+of the package repository, it is possible to register the link to thehosted documentation with 
+[DocumentationGeneratorRegistry](https://github.com/JuliaDocs/DocumentationGeneratorRegistry).
+
+
 ## Woodpecker CI
 
 To run a documentation build from Woodpecker CI, one should create an access token

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -444,7 +444,7 @@ an alternative is to give GitHub workflows write permissions under the repo sett
 ## JuliaHub
 
 [JuliaHub](https://juliahub.com/ui/Home) provides an [overview on registered Julia packages](https://https://juliahub.com/ui/Packages).
-It tries to build package documentation on it's own, if this fails, a stripped down version of the documentation
+It tries to build package documentation on its own, and if this fails, a stripped down version of the documentation
 is generated which just consists of the README and the docstrings of the package.
 In order to point JuliaHub to the documentation already hosted e.g. on the `gh-pages` branch
 of the package repository, it is possible to register the link to the hosted documentation with

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -443,12 +443,13 @@ an alternative is to give GitHub workflows write permissions under the repo sett
 
 ## JuliaHub
 
-JuliaHub provides an [overview on registered Julia packages](https://https://juliahub.com/ui/Packages).
+[JuliaHub](https://juliahub.com/ui/Home) provides an [overview on registered Julia packages](https://https://juliahub.com/ui/Packages).
 It tries to build package documentation on it's own, if this fails, a stripped down version of the documentation
-is generated which just consists of the README and the docstrings of the package. 
+is generated which just consists of the README and the docstrings of the package.
 In order to point JuliaHub to the documentation already hosted e.g. on the `gh-pages` branch
-of the package repository, it is possible to register the link to thehosted documentation with 
+of the package repository, it is possible to register the link to the hosted documentation with
 [DocumentationGeneratorRegistry](https://github.com/JuliaDocs/DocumentationGeneratorRegistry).
+The JuliaHub documentation link is updated after releasing a new package version.
 
 
 ## Woodpecker CI

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -443,7 +443,7 @@ an alternative is to give GitHub workflows write permissions under the repo sett
 
 ## JuliaHub
 
-[JuliaHub](https://juliahub.com/ui/Home) provides an [overview on registered Julia packages](https://https://juliahub.com/ui/Packages).
+[JuliaHub](https://juliahub.com/ui/Home) provides an [overview of registered Julia packages](https://https://juliahub.com/ui/Packages).
 It tries to build package documentation on its own, and if this fails, a stripped down version of the documentation
 is generated which just consists of the README and the docstrings of the package.
 In order to point JuliaHub to the documentation already hosted e.g. on the `gh-pages` branch


### PR DESCRIPTION
Registering with DocumentationGeneratorRegistry ensures that JuliaHub points to the documentation version hosted on the package repo rather than to a possibly stripped-down version.

See https://github.com/JuliaComputing/JuliaHub-Feedback/issues/161 for a hint that this can be done.