### PR TITLE
Add `actions: write` permissions to example Actions workflow

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -191,6 +191,7 @@ on:
 jobs:
   build:
     permissions:
+      actions: write
       contents: write
       pull-requests: read
       statuses: write


### PR DESCRIPTION
add `actions: write` to permissions as julia-actions/cache required

See also: https://github.com/AnzhiZhang/TypedMatrices.jl/actions/runs/10271054984/job/28420170392#step:11:18