### PR TITLE
Fix libsass_jll to 3.6.4

### DIFF
--- a/assets/html/Project.toml
+++ b/assets/html/Project.toml
@@ -4,4 +4,4 @@ DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"
 libsass_jll = "47bcb7c8-5119-555a-9eeb-0afcc36cd728"
 
 [compat]
-libsass_jll = "~3.6"
+libsass_jll = "=3.6.4"


### PR DESCRIPTION
It looks like libsass v3.6.6 generates slightly different CSS from 3.6.4. So it looks like we need to fix the libsass version to the exact version. Should fix the failing `CI / CSS for HTML themes ` workflow.

We should also update libsass and re-generated the CSS files, but let's do that separately. I'd also like to know what actually changed about the CSS output.