### PR TITLE
Normalize the paths for `size_threshold_ignore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version [v1.6.1] - 2024-08-26
+
+### Fixed
+
+* The paths for `size_threshold_ignore` option of `Documenter.HTML` are now correctly normalized and no longer sensitive to platform-dependent differences in path separators. ([#2560], [#2561])
+
 ## Version [v1.6.0] - 2024-08-20
 
 ### Changed
@@ -1372,6 +1378,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v1.4.1]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.4.1
 [v1.5.0]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.5.0
 [v1.6.0]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.6.0
+[v1.6.1]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.6.1
 [#198]: https://github.com/JuliaDocs/Documenter.jl/issues/198
 [#245]: https://github.com/JuliaDocs/Documenter.jl/issues/245
 [#487]: https://github.com/JuliaDocs/Documenter.jl/issues/487
@@ -1874,6 +1881,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2514]: https://github.com/JuliaDocs/Documenter.jl/issues/2514
 [#2549]: https://github.com/JuliaDocs/Documenter.jl/issues/2549
 [#2551]: https://github.com/JuliaDocs/Documenter.jl/issues/2551
+[#2560]: https://github.com/JuliaDocs/Documenter.jl/issues/2560
+[#2561]: https://github.com/JuliaDocs/Documenter.jl/issues/2561
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Version [v1.6.1] - 2024-08-26
+## UNRELEASED
 
 ### Fixed
 
@@ -1378,7 +1378,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v1.4.1]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.4.1
 [v1.5.0]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.5.0
 [v1.6.0]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.6.0
-[v1.6.1]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.6.1
 [#198]: https://github.com/JuliaDocs/Documenter.jl/issues/198
 [#245]: https://github.com/JuliaDocs/Documenter.jl/issues/245
 [#487]: https://github.com/JuliaDocs/Documenter.jl/issues/487

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Documenter"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.6.0"
+version = "1.6.1"
 
 [deps]
 ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Documenter"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.6.1"
+version = "1.6.0"
 
 [deps]
 ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -564,6 +564,9 @@ struct HTML <: Documenter.Writer
             throw(ArgumentError("example_size_threshold must be non-negative, got $(example_size_threshold)"))
         end
         isa(edit_link, Default) && (edit_link = edit_link[])
+        # We use normpath() when we construct the .page value for NavNodes, so we also need to normpath()
+        # these values. This also ensures cross-platform compatibility of the values.
+        size_threshold_ignore = normpath.(size_threshold_ignore)
         new(prettyurls, disable_git, edit_link, repolink, canonical, assets, analytics,
             collapselevel, sidebar_sitename, highlights, mathengine, description, footer,
             ansicolor, lang, warn_outdated, prerender, node, highlightjs,

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -580,7 +580,7 @@ end
             root  = examples_root,
             build = "builds/sizethreshold-defaults-fail",
             source = "src.megapage",
-            format = Documenter.HTML(size_threshold_ignore = ["index.md"]),
+            format = Documenter.HTML(size_threshold_ignore = ["index.md", "subdir/subpage.md"]),
             debug = true,
         )
     catch e

--- a/test/examples/src.megapage/subdir/subpage.md
+++ b/test/examples/src.megapage/subdir/subpage.md
@@ -1,0 +1,20 @@
+# Megabytepage: subdir
+
+This page in a subdirectory has more than 1MB of HTML too.
+
+```@example
+using Random
+for s in Base.Iterators.partition(randstring(2^20), 80)
+    # Note: the join() is necessary to get strings (as opposed to Vector{Char} objects)
+    # on older Julia versions, since there was a breaking-ish bugfix that changed how
+    # Iterators.partition works with strings. join(::SubString) appears to basically be
+    # a no-op, so it has no real effect on newer Julia versions.
+    #
+    # https://github.com/JuliaLang/julia/issues/45768
+    # https://github.com/JuliaLang/julia/pull/46234
+    #
+    # Note: we _could_ also just print the vectors, but then the HTML files end up being
+    # ~14 MiB.
+    println(join(s))
+end
+```


### PR DESCRIPTION
Fix #2560. ~Also bumping to 1.6.1 immediately.~