### PR TITLE
Make user-agent for linkchecks customisable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASD
+
+### Added
+
+* The `User-Agent` header set in the linkcheck HTTP(S) requests can now be customized with the `linkcheck_useragent` option to `makedocs`. ([#2557], [#2562])
+
 ## Version [v1.6.0] - 2024-08-20
 
 ### Changed
@@ -1874,6 +1880,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2514]: https://github.com/JuliaDocs/Documenter.jl/issues/2514
 [#2549]: https://github.com/JuliaDocs/Documenter.jl/issues/2549
 [#2551]: https://github.com/JuliaDocs/Documenter.jl/issues/2551
+[#2557]: https://github.com/JuliaDocs/Documenter.jl/issues/2557
+[#2562]: https://github.com/JuliaDocs/Documenter.jl/issues/2562
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,15 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Version [v1.X.Y] - YYYY-MM-DD
-
-### Added
+## Version [v1.6.0] - 2024-08-20
 
 ### Changed
 
 * The MathJax3 setup now uses `tex-svg-full.js` and additionally draws in `mhchem` by default, allowing for chemistry symbols to be rendered (consistent with Pluto.jl). ([#2549])
 
 ### Fixed
+
+* Collapsing of docstrings in the HTML output can now only be triggered when clicking on the icon or the empty area only. ([#2204], [#2551])
 
 ## Version [v1.5.0] - 2024-06-26
 
@@ -34,7 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * The search prompt in the HTML output again correctly handles parenthesis and other special character that would previously cause the search to crash. ([#2513])
-* Collapsing of docstrings in the HTML output can now only be triggered when clicking on the icon or the empty area only. ([#2204], [#2551])
 
 ## Version [v1.4.1] - 2024-05-02
 
@@ -1372,6 +1371,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v1.4.0]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.4.0
 [v1.4.1]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.4.1
 [v1.5.0]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.5.0
+[v1.6.0]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.6.0
 [#198]: https://github.com/JuliaDocs/Documenter.jl/issues/198
 [#245]: https://github.com/JuliaDocs/Documenter.jl/issues/245
 [#487]: https://github.com/JuliaDocs/Documenter.jl/issues/487

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## UNRELEASD
+## UNRELEASED
 
 ### Added
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Documenter"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.5.0"
+version = "1.6.0"
 
 [deps]
 ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"

--- a/src/docchecks.jl
+++ b/src/docchecks.jl
@@ -191,6 +191,8 @@ function linkcheck(node::MarkdownAST.Node, element::MarkdownAST.AbstractElement,
     return nothing
 end
 
+const _LINKCHECK_DEFAULT_USERAGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36"
+
 function linkcheck(node::MarkdownAST.Node, link::MarkdownAST.Link, doc::Document; method::Symbol=:HEAD)
 
     # first, make sure we're not supposed to ignore this link

--- a/src/docchecks.jl
+++ b/src/docchecks.jl
@@ -203,6 +203,7 @@ function linkcheck(node::MarkdownAST.Node, link::MarkdownAST.Link, doc::Document
 
     if !haskey(doc.internal.locallinks, link)
         timeout = doc.user.linkcheck_timeout
+        useragent = doc.user.linkcheck_useragent
         null_file = @static Sys.iswindows() ? "nul" : "/dev/null"
         # In some cases, web servers (e.g. docs.github.com as of 2022) will reject requests
         # that declare a non-browser user agent (curl specifically passes 'curl/X.Y'). In
@@ -212,12 +213,17 @@ function linkcheck(node::MarkdownAST.Node, link::MarkdownAST.Link, doc::Document
         # Mozilla developer docs, but only is it's a HTTP(S) request.
         #
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent#chrome_ua_string
-        fakebrowser  = startswith(uppercase(link.destination), "HTTP") ? [
-            "--user-agent",
-            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
-            "-H",
-            "accept-encoding: gzip, deflate, br",
-        ] : ""
+        fakebrowser  = if startswith(uppercase(link.destination), "HTTP")
+            headers = [
+                "-H",
+                "accept-encoding: gzip, deflate, br",
+            ]
+            if !isempty(useragent)
+                push!(headers, "--user-agent", useragent)
+            end
+        else
+            ""
+        end
         cmd = `curl $(method === :HEAD ? "-sI" : "-s") --proto =http,https,ftp,ftps $(fakebrowser) $(link.destination) --max-time $timeout -o $null_file --write-out "%{http_code} %{url_effective} %{redirect_url}"`
 
         local result

--- a/src/documents.jl
+++ b/src/documents.jl
@@ -312,6 +312,7 @@ struct User
     linkcheck::Bool           # Check external links..
     linkcheck_ignore::Vector{Union{String,Regex}}  # ..and then ignore (some of) them.
     linkcheck_timeout::Real   # ..but only wait this many seconds for each one.
+    linkcheck_useragent::String  # User agent to use for linkchecks.
     checkdocs::Symbol         # Check objects missing from `@docs` blocks. `:none`, `:exports`, or `:all`.
     doctestfilters::Vector{Regex} # Filtering for doctests
     warnonly::Vector{Symbol}  # List of docerror groups that should only warn, rather than cause a build failure
@@ -385,6 +386,7 @@ function Document(;
         linkcheck:: Bool             = false,
         linkcheck_ignore :: Vector   = [],
         linkcheck_timeout :: Real    = 10,
+        linkcheck_useragent :: String= "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
         checkdocs::Symbol            = :all,
         doctestfilters::Vector{Regex}= Regex[],
         warnonly :: Union{Bool,Symbol,Vector{Symbol}} = Symbol[],
@@ -450,6 +452,7 @@ function Document(;
         linkcheck,
         linkcheck_ignore,
         linkcheck_timeout,
+        linkcheck_useragent,
         checkdocs,
         doctestfilters,
         warnonly,

--- a/src/documents.jl
+++ b/src/documents.jl
@@ -386,7 +386,7 @@ function Document(;
         linkcheck:: Bool             = false,
         linkcheck_ignore :: Vector   = [],
         linkcheck_timeout :: Real    = 10,
-        linkcheck_useragent :: String= "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
+        linkcheck_useragent :: String= _LINKCHECK_DEFAULT_USERAGENT,
         checkdocs::Symbol            = :all,
         doctestfilters::Vector{Regex}= Regex[],
         warnonly :: Union{Bool,Symbol,Vector{Symbol}} = Symbol[],

--- a/src/makedocs.jl
+++ b/src/makedocs.jl
@@ -192,6 +192,18 @@ ignored.
 **`linkcheck_timeout`** configures how long `curl` waits (in seconds) for a link request to
 return a response before giving up. The default is 10 seconds.
 
+**`linkcheck_useragent`** can be used to override the user agent string used by the HTTP and
+HTTPS requests made when checking for broken links. Currently, the default user agent is
+
+```
+$(_LINKCHECK_DEFAULT_USERAGENT)
+```
+
+which is set to mimic a realistic web browser. However, the exact user agent string is subject
+to change. As such, it is possible that breakages can occur when Documenter's version changes,
+but the goal is to set the user agent such that it would be accepted by as many web servers as
+possible.
+
 **`warnonly`** can be used to control whether the `makedocs` build fails with an error, or
 simply prints a warning if it detects any issues with the document. Additionally, a `Symbol`
 or a `Vector` of `Symbol`s can be passed to make Documenter warn for only those specified

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -435,7 +435,7 @@ else
 end
 
 # HTML: draft mode
-examples_html_local_doc = if "html-draft" in EXAMPLE_BUILDS
+examples_html_draft_doc = if "html-draft" in EXAMPLE_BUILDS
     @info("Building mock package docs: HTMLWriter / draft build")
     @quietly makedocs(
         debug = true,

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -416,6 +416,7 @@ examples_html_local_doc = if "html-local" in EXAMPLE_BUILDS
         repo = "https://dev.azure.com/org/project/_git/repo?path={path}&version={commit}{line}&lineStartColumn=1&lineEndColumn=1",
         linkcheck = true,
         linkcheck_ignore = [r"(x|y).md", "z.md", r":func:.*"],
+        linkcheck_useragent = "Documenter/1",
         format = Documenter.HTML(
             assets = [
                 "assets/custom.css",

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -363,8 +363,6 @@ end
             # .. but, crucially, Main.SVG_HTML did _not_ get written out.
             @test !isfile(joinpath(build_dir, "example-output", "$(SVG_BIG.hash_slug)-002.svg"))
         end
-
-        @test doc.user.linkcheck_useragent == Documenter._LINKCHECK_DEFAULT_USERAGENT
     end
 
     @testset "HTML: local" begin
@@ -454,6 +452,9 @@ end
             @test occursin("languages/julia.min", documenterjs)
             @test occursin("languages/julia-repl.min", documenterjs)
         end
+
+        # Testing linkcheck_useragent default
+        @test doc.user.linkcheck_useragent == Documenter._LINKCHECK_DEFAULT_USERAGENT
     end
 
     @testset "HTML: repo-*" begin

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -363,6 +363,9 @@ end
             # .. but, crucially, Main.SVG_HTML did _not_ get written out.
             @test !isfile(joinpath(build_dir, "example-output", "$(SVG_BIG.hash_slug)-002.svg"))
         end
+
+        # Testing linkcheck_useragent default
+        @test doc.user.linkcheck_useragent == Documenter._LINKCHECK_DEFAULT_USERAGENT
     end
 
     @testset "HTML: local" begin
@@ -452,9 +455,6 @@ end
             @test occursin("languages/julia.min", documenterjs)
             @test occursin("languages/julia-repl.min", documenterjs)
         end
-
-        # Testing linkcheck_useragent default
-        @test doc.user.linkcheck_useragent == Documenter._LINKCHECK_DEFAULT_USERAGENT
     end
 
     @testset "HTML: repo-*" begin

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -363,6 +363,8 @@ end
             # .. but, crucially, Main.SVG_HTML did _not_ get written out.
             @test !isfile(joinpath(build_dir, "example-output", "$(SVG_BIG.hash_slug)-002.svg"))
         end
+
+        @test doc.user.linkcheck_useragent == Documenter._LINKCHECK_DEFAULT_USERAGENT
     end
 
     @testset "HTML: local" begin
@@ -421,6 +423,10 @@ end
             # .. but, crucially, Main.SVG_HTML did _not_ get written out.
             @test !isfile(joinpath(build_dir, "example-output-$(SVG_BIG.hash_slug)-002.svg"))
         end
+
+        # It doesn't actually test that the user agent was used correctly, but at least it tests that
+        # the option go set.
+        @test doc.user.linkcheck_useragent == "Documenter/1"
     end
 
     @testset "HTML: pagesonly" begin


### PR DESCRIPTION
This should fix #2557.  Untested, also because I don't know how to use this new option, but I followed #1295 as a template to follow to add a custom user agent.