### PR TITLE
Fix linkcheck_useragent implementation and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* The `User-Agent` header set in the linkcheck HTTP(S) requests can now be customized with the `linkcheck_useragent` option to `makedocs`. ([#2557], [#2562])
+* The `User-Agent` header set in the linkcheck HTTP(S) requests can now be customized with the `linkcheck_useragent` option to `makedocs`. ([#2557], [#2562], [#2571])
 * Admonitions with category `todo` are now colored purple. Previously they were default-colored like all other unknown admonitions categories. ([#2526])
 * A `checkdocs_ignored_modules` keyword argument to `makedocs(...)`, which prevents `checkdocs` from warning about missing documentation in certain modules. ([#2233])
 
@@ -1896,6 +1896,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2560]: https://github.com/JuliaDocs/Documenter.jl/issues/2560
 [#2561]: https://github.com/JuliaDocs/Documenter.jl/issues/2561
 [#2562]: https://github.com/JuliaDocs/Documenter.jl/issues/2562
+[#2569]: https://github.com/JuliaDocs/Documenter.jl/issues/2569
+[#2571]: https://github.com/JuliaDocs/Documenter.jl/issues/2571
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/src/documents.jl
+++ b/src/documents.jl
@@ -312,7 +312,7 @@ struct User
     linkcheck::Bool           # Check external links..
     linkcheck_ignore::Vector{Union{String,Regex}}  # ..and then ignore (some of) them.
     linkcheck_timeout::Real   # ..but only wait this many seconds for each one.
-    linkcheck_useragent::String  # User agent to use for linkchecks.
+    linkcheck_useragent::Union{String, Nothing} # User agent to use for linkchecks.
     checkdocs::Symbol         # Check objects missing from `@docs` blocks. `:none`, `:exports`, or `:all`.
     checkdocs_ignored_modules::Vector{Module}  # ..and then ignore (some of) them.
     doctestfilters::Vector{Regex} # Filtering for doctests
@@ -387,7 +387,7 @@ function Document(;
         linkcheck:: Bool             = false,
         linkcheck_ignore :: Vector   = [],
         linkcheck_timeout :: Real    = 10,
-        linkcheck_useragent :: String= _LINKCHECK_DEFAULT_USERAGENT,
+        linkcheck_useragent :: Union{String, Nothing} = _LINKCHECK_DEFAULT_USERAGENT,
         checkdocs::Symbol            = :all,
         checkdocs_ignored_modules::Vector{Module} = Module[],
         doctestfilters::Vector{Regex}= Regex[],

--- a/src/documents.jl
+++ b/src/documents.jl
@@ -387,7 +387,7 @@ function Document(;
         linkcheck:: Bool             = false,
         linkcheck_ignore :: Vector   = [],
         linkcheck_timeout :: Real    = 10,
-        linkcheck_useragent :: Union{String, Nothing} = _LINKCHECK_DEFAULT_USERAGENT,
+        linkcheck_useragent :: Union{AbstractString, Nothing} = _LINKCHECK_DEFAULT_USERAGENT,
         checkdocs::Symbol            = :all,
         checkdocs_ignored_modules::Vector{Module} = Module[],
         doctestfilters::Vector{Regex}= Regex[],

--- a/src/makedocs.jl
+++ b/src/makedocs.jl
@@ -201,13 +201,17 @@ ignored.
 return a response before giving up. The default is 10 seconds.
 
 **`linkcheck_useragent`** can be used to override the user agent string used by the HTTP and
-HTTPS requests made when checking for broken links. Currently, the default user agent is
+HTTPS requests made when checking for broken links. If set to `nothing`, it uses the default
+user agent string of the library/tool used to actually perform the requests (currently, the
+system's `curl` binary).
+
+If unset, Documenter uses the following user agent string:
 
 ```
 $(_LINKCHECK_DEFAULT_USERAGENT)
 ```
 
-which is set to mimic a realistic web browser. However, the exact user agent string is subject
+This is set to mimic a realistic web browser. However, the exact user agent string is subject
 to change. As such, it is possible that breakages can occur when Documenter's version changes,
 but the goal is to set the user agent such that it would be accepted by as many web servers as
 possible.


### PR DESCRIPTION
* Changes the `linkcheck_useragent` value that unsets the customization completely to `nothing`.
* Fixes an error where linkcheck would throw when `linkcheck_useragent = ""` because the `if` block returns a `nothing` then.
* Apparently, Intel already blocked the new user agent or something. So reorganizing the tests around the fact that they want the `curl` user agent.