### PR TITLE
Follow symlinks when walking the docs directory

### DIFF
--- a/src/builder_pipeline.jl
+++ b/src/builder_pipeline.jl
@@ -94,7 +94,7 @@ function Selectors.runner(::Type{Builder.SetupBuildDirectory}, doc::Documenter.D
     # Markdown files, however, get added to the document and also stored into
     # `mdpages`, to be used later.
     mdpages = String[]
-    for (root, dirs, files) in walkdir(source)
+    for (root, dirs, files) in walkdir(source; follow_symlinks=true)
         for dir in dirs
             d = normpath(joinpath(build, relpath(root, source), dir))
             isdir(d) || mkdir(d)


### PR DESCRIPTION
This way external directories with a bunch of markdown files can be easily included.

This is not a perfect solution but it works surprisingly well in practice. We've been using it for some time in Oscar.jl via some hacky monkey-patching...