### PR TITLE
Add .git-blame-ignore-revs to ignore Runic formatting PR

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Applying the Runic formatter
+# https://github.com/JuliaDocs/Documenter.jl/pull/2591
+8ff48894e4692a95d405103a5c3515be6c7fcd48
+# https://github.com/JuliaDocs/Documenter.jl/pull/2564
+8dc39054746fe702d209506223a501ac0cbaf6c2


### PR DESCRIPTION
This way the formatting changes from https://github.com/JuliaDocs/Documenter.jl/pull/2591 (8ff48894e4692a95d405103a5c3515be6c7fcd48) should not show up in the Git blame.