### PR TITLE
Update URL for LiveServer.jl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -373,7 +373,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * For the `edit_link` keyword to `HTML()`, Documenter automatically tries to figure out if the remote default branch is `main`, `master`, or something else. It will print a warning if it is unable to reliably determine either `edit_link` or `devbranch` (for `deploydocs`). ([#1827], [#1829])
 
-* Profiling showed that a significant amount of the HTML page build time was due to external `git` commands (used to find remote URLs for docstrings). These results are now cached on a per-source-file basis resulting in faster build times. This is particularly useful when using [LiveServer.jl](https://github.com/tlienart/LiveServer.jl)s functionality for live-updating the docs while writing. ([#1838])
+* Profiling showed that a significant amount of the HTML page build time was due to external `git` commands (used to find remote URLs for docstrings). These results are now cached on a per-source-file basis resulting in faster build times. This is particularly useful when using [LiveServer.jl](https://github.com/JuliaDocs/LiveServer.jl)s functionality for live-updating the docs while writing. ([#1838])
 
 ## Version [v0.27.18] - 2022-05-25
 

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ There are several packages that extend Documenter in different ways. The JuliaDo
 * [DocumenterInterLinks.jl](https://github.com/JuliaDocs/DocumenterInterLinks.jl)
 * [DocumenterMarkdown.jl](https://github.com/JuliaDocs/DocumenterMarkdown.jl)
 * [DocumenterTools.jl](https://github.com/JuliaDocs/DocumenterTools.jl)
+* [LiveServer.jl](https://github.com/JuliaDocs/LiveServer.jl)
 
 Other third-party packages that can be combined with Documenter include:
 
 * [DemoCards.jl](https://github.com/JuliaDocs/DemoCards.jl)
 * [Literate.jl](https://github.com/fredrikekre/Literate.jl)
-* [LiveServer.jl](https://github.com/tlienart/LiveServer.jl)
 * [QuizQuestions.jl](https://github.com/jverzani/QuizQuestions.jl)
 * [DocumenterMermaid.jl](https://github.com/JuliaDocs/DocumenterMermaid.jl)
 * [DocumenterDiagrams.jl](https://github.com/pedromxavier/DocumenterDiagrams.jl)

--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -157,7 +157,7 @@ build/
     do not resolve directory URLs like `foo/` to `foo/index.html` for local files. To view
     the documentation locally, it is recommended that you run a local web server out of
     the `docs/build` directory. One way to accomplish this is to install the
-    [LiveServer](https://github.com/tlienart/LiveServer.jl) Julia package. You can then
+    [LiveServer](https://github.com/JuliaDocs/LiveServer.jl) Julia package. You can then
     start the server with `julia -e 'using LiveServer; serve(dir="docs/build")'`.
     Alternatively, if you have Python installed, you can start one with
     `python3 -m http.server --bind localhost`.

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -309,7 +309,7 @@ becomes `src/foo/index.html`, but can be accessed via `src/foo/` in the browser)
 structure is preferred when publishing the generated HTML files as a website (e.g., on
 GitHub Pages), which is Documenter's primary use case. However, when building locally,
 viewing the resulting pages requires a running webserver. It is recommended to use the
-[`LiveServer` package](https://github.com/tlienart/LiveServer.jl) for this.
+[`LiveServer` package](https://github.com/JuliaDocs/LiveServer.jl) for this.
 
 If `prettyurls = false`, then Documenter generates `src/foo.html` instead.
 


### PR DESCRIPTION
LiveServer.jl is now hosted on the JuliaDocs Github organization. This patch updates the URL to fix some linkchecks.