### PR TITLE
Test failing online check against a mock HTTP server

### DIFF
--- a/test/online/Project.toml
+++ b/test/online/Project.toml
@@ -1,7 +1,9 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 IOCapture = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
 MarkdownAST = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RegistryInstances = "2792f1a3-b283-48e8-9a74-f99dce5104f3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/test/online/online_linkcheck.jl
+++ b/test/online/online_linkcheck.jl
@@ -45,9 +45,11 @@ server = HTTP.serve!(lincheck_server_handler, PORT)
         # but now we use a mock HTTP server, to guarantee that the server's behavior doesn't change.
         src = convert(
             MarkdownAST.Node,
-            Markdown.parse("""
-            [Linkcheck Empty UA](http://localhost:$(PORT)/content/www/us/en/developer/tools/oneapi/mpi-library.html)
-            """)
+            Markdown.parse(
+                """
+                [Linkcheck Empty UA](http://localhost:$(PORT)/content/www/us/en/developer/tools/oneapi/mpi-library.html)
+                """
+            )
         )
 
         # The default user-agent fails (server blocks it, returns a 500)


### PR DESCRIPTION
This should fix the failing online linkcheck test.

We could/should probably move all these online tests over to such a mock server probably. And then we can maybe also include them as part of the normal test suite. But this was the minimum amount of work to get the test to pass again.