### PR TITLE
Fix nightly CI by fixing example docstring Markdown

### DIFF
--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -60,9 +60,9 @@ module Mod
         \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2}
         ```
 
-    Long equations in footnotes.[^longeq-footnote]
+    Long equations in footnotes.[^longeq_footnote]
 
-    [^longeq-footnote]:
+    [^longeq_footnote]:
 
         Inline: ``\frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2}``
 

--- a/test/examples/references/latex_showcase.tex
+++ b/test/examples/references/latex_showcase.tex
@@ -2,7 +2,7 @@
 \newcommand{\DocMainTitle}{Documenter LaTeX Showcase}
 \newcommand{\DocVersion}{1.2.3}
 \newcommand{\DocAuthors}{}
-\newcommand{\JuliaVersion}{1.9.3}
+\newcommand{\JuliaVersion}{1.11.1}
 
 % ---- Insert preamble
 \input{preamble.tex}
@@ -1235,21 +1235,15 @@ Display equation:
 \begin{equation*}
 \begin{split}\frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2}\end{split}\end{equation*}
 \end{tcolorbox}
-Long equations in footnotes.[{\textasciicircum}longeq-footnote]
+Long equations in footnotes.\footnotemark[1]
 
-[{\textasciicircum}longeq-footnote]:
-
-
-\begin{minted}{text}
-Inline: ``\frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2}``
+\footnotetext[1]{Inline: \(\frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2}\)
 
 Display equation:
 
-```math
-\frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2}
-```
-\end{minted}
-
+\begin{equation*}
+\begin{split}\frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2} + \frac{1+2+3+4+5+6}{\sigma^2}\end{split}\end{equation*}
+}
 
 
 \href{https://example.org/Repository.jl/blob/make.jl#L44-74}{\texttt{source}}

--- a/test/examples/references/latex_simple.tex
+++ b/test/examples/references/latex_simple.tex
@@ -2,7 +2,7 @@
 \newcommand{\DocMainTitle}{Documenter LaTeX Simple Non-Docker}
 \newcommand{\DocVersion}{1.2.3}
 \newcommand{\DocAuthors}{}
-\newcommand{\JuliaVersion}{1.9.3}
+\newcommand{\JuliaVersion}{1.11.1}
 
 % ---- Insert preamble
 \input{preamble.tex}


### PR DESCRIPTION
So apparently we're not allowed to have hyphens in footnote names. So the docstring actually got interpreted as an (indented) code block. This fixes the footnote.

Incidentally, this will remove the code block that has its info string changing due to (https://github.com/JuliaLang/julia/pull/55465), and so I'd expect nightly to pass now.