### PR TITLE
Update guide.md: `remotes=nothing` kwarg for local packages

### DIFF
--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -85,7 +85,9 @@ makedocs(sitename="My Documentation")
 ```
 
 This assumes you've installed Documenter as discussed in [Installation](@ref) and that your
-`Example.jl` package can be found by Julia.
+`Example.jl` package can be found by Julia. If your package has been added as a dev
+dependency using its local path rather than a remote git repository, you need to add the
+keyword argument `remotes = nothing` to the function `makedocs`.
 
 !!! note
 


### PR DESCRIPTION
The user guide now mentions how to build docs for local packages without a git remote, following the comment of
https://github.com/JuliaDocs/Documenter.jl/issues/2585#issuecomment-2391161531