### PR TITLE
Support substitutions in doctestfilters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+* `makedocs` and `doctest` now accept regex/substitution pairs in `doctestfilters`. ([#2619])
+
 ## Version [v1.8.0] - 2024-11-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* `makedocs` and `doctest` now accept regex/substitution pairs in `doctestfilters`. ([#2619])
+* `makedocs` and `doctest` now accept regex/substitution pairs in `doctestfilters`. ([#2360], [#2619])
 
 ### Changed
 
@@ -1893,6 +1893,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2339]: https://github.com/JuliaDocs/Documenter.jl/issues/2339
 [#2344]: https://github.com/JuliaDocs/Documenter.jl/issues/2344
 [#2348]: https://github.com/JuliaDocs/Documenter.jl/issues/2348
+[#2360]: https://github.com/JuliaDocs/Documenter.jl/issues/2360
 [#2364]: https://github.com/JuliaDocs/Documenter.jl/issues/2364
 [#2365]: https://github.com/JuliaDocs/Documenter.jl/issues/2365
 [#2366]: https://github.com/JuliaDocs/Documenter.jl/issues/2366
@@ -1935,6 +1936,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2592]: https://github.com/JuliaDocs/Documenter.jl/issues/2592
 [#2593]: https://github.com/JuliaDocs/Documenter.jl/issues/2593
 [#2610]: https://github.com/JuliaDocs/Documenter.jl/issues/2610
+[#2619]: https://github.com/JuliaDocs/Documenter.jl/issues/2619
 [#2621]: https://github.com/JuliaDocs/Documenter.jl/issues/2621
 [#2622]: https://github.com/JuliaDocs/Documenter.jl/issues/2622
 [#2624]: https://github.com/JuliaDocs/Documenter.jl/issues/2624

--- a/src/doctest.jl
+++ b/src/doctest.jl
@@ -51,7 +51,7 @@ manual pages can be disabled if `source` is set to `nothing`.
 
 **`testset`** specifies the name of test testset (default `"Doctests"`).
 
-**`doctestfilters`** vector of regex to filter tests (see the manual on [Filtering Doctests](@ref))
+**`doctestfilters`** vector of regex or regex/substitution pairs to filter tests (see the manual on [Filtering Doctests](@ref))
 
 **`fix`**, if set to `true`, updates all the doctests that fail with the correct output
 (default `false`).

--- a/src/documents.jl
+++ b/src/documents.jl
@@ -1,5 +1,7 @@
 # Defines [`Document`](@ref) and its supporting types
 
+const DOCTESTFILTER_TYPE = Union{Regex, Pair{Regex, <:AbstractString}}
+
 # When processing the AST during the build, in the MarkdownAST representation, we
 # replace various code blocks etc. with Documenter-specific elements that the writers
 # then can dispatch on. All the Documenter elements are subtypes of this node.
@@ -319,7 +321,7 @@ struct User
     linkcheck_useragent::Union{String, Nothing} # User agent to use for linkchecks.
     checkdocs::Symbol # Check objects missing from `@docs` blocks. `:none`, `:exports`, or `:all`.
     checkdocs_ignored_modules::Vector{Module} # ..and then ignore (some of) them.
-    doctestfilters::Vector{Regex} # Filtering for doctests
+    doctestfilters::Vector{<:DOCTESTFILTER_TYPE} # Filtering for doctests
     warnonly::Vector{Symbol} # List of docerror groups that should only warn, rather than cause a build failure
     pages::Vector{Any} # Ordering of document pages specified by the user.
     pagesonly::Bool # Discard any .md pages from processing that are not in .pages
@@ -394,7 +396,7 @@ function Document(;
         linkcheck_useragent::Union{AbstractString, Nothing} = _LINKCHECK_DEFAULT_USERAGENT,
         checkdocs::Symbol = :all,
         checkdocs_ignored_modules::Vector{Module} = Module[],
-        doctestfilters::Vector{Regex} = Regex[],
+        doctestfilters::Vector{<:DOCTESTFILTER_TYPE} = Regex[],
         warnonly::Union{Bool, Symbol, Vector{Symbol}} = Symbol[],
         modules::Union{Module, Vector{Module}} = Module[],
         pages::Vector = Any[],

--- a/src/documents.jl
+++ b/src/documents.jl
@@ -1,7 +1,5 @@
 # Defines [`Document`](@ref) and its supporting types
 
-const DOCTESTFILTER_TYPE = Union{Regex, Pair{Regex, <:AbstractString}}
-
 # When processing the AST during the build, in the MarkdownAST representation, we
 # replace various code blocks etc. with Documenter-specific elements that the writers
 # then can dispatch on. All the Documenter elements are subtypes of this node.
@@ -321,7 +319,7 @@ struct User
     linkcheck_useragent::Union{String, Nothing} # User agent to use for linkchecks.
     checkdocs::Symbol # Check objects missing from `@docs` blocks. `:none`, `:exports`, or `:all`.
     checkdocs_ignored_modules::Vector{Module} # ..and then ignore (some of) them.
-    doctestfilters::Vector{<:DOCTESTFILTER_TYPE} # Filtering for doctests
+    doctestfilters::Vector{<:Any} # Filtering for doctests
     warnonly::Vector{Symbol} # List of docerror groups that should only warn, rather than cause a build failure
     pages::Vector{Any} # Ordering of document pages specified by the user.
     pagesonly::Bool # Discard any .md pages from processing that are not in .pages
@@ -396,7 +394,7 @@ function Document(;
         linkcheck_useragent::Union{AbstractString, Nothing} = _LINKCHECK_DEFAULT_USERAGENT,
         checkdocs::Symbol = :all,
         checkdocs_ignored_modules::Vector{Module} = Module[],
-        doctestfilters::Vector{<:DOCTESTFILTER_TYPE} = Regex[],
+        doctestfilters::Vector{<:Any} = Regex[],
         warnonly::Union{Bool, Symbol, Vector{Symbol}} = Symbol[],
         modules::Union{Module, Vector{Module}} = Module[],
         pages::Vector = Any[],

--- a/test/doctests/doctestapi.jl
+++ b/test/doctests/doctestapi.jl
@@ -289,7 +289,7 @@ module BadDocTestKwargs3 end
     end
 
     # DoctestFilters
-    df = [r"global (filter|FILTER)"]
+    df = [r"global (filt|FILT)(er|ER)" => s"global \1", r"global (filt|FILT)"]
     run_doctest(nothing, [DoctestFilters], doctestfilters = df) do result, success, backtrace, output
         @test success
     end


### PR DESCRIPTION
As noted in #2360, `doctestfilters` currently only supports vectors of `Regex`, while `filters` supports vectors including regex/substitution pairs. This PR fixes #2360, supporting substitutions also in `doctestfilters`.