### PR TITLE
Follow symlinks when walking the docs directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+* Symlinks are now followed when walking the docs directory. ([#2610])
+
 ## Version [v1.8.0] - 2024-11-07
 
 ### Changed

--- a/src/builder_pipeline.jl
+++ b/src/builder_pipeline.jl
@@ -94,7 +94,7 @@ function Selectors.runner(::Type{Builder.SetupBuildDirectory}, doc::Documenter.D
     # Markdown files, however, get added to the document and also stored into
     # `mdpages`, to be used later.
     mdpages = String[]
-    for (root, dirs, files) in walkdir(source; follow_symlinks=true)
+    for (root, dirs, files) in walkdir(source; follow_symlinks = true)
         for dir in dirs
             d = normpath(joinpath(build, relpath(root, source), dir))
             isdir(d) || mkdir(d)

--- a/src/builder_pipeline.jl
+++ b/src/builder_pipeline.jl
@@ -94,7 +94,7 @@ function Selectors.runner(::Type{Builder.SetupBuildDirectory}, doc::Documenter.D
     # Markdown files, however, get added to the document and also stored into
     # `mdpages`, to be used later.
     mdpages = String[]
-    for (root, dirs, files) in walkdir(source)
+    for (root, dirs, files) in walkdir(source; follow_symlinks=true)
         for dir in dirs
             d = normpath(joinpath(build, relpath(root, source), dir))
             isdir(d) || mkdir(d)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,10 @@ end
     @info "Building example/make.jl"
     include("examples/make.jl")
 
+    # Build the symlinked example docs
+    @info "Building symlinks/make.jl"
+    include("symlinks/tests.jl")
+
     # Test missing docs
     @info "Building missingdocs/make.jl"
     include("missingdocs/make.jl")

--- a/test/symlinks/extra/other_real.md
+++ b/test/symlinks/extra/other_real.md
@@ -1,0 +1,9 @@
+# Other Testing
+
+Here's another test
+
+```@repl
+pwd()
+
+touch("root_index.txt")
+```

--- a/test/symlinks/src/index.md
+++ b/test/symlinks/src/index.md
@@ -1,0 +1,9 @@
+# Testing
+
+Here's a test
+
+```@repl
+pwd()
+
+touch("root_index.txt")
+```

--- a/test/symlinks/src/other.md
+++ b/test/symlinks/src/other.md
@@ -1,0 +1,1 @@
+../extra/other_real.md

--- a/test/symlinks/tests.jl
+++ b/test/symlinks/tests.jl
@@ -1,0 +1,20 @@
+using Documenter
+
+const pages = [
+    "Home" => "index.md",
+    "File" => "other.md",
+]
+
+@info "Building symlinks based docu"
+makedocs(sitename = "Test", pages = pages)
+
+@info "Testing symlinks"
+@testset "Symlinks" begin
+    # check that the symlinked page is built at all
+    @test isdir("symlinks/build/other")
+    @test isfile("symlinks/build/other/index.html")
+
+    # check that it contains what we want
+    filecontents = read("symlinks/build/other/index.html", String)
+    @test occursin("another test", filecontents)
+end

--- a/test/symlinks/tests.jl
+++ b/test/symlinks/tests.jl
@@ -5,10 +5,8 @@ const pages = [
     "File" => "other.md",
 ]
 
-@info "Building symlinks based docu"
-makedocs(sitename = "Test", pages = pages)
+@quietly makedocs(sitename = "Test", pages = pages)
 
-@info "Testing symlinks"
 @testset "Symlinks" begin
     # check that the symlinked page is built at all
     @test isdir("symlinks/build/other")


### PR DESCRIPTION
Succeeds #2573 .

I couldn't figure out an elegant way to do this, so I copied an existing test, and changed its page contents to be symlinks.

The test I have added does work, but issues a lot of warnings about overwriting modules and methods.

```
WARNING: replacing module Mod.
WARNING: replacing module AutoDocs.
WARNING: Method definition (::Type{Main.MIMEBytes{M} where M<:(Base.Multimedia.MIME{mime} where mime)})(AbstractString, AbstractArray{UInt8, 1}) in module Main at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/examples/make.jl:152 overwritten at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/symlinks/make.jl:152.
WARNING: Method definition show(IO, M, Main.MIMEBytes{M}) where {M<:(Base.Multimedia.MIME{mime} where mime)} in module Main at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/examples/make.jl:157 overwritten at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/symlinks/make.jl:157.
WARNING: redefinition of constant Main.AT_EXAMPLE_FILES. This may fail, cause incorrect answers, or produce other errors.
WARNING: Method definition (::Type{Main.MultiMIMESVG})(AbstractArray{UInt8, 1}) in module Main at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/examples/make.jl:173 overwritten at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/symlinks/make.jl:173.
WARNING: Method definition show(IO, Base.Multimedia.MIME{Symbol("image/svg+xml")}, Main.MultiMIMESVG) in module Main at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/examples/make.jl:178 overwritten at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/symlinks/make.jl:178.
WARNING: Method definition show(IO, Base.Multimedia.MIME{Symbol("text/html")}, Main.MultiMIMESVG) in module Main at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/examples/make.jl:179 overwritten at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/symlinks/make.jl:179.
WARNING: Method definition withassets(Any, Any...) in module Main at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/examples/make.jl:183 overwritten at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/symlinks/make.jl:183.
WARNING: Method definition (::Type{Main.TestRemote})() in module Main at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/examples/make.jl:203 overwritten at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/symlinks/make.jl:203.
WARNING: Method definition repourl(Main.TestRemote) in module Main at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/examples/make.jl:204 overwritten at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/symlinks/make.jl:204.
WARNING: Method definition fileurl(Main.TestRemote, Any, Any, Any) in module Main at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/examples/make.jl:205 overwritten at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/symlinks/make.jl:205.
WARNING: Method definition issueurl(Main.TestRemote, Any) in module Main at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/examples/make.jl:209 overwritten at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/symlinks/make.jl:209.
WARNING: Method definition html_doc(Any, Any) in module Main at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/examples/make.jl:260 overwritten at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/symlinks/make.jl:260.
WARNING: Method definition kwcall(NamedTuple{names, T} where T<:Tuple where names, typeof(Main.html_doc), Any, Any) in module Main at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/examples/make.jl:260 overwritten at /home/aaruni/Programs/git/GitHub/Documenter.jl/test/symlinks/make.jl:260.

```

cc @fingolfin 