### PR TITLE
Delete unused struct MethodNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Symlinks are now followed when walking the docs directory. ([#2610])
 * PDF/LaTeX builds now throw a more informative error when `sitename` is not provided. ([#2636])
-* Removed unused struct `MethodNode`.
 
 ## Version [v1.8.1] - 2025-02-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Symlinks are now followed when walking the docs directory. ([#2610])
 * PDF/LaTeX builds now throw a more informative error when `sitename` is not provided. ([#2636])
+* Removed unused struct `MethodNode`.
 
 ## Version [v1.8.1] - 2025-02-11
 

--- a/src/documents.jl
+++ b/src/documents.jl
@@ -148,11 +148,6 @@ struct MetaNode <: AbstractDocumenterBlock
     dict::Dict{Symbol, Any}
 end
 
-struct MethodNode
-    method::Method
-    visible::Bool
-end
-
 struct DocsNode <: AbstractDocumenterBlock
     anchor::Anchor
     object::Object


### PR DESCRIPTION
The struct `MethodNode` appears to be unused. Deleting the struct and running `make test` in `Documenter.jl` appears to produce no errors:

```
Test Summary: | Pass  Total     Time
Documenter    | 2553   2553  3m15.3s
     Testing Documenter tests passed
```