### PR TITLE
When fixing doctests with errors, don't overwrite `[...]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The solution is to remove the duplicate inclusion.
 
 * `checkdocs` has a new option `:public` to check that unexported symbols marked with `public` are included in the docs. ([#2629])
+* Fixing doctests that use `[...]` to hide part of an error message (such as a stacktrace) no longer replaces the `[...]` if the output otherwise matches ([#2642])
 
 ## Version [v1.8.1] - 2025-02-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The solution is to remove the duplicate inclusion.
 
 * `checkdocs` has a new option `:public` to check that unexported symbols marked with `public` are included in the docs. ([#2629])
-* Fixing doctests that use `[...]` to hide part of an error message (such as a stacktrace) no longer replaces the `[...]` if the output otherwise matches ([#2642])
+* Fixing doctests that use `[...]` to hide part of an error message (such as a stacktrace) no longer replaces the `[...]` if the output otherwise matches ([#2511], [#2642])
 
 ## Version [v1.8.1] - 2025-02-11
 
@@ -1930,6 +1930,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2496]: https://github.com/JuliaDocs/Documenter.jl/issues/2496
 [#2497]: https://github.com/JuliaDocs/Documenter.jl/issues/2497
 [#2499]: https://github.com/JuliaDocs/Documenter.jl/issues/2499
+[#2511]: https://github.com/JuliaDocs/Documenter.jl/issues/2511
 [#2513]: https://github.com/JuliaDocs/Documenter.jl/issues/2513
 [#2514]: https://github.com/JuliaDocs/Documenter.jl/issues/2514
 [#2526]: https://github.com/JuliaDocs/Documenter.jl/issues/2526
@@ -1950,6 +1951,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2624]: https://github.com/JuliaDocs/Documenter.jl/issues/2624
 [#2629]: https://github.com/JuliaDocs/Documenter.jl/issues/2629
 [#2636]: https://github.com/JuliaDocs/Documenter.jl/issues/2636
+[#2642]: https://github.com/JuliaDocs/Documenter.jl/issues/2642
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/src/doctests.jl
+++ b/src/doctests.jl
@@ -341,7 +341,13 @@ function checkresult(sandbox::Module, result::Result, meta::Dict, doc::Documente
         if isempty(head) || !startswith(filteredstr, filteredhead) ||
                 (doc.user.doctest === :fix && filteredstr != filteredhead)
             if doc.user.doctest === :fix
-                fix_doctest(result, str, doc; prefix)
+                # special case: if everything matched prior to filtering, except for a
+                # trailing "[...]" in the reference string, then don't "fix" this but
+                # rather assume this is intentionally cutting off part of the output
+                # resp. stacktrace
+                if !(startswith(str, head) && endswith(result.output, "[...]"))
+                    fix_doctest(result, str, doc; prefix)
+                end
             else
                 report(result, str, doc)
                 @debug "Doctest metadata" meta

--- a/test/doctests/fix/broken.md
+++ b/test/doctests/fix/broken.md
@@ -115,3 +115,8 @@ julia> a = ("a", "b", "c");
 
 julia> a
 ```
+```jldoctest
+julia> :a / :b
+ERROR: MethodError: no method matching /(::Symbol, ::Symbol)
+[...]
+```

--- a/test/doctests/fix/fixed.md
+++ b/test/doctests/fix/fixed.md
@@ -133,3 +133,8 @@ julia> a = ("a", "b", "c");
 julia> a
 ("a", "b", "c")
 ```
+```jldoctest
+julia> :a / :b
+ERROR: MethodError: no method matching /(::Symbol, ::Symbol)
+[...]
+```


### PR DESCRIPTION
Sometimes it is useful to show errors in doctests. However if those contain stacktraces, this can be problematic as those contain line numbers which will change over time (and often also when e.g. Julia or some dependencies change). And sometimes it is simply desirable to shorten the error message for other reasons.

For this reason Documenter supports replacing part of the error message with `[...]` which can be used to omit e.g. a stacktrace while still passing doctest checks.

However so far using Documenter's `doctest=:fix` feature would replace all uses of `[...]` by the full error message, making it unnecessarily tedious to update doctests in packages that use this feature.

This patch changes that by skipping doctest fixups for tests where the reference output ends with `[...]` and otherwise matches the actual error message as a prefix.

Resolves #2511

CC @thofma 