### PR TITLE
CI: only run one CI test set per pull request

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,14 @@ on:
     tags: '*'
   pull_request:
   workflow_dispatch:
+
+concurrency:
+  # group by workflow and ref; the last slightly strange component ensures that for pull
+  # requests, we limit to 1 concurrent job, but for the master branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  # Cancel intermediate builds, but only if it is a pull request build.
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}


### PR DESCRIPTION
Right now if I quickly push N times to a pull request branch this triggers N runs of the CI tests -- even though only the one corresponding to the final push is relevant.

With this patch GitHub will automatically cancel previous running or scheduled CI runs for a pull request whenever it gets updated.

We've been using this on a bunch of repositories for years now, including Oscar.jl