### PR TITLE
Fix `Error: HTMLWriter: prerendering failed` on Windows (`MODULE_NOT_FOUND`)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -114,8 +114,14 @@ jobs:
         run: julia --color=yes --project=assets/html assets/html/verify.jl
 
   prerender:
-    name: "NodeJS for prerender"
-    runs-on: ubuntu-latest
+    name: "NodeJS for prerender - ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * The breadcrumb in the HTML output will not show a spurious scrollbar anymore. ([#2648], [#2652])
+* The syntax highlight pre-rendering now correctly works on Windows. ([#2649])
 
 ### Fixed
 
@@ -1964,6 +1965,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2636]: https://github.com/JuliaDocs/Documenter.jl/issues/2636
 [#2642]: https://github.com/JuliaDocs/Documenter.jl/issues/2642
 [#2648]: https://github.com/JuliaDocs/Documenter.jl/issues/2648
+[#2649]: https://github.com/JuliaDocs/Documenter.jl/issues/2649
 [#2651]: https://github.com/JuliaDocs/Documenter.jl/issues/2651
 [#2652]: https://github.com/JuliaDocs/Documenter.jl/issues/2652
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -609,6 +609,9 @@ function prepare_prerendering(prerender, node, highlightjs, highlights)
         key = join((x.first for x in libs), ',')
         highlightjs = get!(HLJSFILES, key) do
             path, io = mktemp()
+            # The path will be used as module path to be loaded by Node.js,
+            # so we always need `/`. But on Windows, `mktemp` will give `\`.
+            path = replace(path, '\\' => '/')
             for lib in libs
                 println(io, "// $(lib.first)")
                 run(pipeline(`$(curl) -fsSL $(lib.second.url)`; stdout = io))


### PR DESCRIPTION

```julia
┌ Error: HTMLWriter: prerendering failed
│   exception =
│    failed process: Process(`'~\scoop\apps\nodejs-lts\current\node.exe' -e "const hljs = require('~\AppData\Local\Temp\jl_42F8.tmp');
│    console.log(hljs.highlight(\"***\", {'language': \"julia\"}).value);
│    "`, ProcessExited(1)) [1]
│
│   stderr = "node:internal/modules/cjs/loader:1228\r\n  throw err;\r\n  ^\r\n\r\nError: Cannot find module '***AppDataLocalTempjl_42F8.tmp'\r\nRequire stack:\r\n- ***\\docs\\[eval]\r\n    at Function._resolveFilename (node:internal/modules/cjs/loader:1225:15)\r\n    at Function._load (node:internal/modules/cjs/loader:1055:27)\r\n    at TracingChannel.traceSync (node:diagnostics_channel:322:14)\r\n    at wrapModuleLoad (node:internal/modules/cjs/loader:220:24)\r\n    at Module.require (node:internal/modules/cjs/loader:1311:12)\r\n    at require (node:internal/modules/helpers:136:16)\r\n    at [eval]:1:14\r\n    at runScriptInThisContext (node:internal/vm:209:10)\r\n    at node:internal/process/execution:449:12\r\n    at [eval]-wrapper:6:24 {\r\n  code: 'MODULE_NOT_FOUND',\r\n  requireStack: [ '***\\\\docs\\\\[eval]' ]\r\n}\r\n\r\nNode.js v22.14.0\r\n"
└ @ Documenter.HTMLWriter ~\.julia\packages\Documenter\iwb7N\src\html\HTMLWriter.jl:2218
```

```julia
┌ Error: HTMLWriter: prerendering failed
│   exception =
│    failed process: Process(`'~\scoop\apps\nodejs-lts\current\node.exe' -e "const hljs = require('~\AppData\Local\Temp\jl_42F8.tmp');
│    console.log(hljs.highlight(\"***\", {'language': \"julia-repl\"}).value);
│    "`, ProcessExited(1)) [1]
│
│   stderr = "node:internal/modules/cjs/loader:1228\r\n  throw err;\r\n  ^\r\n\r\nError: Cannot find module '***AppDataLocalTempjl_42F8.tmp'\r\nRequire stack:\r\n- ***\\docs\\[eval]\r\n    at Function._resolveFilename (node:internal/modules/cjs/loader:1225:15)\r\n    at Function._load (node:internal/modules/cjs/loader:1055:27)\r\n    at TracingChannel.traceSync (node:diagnostics_channel:322:14)\r\n    at wrapModuleLoad (node:internal/modules/cjs/loader:220:24)\r\n    at Module.require (node:internal/modules/cjs/loader:1311:12)\r\n    at require (node:internal/modules/helpers:136:16)\r\n    at [eval]:1:14\r\n    at runScriptInThisContext (node:internal/vm:209:10)\r\n    at node:internal/process/execution:449:12\r\n    at [eval]-wrapper:6:24 {\r\n  code: 'MODULE_NOT_FOUND',\r\n  requireStack: [ '***\\\\docs\\\\[eval]' ]\r\n}\r\n\r\nNode.js v22.14.0\r\n"
└ @ Documenter.HTMLWriter ~\.julia\packages\Documenter\iwb7N\src\html\HTMLWriter.jl:2218
```

```julia
julia> let stderr = "node:internal/modules/cjs/loader:1228\r\n  throw err;\r\n  ^\r\n\r\nError: Cannot find module '***AppDataLocalTempjl_42F8.tmp'\r\nRequire stack:\r\n- ***\\docs\\[eval]\r\n    at Function._resolveFilename (node:internal/modules/cjs/loader:1225:15)\r\n    at Function._load (node:internal/modules/cjs/loader:1055:27)\r\n    at TracingChannel.traceSync (node:diagnostics_channel:322:14)\r\n    at wrapModuleLoad (node:internal/modules/cjs/loader:220:24)\r\n    at Module.require (node:internal/modules/cjs/loader:1311:12)\r\n    at require (node:internal/modules/helpers:136:16)\r\n    at [eval]:1:14\r\n    at runScriptInThisContext (node:internal/vm:209:10)\r\n    at node:internal/process/execution:449:12\r\n    at [eval]-wrapper:6:24 {\r\n  code: 'MODULE_NOT_FOUND',\r\n  requireStack: [ '***\\\\docs\\\\[eval]' ]\r\n}\r\n\r\nNode.js v22.14.0\r\n"
       print(stderr)
       end
node:internal/modules/cjs/loader:1228
  throw err;
  ^

Error: Cannot find module '***AppDataLocalTempjl_42F8.tmp'
Require stack:
- ***\docs\[eval]
    at Function._resolveFilename (node:internal/modules/cjs/loader:1225:15)
    at Function._load (node:internal/modules/cjs/loader:1055:27)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:220:24)
    at Module.require (node:internal/modules/cjs/loader:1311:12)
    at require (node:internal/modules/helpers:136:16)
    at [eval]:1:14
    at runScriptInThisContext (node:internal/vm:209:10)
    at node:internal/process/execution:449:12
    at [eval]-wrapper:6:24 {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '***\\docs\\[eval]' ]
}

Node.js v22.14.0
```

```julia
(docs) pkg> status Documenter
Status `***\docs\Project.toml`
  [e30172f5] Documenter v1.8.1
```

Ref: #1627.

