### PR TITLE
Keep cursor in search box when adjusting filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-* Now the cursor remain focused on search box even after selecting the filter ([#2410])
+## Changed
+
+* Now the cursor remain focused on search box even after selecting the filter. ([#2410])
 
 ## Version [v1.9.0] - 2025-03-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# Unreleased
+
+* Now the cursor remain focused on search box even after selecting the filter ([#2410])
+
 ## Version [v1.9.0] - 2025-03-17
 
 ### Added
@@ -1924,6 +1928,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2394]: https://github.com/JuliaDocs/Documenter.jl/issues/2394
 [#2406]: https://github.com/JuliaDocs/Documenter.jl/issues/2406
 [#2408]: https://github.com/JuliaDocs/Documenter.jl/issues/2408
+[#2410]: https://github.com/JuliaDocs/Documenter.jl/issues/2410
 [#2414]: https://github.com/JuliaDocs/Documenter.jl/issues/2414
 [#2415]: https://github.com/JuliaDocs/Documenter.jl/issues/2415
 [#2424]: https://github.com/JuliaDocs/Documenter.jl/issues/2424

--- a/assets/html/js/search.js
+++ b/assets/html/js/search.js
@@ -463,6 +463,9 @@ function runSearchMainCode() {
   };
 
   $(document).on("click", ".search-filter", function () {
+    let search_input = $(".documenter-search-input");
+    let cursor_position = search_input[0].selectionStart;
+
     if ($(this).hasClass("search-filter-selected")) {
       selected_filter = "";
     } else {
@@ -471,6 +474,9 @@ function runSearchMainCode() {
 
     // This updates search results and toggles classes for UI:
     update_search();
+
+    search_input.focus();
+    search_input.setSelectionRange(cursor_position, cursor_position);
   });
 
   /**


### PR DESCRIPTION
I just saved the state of the cursor and the value of input box and after selecting the filter bring back the focus to the search box and to the correct cursor position.

Works fine locally on my device

Resolves #2410