### PR TITLE
Reduce memory usage when using many pages with examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Don't require custom themes to set a color for the 'todo' admonition. ([#2576])
 * Entries in `@repl` blocks that were hidden with `# hide` no longer produce erroneous empty lines ([#1521], [#2054], [#2399])
+* Reduce memory usage when there are many pages with doctests and examples, by clearing out the "sandbox" modules used for running the code, allowing the garbage collector to reclaim memory. ([#2640])
 
 ## Version [v1.9.0] - 2025-03-17
 
@@ -1984,6 +1985,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2624]: https://github.com/JuliaDocs/Documenter.jl/issues/2624
 [#2629]: https://github.com/JuliaDocs/Documenter.jl/issues/2629
 [#2636]: https://github.com/JuliaDocs/Documenter.jl/issues/2636
+[#2640]: https://github.com/JuliaDocs/Documenter.jl/issues/2640
 [#2642]: https://github.com/JuliaDocs/Documenter.jl/issues/2642
 [#2646]: https://github.com/JuliaDocs/Documenter.jl/issues/2646
 [#2648]: https://github.com/JuliaDocs/Documenter.jl/issues/2648

--- a/test/clear_module/src/index.md
+++ b/test/clear_module/src/index.md
@@ -1,0 +1,23 @@
+# Testing
+
+We set up some test code and create an object with a finalizer.
+
+```@setup
+@eval Main finalizer_count = [0]
+
+mutable struct MyMutableStruct
+  bar
+  function MyMutableStruct(bar)
+      x = new(bar)
+      finalizer(x) do y
+        Main.finalizer_count[1] += 1
+      end
+  end
+end
+
+a = MyMutableStruct(1)
+```
+
+Once Documenter is finished processing this page, it should remove the
+reference to the object `a` and a subsequent garbage collection should free
+it, which we can later test by observing the value of `Main.finalizer_count`.

--- a/test/clear_module/tests.jl
+++ b/test/clear_module/tests.jl
@@ -1,0 +1,15 @@
+using Documenter
+using Test
+
+const pages = [
+    "Home" => "index.md",
+]
+
+makedocs(sitename = "Test", pages = pages, doctest = true)
+
+@testset "clear_modules!" begin
+    # force a full GC
+    GC.gc(true)
+    # check that the finalizer was run
+    @test Main.finalizer_count[1] == 1
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,6 +94,10 @@ end
     @info "Building workdir/tests.jl"
     @quietly include("workdir/tests.jl")
 
+    # A simple build verifying that sandbox modules are cleared at the end of each page
+    @info "Building clear_module/tests.jl"
+    @quietly include("clear_module/tests.jl")
+
     # Passing a writer positionally (https://github.com/JuliaDocs/Documenter.jl/issues/1046)
     @test_throws MethodError makedocs(sitename = "", HTML())
 


### PR DESCRIPTION
Resolves #2640 -- but I am not sure how to test this well. Perhaps by adding an object with a finalizer and then forcing a full GC?

Anyway, perhaps at least @moyner can try if this helps with his concrete issue?