### PR TITLE
Set default value for 'todo' admonition color

### DIFF
--- a/assets/html/scss/bulma/utilities/derived-variables.sass
+++ b/assets/html/scss/bulma/utilities/derived-variables.sass
@@ -7,6 +7,8 @@ $info: $cyan !default
 $success: $green !default
 $warning: $yellow !default
 $danger: $red !default
+$compat: $turquoise !default
+$todo: $purple !default
 
 $light: $white-ter !default
 $dark: $grey-darker !default

--- a/assets/html/scss/documenter/_variables.scss
+++ b/assets/html/scss/documenter/_variables.scss
@@ -15,7 +15,6 @@ $blue: #3c5dcd !default;
 $purple: #9558b2 !default;
 
 $link: #2e63b8 !default;
-$compat: $turquoise !default;
 $text: #222222 !default;
 $text-strong: $text !default;
 $code: #000000 !default;


### PR DESCRIPTION
... across all themes.

Fixes #2576. Closes #2579.

This makes logical sense: the default value for `todo` was missing. I used the opportunity to move the default value for `compat` to the right place, too.

I verified this fixes the issue by running the code in https://github.com/JuliaDynamics/doctheme. Specifically, I ...

1. Reverted their commit https://github.com/JuliaDynamics/doctheme/commit/d077cc7f4d0ecb7b306747b56e08a8f1a88908f8
2. then did `cat juliadynamics-style.scss juliadynamics-darkdefs.scss > juliadynamics-dark.scss`
3. finally started julia and...
```
using Documenter,  DocumenterTools: Themes
Themes.compile("juliadynamics-dark.scss", "../assets/html/themes/documenter-dark.css")
```