### PR TITLE
Run regression tests on some PRs

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -1,6 +1,10 @@
-name: regression-tests
+name: 'Regression Tests'
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/regression-tests.yml'
+      - 'Project.toml'
 jobs:
   test-dependent-packages:
     name: run-tests-${{ matrix.package }}


### PR DESCRIPTION
Runs them on PRs that:

1. Change the regression tests workflow itself.
2. Change the `Project.toml`, which would in most cases be the release PR.