### PR TITLE
Fix cleaning of the modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
-* Fixed a bug in the cleaning of `@example` blocks with `a::SomeType = somevalue` typed declarations. ([#2673, #2674])
+* Fixed a bug in the cleaning of `@example` blocks with `a::SomeType = somevalue` typed declarations. ([#2674])
 
 # Version [v1.10.0] - 2025-03-31
 
@@ -2005,6 +2005,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2658]: https://github.com/JuliaDocs/Documenter.jl/issues/2658
 [#2659]: https://github.com/JuliaDocs/Documenter.jl/issues/2659
 [#2662]: https://github.com/JuliaDocs/Documenter.jl/issues/2662
+[#2674]: https://github.com/JuliaDocs/Documenter.jl/issues/2674
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,21 +3,21 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# Version [v1.10.1] - 2025-03-31
+## Version [v1.10.1] - 2025-03-31
 
-## Fixed
+### Fixed
 
 * Fixed a bug in the cleaning of `@example` blocks with `a::SomeType = somevalue` typed declarations. ([#2674])
 
-# Version [v1.10.0] - 2025-03-31
+## Version [v1.10.0] - 2025-03-31
 
-## Changed
+### Changed
 
 * Now the cursor remain focused on search box even after selecting the filter. ([#2410])
 * The "sandbox" modules used for running the code (doctests, examples) are now cleared after a page has been processed, allowing the garbage collector to reclaim memory and therefore reducing memory usage. ([#2640], [#2662])
 * Show file paths in error messages relative to the current working directory instead of relative to the document root. ([#2659])
 
-## Fixed
+### Fixed
 
 * Don't require custom themes to set a color for the 'todo' admonition. ([#2576])
 * Entries in `@repl` blocks that were hidden with `# hide` no longer produce erroneous empty lines ([#1521], [#2054], [#2399])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# Version [v1.10.1] - 2025-03-31
+
+## Fixed
+
+* Fixed a bug in the cleaning of `@example` blocks with `a::SomeType = somevalue` typed declarations. ([#2673, #2674])
+
 # Version [v1.10.0] - 2025-03-31
 
 ## Changed

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Documenter"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.10.0"
+version = "1.10.1"
 
 [deps]
 ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -6,7 +6,13 @@ function clear_module!(M::Module)
     # we need `invokelatest` here for Julia >= 1.12 (or 1.13?)
     for name in Base.invokelatest(names, M, all = true)
         if !isconst(M, name)
-            @eval M $name = $nothing
+            # see, e.g https://github.com/JuliaDocs/Documenter.jl/issues/2673
+            # it is not possible to set `nothing` to variables, which are strongly typed
+            # still attempt to set it, but ignore any errors
+            try
+                @eval M $name = $nothing
+            catch _
+            end
         end
     end
     return

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -11,7 +11,8 @@ function clear_module!(M::Module)
             # still attempt to set it, but ignore any errors
             try
                 @eval M $name = $nothing
-            catch _
+            catch err
+                @debug "Could not clear variable `$name` by assigning `nothing`" err
             end
         end
     end

--- a/test/clear_module/src/index.md
+++ b/test/clear_module/src/index.md
@@ -21,3 +21,31 @@ a = MyMutableStruct(1)
 Once Documenter is finished processing this page, it should remove the
 reference to the object `a` and a subsequent garbage collection should free
 it, which we can later test by observing the value of `Main.finalizer_count`.
+
+# Example blocks
+
+```@example example-1
+a = 1 # simple assignment
+```
+
+```@example example-2
+nothing = 1 # it is possible to use `nothing` as a variable name
+a = 2
+```
+
+```@example example-3
+nothing() = 3 # it is possible to use `nothing` as a function name
+a = nothing()
+```
+
+```@example example-4
+typed::String = "string" # it is possible to use `::` to specify the type of a variable
+```
+
+```@example example-5
+const a = 5 # it is possible to use `const` to define a constant
+```
+
+Once Documenter is finished processing this page, it attempts to remove the 
+variables defined in the example blocks. Documenter should not error when 
+processing those example blocks even if it cannot remove the variables.

--- a/test/clear_module/src/index.md
+++ b/test/clear_module/src/index.md
@@ -39,7 +39,9 @@ a = nothing()
 ```
 
 ```@example example-4
+@static if VERSION >= v"1.8"
 typed::String = "string" # it is possible to use `::` to specify the type of a variable
+end
 ```
 
 ```@example example-5


### PR DESCRIPTION
This PR attempts to fix #2673 . The problem is that the new cleaning functionality aggressively tries to assign `nothing` to all names defined in the module. It does check against `const`, but this isn't enough since users can write typed assignments, e.g. `a::String = "b"`. This would later cause problems when assigning `a` to `nothing`. This PR fixes it by wrapping the `@eval` in `try-catch` block and also adding this as an example in the tests.