### PR TITLE
Remove at-meta, at-setup, at-docs from search index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## Fixed
+
+* `@meta`, `@setup`, and `@docs` blocks no longer generate spurious entries in the search index. ([#1929], [#2675])
+
 ## Version [v1.10.1] - 2025-03-31
 
 ### Fixed

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -1695,7 +1695,7 @@ function domify(dctx::DCtx)
     ctx, navnode = dctx.ctx, dctx.navnode
     return map(getpage(ctx, navnode).mdast.children) do node
         rec = searchrecord(ctx, navnode, node)
-        if rec !== nothing
+        if !isnothing(rec)
             push!(ctx.search_index, rec)
         end
         domify(dctx, node, node.element)

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -714,10 +714,14 @@ function SearchRecord(ctx, navnode, node::Node, ::MarkdownAST.AbstractElement)
 end
 
 # Returns nothing for nodes that shouldn't be indexed in search
+const _SEARCHRECORD_IGNORED_BLOCK_TYPES = Union{
+    Documenter.MetaNode,
+    Documenter.DocsNodesBlock,
+    Documenter.SetupNode,
+}
 function searchrecord(ctx::HTMLContext, navnode::Documenter.NavNode, node::Node)
     # Skip indexing special at-blocks
-    if node.element isa Union{Documenter.MetaNode, Documenter.DocsNodesBlock, 
-                             Documenter.SetupNode}
+    if node.element isa _SEARCHRECORD_IGNORED_BLOCK_TYPES
         return nothing
     end
     return SearchRecord(ctx, navnode, node, node.element)


### PR DESCRIPTION
As discussed on slack I am first trying to do the easy part of entirely removing the meta and setup blocks since they are not required in the search index