### PR TITLE
Fix performance regression in `clear_modules!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added anchor links to admonition blocks, making it possible to create direct links to specific admonitions. ([#2505], [#2676])
 * Added different banners for dev and unreleased docs ([#2382], [#2682])
 
-## Fixed
+### Fixed
 
 * `@meta`, `@setup`, and `@docs` blocks no longer generate spurious entries in the search index. ([#1929], [#2675])
+* Fixed a performance regression introduced in v1.10.0 as part of the code clearing out the sandbox modules to save memory and caused by calling `GC.gc()` too often.
 
 ## Version [v1.10.1] - 2025-03-31
 

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -24,7 +24,6 @@ function clear_modules!(d::Dict{Symbol, Any})
         startswith(String(k), "__atexample__") || continue
         v isa Module && clear_module!(v)
     end
-    GC.gc()
     return
 end
 


### PR DESCRIPTION
See https://github.com/oscar-system/Oscar.jl/issues/4824 for background.

Unfortunately there is a much worse performance regression on master introduced by PR #2676 (ping @Rahban1). Luckily this one has not yet been in a release of Documenter.

It would be great to have this fix in a release ASAP. Perhaps it would make sense to make a branch for a 1.10.2 release with just this fix but not the other changes, so we have time to properly deal with the other regression (other than reverting the PR in question) ?