### PR TITLE
[release-1.10] Backports for 1.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## Fixed
+### Fixed
 
 * `@meta`, `@setup`, and `@docs` blocks no longer generate spurious entries in the search index. ([#1929], [#2675])
+* Fixed a performance regression introduced in v1.10.0 as part of the code clearing out the sandbox modules to save memory and caused by calling `GC.gc()` too often. ([#2685])
 
 ## Version [v1.10.1] - 2025-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## Fixed
+
+* `@meta`, `@setup`, and `@docs` blocks no longer generate spurious entries in the search index. ([#1929], [#2675])
+
 ## Version [v1.10.1] - 2025-03-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## Version [v1.10.2] - 2025-04-25
 
 ### Fixed
 
@@ -1469,6 +1469,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v1.8.1]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.8.1
 [v1.9.0]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.9.0
 [v1.10.0]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.10.0
+[v1.10.1]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.10.1
+[v1.10.2]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.10.2
 [#198]: https://github.com/JuliaDocs/Documenter.jl/issues/198
 [#245]: https://github.com/JuliaDocs/Documenter.jl/issues/245
 [#487]: https://github.com/JuliaDocs/Documenter.jl/issues/487
@@ -1838,6 +1840,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1912]: https://github.com/JuliaDocs/Documenter.jl/issues/1912
 [#1919]: https://github.com/JuliaDocs/Documenter.jl/issues/1919
 [#1924]: https://github.com/JuliaDocs/Documenter.jl/issues/1924
+[#1929]: https://github.com/JuliaDocs/Documenter.jl/issues/1929
 [#1930]: https://github.com/JuliaDocs/Documenter.jl/issues/1930
 [#1931]: https://github.com/JuliaDocs/Documenter.jl/issues/1931
 [#1932]: https://github.com/JuliaDocs/Documenter.jl/issues/1932
@@ -2013,6 +2016,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2659]: https://github.com/JuliaDocs/Documenter.jl/issues/2659
 [#2662]: https://github.com/JuliaDocs/Documenter.jl/issues/2662
 [#2674]: https://github.com/JuliaDocs/Documenter.jl/issues/2674
+[#2675]: https://github.com/JuliaDocs/Documenter.jl/issues/2675
+[#2685]: https://github.com/JuliaDocs/Documenter.jl/issues/2685
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Documenter"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.10.1"
+version = "1.10.2"
 
 [deps]
 ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -24,7 +24,6 @@ function clear_modules!(d::Dict{Symbol, Any})
         startswith(String(k), "__atexample__") || continue
         v isa Module && clear_module!(v)
     end
-    GC.gc()
     return
 end
 

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -713,6 +713,20 @@ function SearchRecord(ctx, navnode, node::Node, ::MarkdownAST.AbstractElement)
     return SearchRecord(ctx, navnode; text = mdflatten(node))
 end
 
+# Returns nothing for nodes that shouldn't be indexed in search
+const _SEARCHRECORD_IGNORED_BLOCK_TYPES = Union{
+    Documenter.MetaNode,
+    Documenter.DocsNodesBlock,
+    Documenter.SetupNode,
+}
+function searchrecord(ctx::HTMLContext, navnode::Documenter.NavNode, node::Node)
+    # Skip indexing special at-blocks
+    if node.element isa _SEARCHRECORD_IGNORED_BLOCK_TYPES
+        return nothing
+    end
+    return SearchRecord(ctx, navnode, node, node.element)
+end
+
 function JSON.lower(rec::SearchRecord)
     # Replace any backslashes in links, if building the docs on Windows
     src = replace(rec.src, '\\' => '/')
@@ -1680,8 +1694,10 @@ end
 function domify(dctx::DCtx)
     ctx, navnode = dctx.ctx, dctx.navnode
     return map(getpage(ctx, navnode).mdast.children) do node
-        rec = SearchRecord(ctx, navnode, node, node.element)
-        push!(ctx.search_index, rec)
+        rec = searchrecord(ctx, navnode, node)
+        if !isnothing(rec)
+            push!(ctx.search_index, rec)
+        end
         domify(dctx, node, node.element)
     end
 end


### PR DESCRIPTION
X-ref: #2675, #2685

## Pre-release

 - [ ] Change the version number in `Project.toml`
   * If the release is breaking, increment MAJOR
   * If the release adds a new user-visible feature, increment MINOR
   * Otherwise (bug-fixes, documentation improvements), increment PATCH
 - [ ] Update `CHANGELOG.md`, following the existing style (in particular, make sure that the change log for this version has the correct version number and date).
 - [ ] Run `make changelog`, to make sure that all the issue references in `CHANGELOG.md` are up to date.
 - [ ] Check that the commit messages in this PR do not contain `[ci skip]`
 - [ ] Run [regression-tests workflow](https://github.com/JuliaDocs/Documenter.jl/actions/workflows/regression-tests.yml) using a `workflow_dispatch` trigger to check for any changes that broke extensions: <link-to-workflow-run-here>

## The release

 - [ ] After merging the pull request, tag the release. There are two options for this:

   1. [Comment `[at]JuliaRegistrator register` on the GitHub commit.](https://github.com/JuliaRegistries/Registrator.jl#via-the-github-app)
   2. Use [JuliaHub's package registration feature](https://help.juliahub.com/juliahub/stable/contribute/#registrator) to trigger the registration.

   Either of those should automatically publish a new version to the Julia registry.
 - Once registered, the `TagBot.yml` workflow should create a tag, and rebuild the documentation for this tag.
 - These steps can take quite a bit of time (1 hour or more), so don't be surprised if the new documentation takes a while to appear.