### PR TITLE
Separate decision making repo from deploy repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added anchor links to admonition blocks, making it possible to create direct links to specific admonitions. ([#2505], [#2676], [#2688])
 * Added different banners for dev and unreleased docs ([#2382], [#2682])
+* Introduced the `deploy_repo` keyword argument for `deploydocs` to better support out-of-repo documentation deployments ([#2692])
 
 ## Version [v1.10.2] - 2025-04-25
 
@@ -2029,6 +2030,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2676]: https://github.com/JuliaDocs/Documenter.jl/issues/2676
 [#2682]: https://github.com/JuliaDocs/Documenter.jl/issues/2682
 [#2685]: https://github.com/JuliaDocs/Documenter.jl/issues/2685
+[#2692]: https://github.com/JuliaDocs/Documenter.jl/pull/2692
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -602,15 +602,10 @@ repository on a "target" repo:
 4. Adapt `docs/make.jl` to deploy on "target" repository:
 
 ```julia
-# url of target repo
-repo = "github.com/TargetRepoOrg/TargetRepo.git"
-
-# You have to override the corresponding environment variable that
-# deplodocs uses to determine if it is deploying to the correct repository.
-# For GitHub, it's the GITHUB_REPOSITORY variable:
-withenv("GITHUB_REPOSITORY" => repo) do
-  deploydocs(repo=repo)
-end
+deploydocs(
+  repo="github.com/SourceRepoOrg/SourceRepo",
+  deploy_repo="github.com/TargetRepoOrg/TargetRepo"
+)
 ```
 
 ## Deploying from a monorepo

--- a/src/deployconfig.jl
+++ b/src/deployconfig.jl
@@ -166,7 +166,8 @@ end
 function deploy_folder(
         cfg::Travis;
         repo,
-        repo_previews = repo,
+        repo_previews = nothing,
+        deploy_repo = nothing,
         branch = "gh-pages",
         branch_previews = branch,
         devbranch,
@@ -201,7 +202,7 @@ function deploy_folder(
         all_ok &= tag_ok
         println(io, "- $(marker(tag_ok)) ENV[\"TRAVIS_TAG\"] contains a valid VersionNumber")
         deploy_branch = branch
-        deploy_repo = repo
+        deploy_repo = something(deploy_repo, repo)
         is_preview = false
         ## Deploy to folder according to the tag
         subfolder = tag_nobuild
@@ -215,7 +216,7 @@ function deploy_folder(
         all_ok &= branch_ok
         println(io, "- $(marker(branch_ok)) ENV[\"TRAVIS_BRANCH\"] matches devbranch=\"$(devbranch)\"")
         deploy_branch = branch
-        deploy_repo = repo
+        deploy_repo = something(deploy_repo, repo)
         is_preview = false
         ## Deploy to deploydocs devurl kwarg
         subfolder = devurl
@@ -228,7 +229,7 @@ function deploy_folder(
         all_ok &= btype_ok
         println(io, "- $(marker(btype_ok)) `push_preview` keyword argument to deploydocs is `true`")
         deploy_branch = branch_previews
-        deploy_repo = repo_previews
+        deploy_repo = something(repo_previews, deploy_repo, repo)
         is_preview = true
         ## deploy to previews/PR
         subfolder = "previews/PR$(something(pr_number, 0))"
@@ -312,7 +313,8 @@ end
 function deploy_folder(
         cfg::GitHubActions;
         repo,
-        repo_previews = repo,
+        repo_previews = nothing,
+        deploy_repo = nothing,
         branch = "gh-pages",
         branch_previews = branch,
         devbranch,
@@ -348,7 +350,7 @@ function deploy_folder(
         all_ok &= tag_ok
         println(io, "- $(marker(tag_ok)) ENV[\"GITHUB_REF\"]=\"$(cfg.github_ref)\" contains a valid VersionNumber")
         deploy_branch = branch
-        deploy_repo = repo
+        deploy_repo = something(deploy_repo, repo)
         is_preview = false
         ## Deploy to folder according to the tag
         subfolder = m === nothing ? nothing : tag_nobuild
@@ -363,7 +365,7 @@ function deploy_folder(
         all_ok &= branch_ok
         println(io, "- $(marker(branch_ok)) ENV[\"GITHUB_REF\"] matches devbranch=\"$(devbranch)\"")
         deploy_branch = branch
-        deploy_repo = repo
+        deploy_repo = something(deploy_repo, repo)
         is_preview = false
         ## Deploy to deploydocs devurl kwarg
         subfolder = devurl
@@ -382,7 +384,7 @@ function deploy_folder(
         all_ok &= btype_ok
         println(io, "- $(marker(btype_ok)) `push_preview` keyword argument to deploydocs is `true`")
         deploy_branch = branch_previews
-        deploy_repo = repo_previews
+        deploy_repo = something(repo_previews, deploy_repo, repo)
         is_preview = true
         ## deploydocs to previews/PR
         subfolder = "previews/PR$(something(pr_number, 0))"
@@ -607,7 +609,8 @@ end
 function deploy_folder(
         cfg::GitLab;
         repo,
-        repo_previews = repo,
+        repo_previews = nothing,
+        deploy_repo = nothing,
         devbranch,
         push_preview,
         devurl,
@@ -650,7 +653,7 @@ function deploy_folder(
         is_preview = false
         subfolder = tag_nobuild
         deploy_branch = branch
-        deploy_repo = repo
+        deploy_repo = something(deploy_repo, repo)
     elseif build_type == :preview
         pr_number = tryparse(Int, cfg.pull_request_iid)
         pr_ok = pr_number !== nothing
@@ -669,7 +672,7 @@ function deploy_folder(
         ## deploy to previews/PR
         subfolder = "previews/PR$(something(pr_number, 0))"
         deploy_branch = branch_previews
-        deploy_repo = repo_previews
+        deploy_repo = something(repo_previews, deploy_repo, repo)
     else
         branch_ok = !isempty(cfg.commit_tag) || cfg.commit_branch == devbranch
         all_ok &= branch_ok
@@ -680,7 +683,7 @@ function deploy_folder(
         is_preview = false
         subfolder = devurl
         deploy_branch = branch
-        deploy_repo = repo
+        deploy_repo = something(deploy_repo, repo)
     end
 
     key_ok = env_nonempty("DOCUMENTER_KEY")
@@ -750,7 +753,8 @@ end
 function deploy_folder(
         cfg::Buildkite;
         repo,
-        repo_previews = repo,
+        repo_previews = nothing,
+        deploy_repo = nothing,
         devbranch,
         push_preview,
         devurl,
@@ -791,7 +795,7 @@ function deploy_folder(
         is_preview = false
         subfolder = tag_nobuild
         deploy_branch = branch
-        deploy_repo = repo
+        deploy_repo = something(deploy_repo, repo)
     elseif build_type == :preview
         pr_number = tryparse(Int, cfg.pull_request)
         pr_ok = pr_number !== nothing
@@ -810,7 +814,7 @@ function deploy_folder(
         ## deploy to previews/PR
         subfolder = "previews/PR$(something(pr_number, 0))"
         deploy_branch = branch_previews
-        deploy_repo = repo_previews
+        deploy_repo = something(repo_previews, deploy_repo, repo)
     else
         branch_ok = !isempty(cfg.commit_tag) || cfg.commit_branch == devbranch
         all_ok &= branch_ok
@@ -821,7 +825,7 @@ function deploy_folder(
         is_preview = false
         subfolder = devurl
         deploy_branch = branch
-        deploy_repo = repo
+        deploy_repo = something(deploy_repo, repo)
     end
 
     key_ok = env_nonempty("DOCUMENTER_KEY")
@@ -1003,7 +1007,8 @@ end
 function deploy_folder(
         cfg::Woodpecker;
         repo,
-        repo_previews = repo,
+        repo_previews = nothing,
+        deploy_repo = nothing,
         branch = "pages",
         branch_previews = branch,
         devbranch,
@@ -1047,7 +1052,7 @@ function deploy_folder(
         all_ok &= tag_ok
         println(io, "- $(marker(tag_ok)) ENV[\"CI_COMMIT_TAG\"]=\"$(cfg.woodpecker_tag)\" contains a valid VersionNumber")
         deploy_branch = branch
-        deploy_repo = repo
+        deploy_repo = something(deploy_repo, repo)
         is_preview = false
         ## Deploy to folder according to the tag
         subfolder = tag_nobuild
@@ -1062,7 +1067,7 @@ function deploy_folder(
         all_ok &= branch_ok
         println(io, "- $(marker(branch_ok)) ENV[\"CI_COMMIT_REF\"] matches devbranch=\"$(devbranch)\"")
         deploy_branch = branch
-        deploy_repo = repo
+        deploy_repo = something(deploy_repo, repo)
         is_preview = false
         ## Deploy to deploydocs devurl kwarg
         subfolder = devurl
@@ -1081,7 +1086,7 @@ function deploy_folder(
         all_ok &= btype_ok
         println(io, "- $(marker(btype_ok)) `push_preview` keyword argument to deploydocs is `true`")
         deploy_branch = branch_previews
-        deploy_repo = repo_previews
+        deploy_repo = something(repo_previews, deploy_repo, repo)
         is_preview = true
         ## deploydocs to previews/PR
         subfolder = "previews/PR$(something(pr_number1, 0))"

--- a/src/deploydocs.jl
+++ b/src/deploydocs.jl
@@ -16,7 +16,8 @@
         forcepush = false,
         deploy_config = auto_detect_deploy_system(),
         push_preview = false,
-        repo_previews = repo,
+        repo_previews = nothing,
+        deploy_repo = nothing,
         branch_previews = branch,
         tag_prefix = "",
     )
@@ -141,6 +142,8 @@ It defaults to the value of `branch`.
 **`repo_previews`** is the remote repository to which pull request previews are
 deployed. It defaults to the value of `repo`.
 
+** `deploy_repo`** is the remote repository to deploy to.
+
 !!! note
     Pull requests made from forks will not have previews.
     Hosting previews requires access to the deploy key.
@@ -190,8 +193,9 @@ function deploydocs(;
 
         repo = error("no 'repo' keyword provided."),
         branch = "gh-pages",
+        deploy_repo = nothing,
 
-        repo_previews = repo,
+        repo_previews = nothing,
         branch_previews = branch,
 
         deps = nothing,
@@ -230,6 +234,7 @@ function deploydocs(;
         push_preview = push_preview,
         repo = repo,
         repo_previews = repo_previews,
+        deploy_repo = deploy_repo,
         tag_prefix
     )
     if deploy_decision.all_ok

--- a/src/deploydocs.jl
+++ b/src/deploydocs.jl
@@ -129,6 +129,12 @@ If `versions = nothing` documentation will be deployed directly to the "root", i
 not to a versioned subfolder. See the manual section on
 [Deploying without the versioning scheme](@ref) for more details.
 
+**`deploy_repo`** can be used to override the remote repository to deploy to, which
+normally will be the same as `repo` (if this is unset or set to `nothing`). This is mostly
+used when the documentation is deployed to a dedicated "docs hosting repository", usually
+to avoid issues with the main repository's `gh-pages` branch getting too large. The
+expected format of the argument is the same as for `repo`.
+
 **`push_preview`** a boolean that specifies if preview documentation should be
 deployed from pull requests or not. If your published documentation is hosted
 at `"https://USER.github.io/PACKAGE.jl/stable`, by default the preview will be
@@ -140,9 +146,8 @@ forks.
 It defaults to the value of `branch`.
 
 **`repo_previews`** is the remote repository to which pull request previews are
-deployed. It defaults to the value of `repo`.
-
-** `deploy_repo`** is the remote repository to deploy to.
+deployed. It defaults to the value of `repo`, and when specified manually, must
+follow its formatting scheme.
 
 !!! note
     Pull requests made from forks will not have previews.

--- a/test/deployconfig.jl
+++ b/test/deployconfig.jl
@@ -180,6 +180,28 @@ end
             @test Documenter.authentication_method(cfg) === Documenter.SSH
             @test Documenter.documenter_key(cfg) === "SGVsbG8sIHdvcmxkLg=="
         end
+        # External Repo: Regular tag build with SSH deploy key (SSH key prioritized)
+        withenv(
+            "GITHUB_EVENT_NAME" => "push",
+            "GITHUB_REPOSITORY" => "JuliaDocs/Documenter.jl",
+            "GITHUB_REF" => "refs/tags/v1.2.3",
+            "GITHUB_ACTOR" => "github-actions",
+            "GITHUB_TOKEN" => "SGVsbG8sIHdvcmxkLg==",
+            "DOCUMENTER_KEY" => "SGVsbG8sIHdvcmxkLg==",
+        ) do
+            cfg = Documenter.GitHubActions()
+            d = Documenter.deploy_folder(
+                cfg; repo = "github.com/JuliaDocs/Documenter.jl.git",
+                deploy_repo = "github.com/JuliaDocs/DocumenterDocs.jl.git",
+                devbranch = "master", devurl = "dev", push_preview = true
+            )
+            @test d.all_ok
+            @test d.subfolder == "v1.2.3"
+            @test d.repo == "github.com/JuliaDocs/DocumenterDocs.jl.git"
+            @test d.branch == "gh-pages"
+            @test Documenter.authentication_method(cfg) === Documenter.SSH
+            @test Documenter.documenter_key(cfg) === "SGVsbG8sIHdvcmxkLg=="
+        end
         # Regular tag build with GITHUB_TOKEN and with tag prefix
         withenv(
             "GITHUB_EVENT_NAME" => "push",
@@ -394,6 +416,46 @@ end
                 @test Documenter.authentication_method(cfg) === Documenter.SSH
                 @test Documenter.documenter_key(cfg) === "SGVsbG8sIHdvcmxkLg=="
                 @test Documenter.documenter_key_previews(cfg) === "SGVsbG8sIHdvcmxkLw=="
+            end
+            # External Repo: Regular pull request build with GITHUB_TOKEN
+            withenv(
+                "GITHUB_EVENT_NAME" => "pull_request",
+                "GITHUB_REPOSITORY" => "JuliaDocs/Documenter.jl",
+                "GITHUB_REF" => "refs/pull/1962/merge",
+                "GITHUB_ACTOR" => "github-actions",
+                "DOCUMENTER_KEY" => nothing,
+            ) do
+                cfg = Documenter.GitHubActions()
+                d = Documenter.deploy_folder(
+                    cfg; repo = "github.com/JuliaDocs/Documenter.jl.git",
+                    deploy_repo = "github.com/JuliaDocs/DocumenterDocs.jl.git",
+                    devbranch = "master", devurl = "hello-world", push_preview = true
+                )
+                @test d.all_ok
+                @test d.subfolder == "previews/PR1962"
+                @test d.repo == "github.com/JuliaDocs/DocumenterDocs.jl.git"
+                @test d.branch == "gh-pages"
+            end
+            # External Repo: Regular pull request build with SSH deploy key (SSH key prioritized), but push previews to a different repo and different branch
+            withenv(
+                "GITHUB_EVENT_NAME" => "pull_request",
+                "GITHUB_REPOSITORY" => "JuliaDocs/Documenter.jl",
+                "GITHUB_REF" => "refs/pull/1962/merge",
+                "GITHUB_ACTOR" => "github-actions",
+                "DOCUMENTER_KEY" => "SGVsbG8sIHdvcmxkLg==",
+            ) do
+                cfg = Documenter.GitHubActions()
+                d = Documenter.deploy_folder(
+                    cfg; repo = "github.com/JuliaDocs/Documenter.jl.git",
+                    devbranch = "master", devurl = "hello-world", push_preview = true,
+                    repo_previews = "github.com/JuliaDocs/Documenter-previews.jl.git",
+                    deploy_repo = "github.com/JuliaDocs/DocumenterDocs.jl.git",
+                    branch_previews = "gh-pages-previews"
+                )
+                @test d.all_ok
+                @test d.subfolder == "previews/PR1962"
+                @test d.repo == "github.com/JuliaDocs/Documenter-previews.jl.git" # prioritize repo_previews
+                @test d.branch == "gh-pages-previews"
             end
         end
         # Missing environment variables


### PR DESCRIPTION
When deploying the documentation to an different repository we try to make decisions based on the `repo` argument.

Naively changing `repo` to the target repository leads to:

```
┌ Info: Deployment criteria for deploying preview build from GitHub Actions:
│ - ✘ ENV["GITHUB_REPOSITORY"]="trixi-framework/Trixi.jl" occurs in repo="github.com/trixi-framework/TrixiDocumentation"
│ - ✔ ENV["GITHUB_REF"] corresponds to a PR number
│ - ✔ PR originates from the same repository
│ - ✔ `push_preview` keyword argument to deploydocs is `true`
│ - ✔ ENV["GITHUB_ACTOR"] exists and is non-empty
│ - ✔ ENV["DOCUMENTER_KEY"] exists and is non-empty
└ Deploying: ✘
```

Since `ENV[GITHUB_REPOSITORY]` and `repo` disagree.
Currently the docs in https://documenter.juliadocs.org/stable/man/hosting/#Out-of-repo-deployment recommend:

```
# You have to override the corresponding environment variable that
# deplodocs uses to determine if it is deploying to the correct repository.
# For GitHub, it's the GITHUB_REPOSITORY variable:
withenv("GITHUB_REPOSITORY" => repo) do
  deploydocs(repo=repo)
end
```

Yet this leads to:

```
┌ Info: Deployment criteria for deploying preview build from GitHub Actions:
│ - ✔ ENV["GITHUB_REPOSITORY"]="github.com/trixi-framework/TrixiDocumentation" occurs in repo="github.com/trixi-framework/TrixiDocumentation"
│ - ✔ ENV["GITHUB_REF"] corresponds to a PR number
│ - ✘ PR originates from the same repository
│ - ✔ `push_preview` keyword argument to deploydocs is `true`
│ - ✔ ENV["GITHUB_ACTOR"] exists and is non-empty
│ - ✔ ENV["DOCUMENTER_KEY"] exists and is non-empty
└ Deploying: ✘
```

Since we use the `ENV[GITHUB_REPOSITORY]` to check that a PR originates from the same repository.

My proposed fix is to disentagle the `repo` from the deployment target. `repo` remains the default and always describes the source (which may or may not be the target),
but we introduce a new keyword `deploy_depo` that can be used to override the target repository.

This allows us to remove the `with_env` hack.

