### PR TITLE
Fix clear_module! world semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added anchor links to admonition blocks, making it possible to create direct links to specific admonitions. ([#2505], [#2676], [#2688])
 * Added different banners for dev and unreleased docs ([#2382], [#2682])
 
+### Fixed
+
+* In Julia v1.12, the queries used by `clear_module!` will now be versioned by world, allowing the deleting of bindings to work correctly. ([#2693])
+
 ## Version [v1.10.2] - 2025-04-25
 
 ### Fixed
@@ -2029,6 +2033,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2676]: https://github.com/JuliaDocs/Documenter.jl/issues/2676
 [#2682]: https://github.com/JuliaDocs/Documenter.jl/issues/2682
 [#2685]: https://github.com/JuliaDocs/Documenter.jl/issues/2685
+[#2693]: https://github.com/JuliaDocs/Documenter.jl/issues/2693
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -2,7 +2,12 @@
 
 function clear_global!(M::Module, name::Symbol)
     isconst(M, name) && return
-    VERSION >= v"1.9" ? setglobal!(M, name, nothing) : Core.eval(M, :($name = $nothing))
+    if VERSION >= v"1.9"
+        Nothing <: Core.get_binding_type(M, name) || return
+        setglobal!(M, name, nothing)
+    else
+        Core.eval(M, :($name = $nothing))
+    end
     return nothing
 end
 

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -4,13 +4,13 @@
 # See also <https://github.com/JuliaDocs/Documenter.jl/issues/2640>.
 function clear_module!(M::Module)
     # we need `invokelatest` here for Julia >= 1.12 (or 1.13?)
-    for name in Base.invokelatest(names, M, all = true)
-        if !isconst(M, name)
+    for name in Base.invokelatest(names, M, all = true)::Vector{Any}
+        if !(Base.invokelatest(isconst, M, name::Symbol)::Bool)
             # see, e.g https://github.com/JuliaDocs/Documenter.jl/issues/2673
             # it is not possible to set `nothing` to variables, which are strongly typed
             # still attempt to set it, but ignore any errors
             try
-                @eval M $name = $nothing
+                VERSION >= v"1.9" ? setglobal!(M, name, nothing) : Core.eval(M, :($name = $nothing))
             catch err
                 @debug "Could not clear variable `$name` by assigning `nothing`" err
             end

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -3,7 +3,7 @@
 function clear_global!(M::Module, name::Symbol)
     isconst(M, name) && return
     VERSION >= v"1.9" ? setglobal!(M, name, nothing) : Core.eval(M, :($name = $nothing))
-    nothing
+    return nothing
 end
 
 # helper for "cleaning up" content of modules to enable garbage collection.

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -15,7 +15,7 @@ function clear_module!(M::Module)
         # it is not possible to set `nothing` to variables, which are strongly typed
         # still attempt to set it, but ignore any errors
         try
-            invokelatest(clear_global!, M, name::Symbol)
+            Base.invokelatest(clear_global!, M, name::Symbol)
         catch err
             @debug "Could not clear variable `$name` by assigning `nothing`" err
         end

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -10,7 +10,7 @@ end
 # See also <https://github.com/JuliaDocs/Documenter.jl/issues/2640>.
 function clear_module!(M::Module)
     # we need `invokelatest` here for Julia >= 1.12 (or 1.13?)
-    for name in Base.invokelatest(names, M, all = true)::Vector{Any}
+    for name in Base.invokelatest(names, M, all = true)::Vector{Symbol}
         # see, e.g https://github.com/JuliaDocs/Documenter.jl/issues/2673
         # it is not possible to set `nothing` to variables, which are strongly typed
         # still attempt to set it, but ignore any errors


### PR DESCRIPTION
The `isconst` is a world-specific query, so it needs `invokelatest` too. Restructure a bit of the code to do that in a helper function. Also add a call to delete all bindings in v1.12+. Although that may be expensive and currently warns that it may be incorrect, it may be helpful to get testing of that.