### PR TITLE
CI: run regression-tests.yml on all PRs & primary branches

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -1,6 +1,14 @@
 name: 'Regression Tests'
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - master
+      - release-*
+      # You can suffix the branch name with '-runci' to run the CI on that branch
+      # without having to open a pull request. This is useful for long-lived branches.
+      - '*/*-runci'
+    tags: '*'
   pull_request:
     paths:
       - '.github/workflows/regression-tests.yml'


### PR DESCRIPTION
It seems natural to run the regression tests on all PRs so that we actually notice regressions as they are introduced resp. as soon as possible (if caused by external factors), and not just when we remember to manually run these tests.