### PR TITLE
Dispatch logic on `versions` when deploying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Refactored `deploydocs` internals to allow dispatch on the `versions` keyword, intended as a non-public API for DocumenterVitepress which cannot use the default versioning mechanism during deployment ([#2695]).
 * Added anchor links to admonition blocks, making it possible to create direct links to specific admonitions. ([#2505], [#2676], [#2688])
 * Added different banners for dev and unreleased docs ([#2382], [#2682])
 
@@ -2029,6 +2030,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2676]: https://github.com/JuliaDocs/Documenter.jl/issues/2676
 [#2682]: https://github.com/JuliaDocs/Documenter.jl/issues/2682
 [#2685]: https://github.com/JuliaDocs/Documenter.jl/issues/2685
+[#2695]: https://github.com/JuliaDocs/Documenter.jl/issues/2695
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/src/deploydocs.jl
+++ b/src/deploydocs.jl
@@ -235,8 +235,10 @@ function deploydocs(;
     if deploy_decision.all_ok
         deploy_branch = deploy_decision.branch
         deploy_repo = deploy_decision.repo
-        deploy_subfolder = determine_deploy_subfolder(deploy_decision, versions)
         deploy_is_preview = deploy_decision.is_preview
+        
+        # this dispatches on `versions` for a non-public API for DocumenterVitepress
+        deploy_subfolder = determine_deploy_subfolder(deploy_decision, versions)
 
         # Install dependencies when applicable.
         if deps !== nothing
@@ -412,6 +414,7 @@ function git_push(
             write(joinpath(dirname, "CNAME"), cname)
         end
 
+        # this dispatches on `versions` for a non-public API for DocumenterVitepress
         postprocess_before_push(versions; subfolder, devurl, deploy_dir, dirname)
 
         # Add, commit, and push the docs to the remote.
@@ -507,7 +510,7 @@ end
 # Run arbitrary logic (for example, creating siteinfo and version files)
 # on the documentation with the new additions before the changes are pushed to the remote.
 # The logic depends on the versioning scheme defined via `versions`.
-# This function was factored out as part of a "shadow API" via dispatch on the `versions` keyword arg
+# This function was factored out as part of a non-public API via dispatch on the `versions` keyword arg
 # to `deploydocs`, for use in DocumenterVitepress because it cannot use the default versioning.
 function postprocess_before_push(versions::Nothing; subfolder, devurl, deploy_dir, dirname)
     # If the documentation is unversioned and deployed to root, we generate a
@@ -555,7 +558,7 @@ end
 
 # Determine the subfolder to deploy to given the `deploy_decision` and the `versions`.
 # Either return a `String` or `nothing` to deploy to the root folder.
-# This function was factored out as part of a "shadow API" via dispatch on the `versions` keyword arg
+# This function was factored out as part of a non-public API via dispatch on the `versions` keyword arg
 # to `deploydocs`, for use in DocumenterVitepress because it cannot use the default versioning.
 function determine_deploy_subfolder(deploy_decision, versions::Nothing)
     # Non-versioned docs: deploy to root unless it's a preview

--- a/src/deploydocs.jl
+++ b/src/deploydocs.jl
@@ -236,7 +236,7 @@ function deploydocs(;
         deploy_branch = deploy_decision.branch
         deploy_repo = deploy_decision.repo
         deploy_is_preview = deploy_decision.is_preview
-        
+
         # this dispatches on `versions` for a non-public API for DocumenterVitepress
         deploy_subfolder = determine_deploy_subfolder(deploy_decision, versions)
 
@@ -537,7 +537,7 @@ function postprocess_before_push(versions::AbstractVector; subfolder, devurl, de
     HTMLWriter.generate_redirect_file(joinpath(dirname, "index.html"), entries)
 
     # generate the symlinks, make sure we don't overwrite devurl
-    cd(dirname) do
+    return cd(dirname) do
         for kv in symlinks
             i = findfirst(x -> x.first == devurl, symlinks)
             if i === nothing
@@ -562,11 +562,11 @@ end
 # to `deploydocs`, for use in DocumenterVitepress because it cannot use the default versioning.
 function determine_deploy_subfolder(deploy_decision, versions::Nothing)
     # Non-versioned docs: deploy to root unless it's a preview
-    deploy_decision.is_preview ? deploy_decision.subfolder : nothing
+    return deploy_decision.is_preview ? deploy_decision.subfolder : nothing
 end
 
 function determine_deploy_subfolder(deploy_decision, versions::AbstractVector)
-    deploy_decision.subfolder
+    return deploy_decision.subfolder
 end
 
 function rm_and_add_symlink(target, link)

--- a/src/deploydocs.jl
+++ b/src/deploydocs.jl
@@ -235,13 +235,8 @@ function deploydocs(;
     if deploy_decision.all_ok
         deploy_branch = deploy_decision.branch
         deploy_repo = deploy_decision.repo
-        deploy_subfolder = deploy_decision.subfolder
+        deploy_subfolder = determine_deploy_subfolder(deploy_decision, versions)
         deploy_is_preview = deploy_decision.is_preview
-
-        # Non-versioned docs: deploy to root
-        if versions === nothing && !deploy_is_preview
-            deploy_subfolder = nothing
-        end
 
         # Install dependencies when applicable.
         if deps !== nothing
@@ -307,6 +302,20 @@ function deploydocs(;
     return
 end
 
+"""
+    determine_deploy_subfolder(deploy_decision, versions)
+
+Determine the subfolder to deploy to given the `deploy_decision` and the `versions`.
+Either return a `String` or `nothing` to deploy to the root folder.
+"""
+function determine_deploy_subfolder(deploy_decision, versions::Nothing)
+    # Non-versioned docs: deploy to root unless it's a preview
+    deploy_decision.is_preview ? deploy_decision.subfolder : nothing
+end
+
+function determine_deploy_subfolder(deploy_decision, versions::AbstractVector)
+    deploy_decision.subfolder
+end
 
 function _get_inventory_version(objects_inv)
     return open(objects_inv) do input
@@ -418,46 +427,7 @@ function git_push(
             write(joinpath(dirname, "CNAME"), cname)
         end
 
-        if versions === nothing
-            # If the documentation is unversioned and deployed to root, we generate a
-            # siteinfo.js file that would disable the version selector in the docs
-            HTMLWriter.generate_siteinfo_file(deploy_dir, nothing)
-        else
-            # Generate siteinfo-file with DOCUMENTER_CURRENT_VERSION
-            # Determine if this is a development version (e.g., "dev" or "latest")
-            is_dev_version = (subfolder == devurl || subfolder == "latest")
-            HTMLWriter.generate_siteinfo_file(deploy_dir, subfolder, is_dev_version)
-
-            # Expand the users `versions` vector
-            entries, symlinks = HTMLWriter.expand_versions(dirname, versions)
-
-            # Create the versions.js file containing a list of `entries`.
-            # This must always happen after the folder copying.
-            HTMLWriter.generate_version_file(joinpath(dirname, "versions.js"), entries, symlinks)
-
-            # Create the index.html file to redirect ./stable or ./dev.
-            # This must always happen after the folder copying.
-            HTMLWriter.generate_redirect_file(joinpath(dirname, "index.html"), entries)
-
-            # generate the symlinks, make sure we don't overwrite devurl
-            cd(dirname) do
-                for kv in symlinks
-                    i = findfirst(x -> x.first == devurl, symlinks)
-                    if i === nothing
-                        rm_and_add_symlink(kv.second, kv.first)
-                    else
-                        throw(
-                            ArgumentError(
-                                string(
-                                    "link `$(kv)` cannot overwrite ",
-                                    "`devurl = $(devurl)` with the same name."
-                                )
-                            )
-                        )
-                    end
-                end
-            end
-        end
+        postprocess_before_push(versions; subfolder, devurl, deploy_dir, dirname)
 
         # Add, commit, and push the docs to the remote.
         run(`$(git()) add -A -- ':!.documenter-identity-file.tmp' ':!**/.documenter-identity-file.tmp'`)
@@ -547,6 +517,57 @@ function git_push(
         end
     end
     return
+end
+
+"""
+    postprocess_before_push(versions; subfolder, devurl, deploy_dir, dirname)
+
+Run arbitrary logic (for example, creating siteinfo and version files)
+on the documentation with the new additions before the changes are pushed to the remote.
+The logic depends on the versioning scheme defined via `versions`.
+"""
+function postprocess_before_push(versions::Nothing; subfolder, devurl, deploy_dir, dirname)
+    # If the documentation is unversioned and deployed to root, we generate a
+    # siteinfo.js file that would disable the version selector in the docs
+    HTMLWriter.generate_siteinfo_file(deploy_dir, nothing)
+    return
+end
+
+function postprocess_before_push(versions::AbstractVector; subfolder, devurl, deploy_dir, dirname)
+    # Generate siteinfo-file with DOCUMENTER_CURRENT_VERSION
+    # Determine if this is a development version (e.g., "dev" or "latest")
+    is_dev_version = (subfolder == devurl || subfolder == "latest")
+    HTMLWriter.generate_siteinfo_file(deploy_dir, subfolder, is_dev_version)
+
+    # Expand the users `versions` vector
+    entries, symlinks = HTMLWriter.expand_versions(dirname, versions)
+
+    # Create the versions.js file containing a list of `entries`.
+    # This must always happen after the folder copying.
+    HTMLWriter.generate_version_file(joinpath(dirname, "versions.js"), entries, symlinks)
+
+    # Create the index.html file to redirect ./stable or ./dev.
+    # This must always happen after the folder copying.
+    HTMLWriter.generate_redirect_file(joinpath(dirname, "index.html"), entries)
+
+    # generate the symlinks, make sure we don't overwrite devurl
+    cd(dirname) do
+        for kv in symlinks
+            i = findfirst(x -> x.first == devurl, symlinks)
+            if i === nothing
+                rm_and_add_symlink(kv.second, kv.first)
+            else
+                throw(
+                    ArgumentError(
+                        string(
+                            "link `$(kv)` cannot overwrite ",
+                            "`devurl = $(devurl)` with the same name."
+                        )
+                    )
+                )
+            end
+        end
+    end
 end
 
 function rm_and_add_symlink(target, link)

--- a/src/deploydocs.jl
+++ b/src/deploydocs.jl
@@ -302,21 +302,6 @@ function deploydocs(;
     return
 end
 
-"""
-    determine_deploy_subfolder(deploy_decision, versions)
-
-Determine the subfolder to deploy to given the `deploy_decision` and the `versions`.
-Either return a `String` or `nothing` to deploy to the root folder.
-"""
-function determine_deploy_subfolder(deploy_decision, versions::Nothing)
-    # Non-versioned docs: deploy to root unless it's a preview
-    deploy_decision.is_preview ? deploy_decision.subfolder : nothing
-end
-
-function determine_deploy_subfolder(deploy_decision, versions::AbstractVector)
-    deploy_decision.subfolder
-end
-
 function _get_inventory_version(objects_inv)
     return open(objects_inv) do input
         for line in eachline(input)
@@ -519,13 +504,11 @@ function git_push(
     return
 end
 
-"""
-    postprocess_before_push(versions; subfolder, devurl, deploy_dir, dirname)
-
-Run arbitrary logic (for example, creating siteinfo and version files)
-on the documentation with the new additions before the changes are pushed to the remote.
-The logic depends on the versioning scheme defined via `versions`.
-"""
+# Run arbitrary logic (for example, creating siteinfo and version files)
+# on the documentation with the new additions before the changes are pushed to the remote.
+# The logic depends on the versioning scheme defined via `versions`.
+# This function was factored out as part of a "shadow API" via dispatch on the `versions` keyword arg
+# to `deploydocs`, for use in DocumenterVitepress because it cannot use the default versioning.
 function postprocess_before_push(versions::Nothing; subfolder, devurl, deploy_dir, dirname)
     # If the documentation is unversioned and deployed to root, we generate a
     # siteinfo.js file that would disable the version selector in the docs
@@ -568,6 +551,19 @@ function postprocess_before_push(versions::AbstractVector; subfolder, devurl, de
             end
         end
     end
+end
+
+# Determine the subfolder to deploy to given the `deploy_decision` and the `versions`.
+# Either return a `String` or `nothing` to deploy to the root folder.
+# This function was factored out as part of a "shadow API" via dispatch on the `versions` keyword arg
+# to `deploydocs`, for use in DocumenterVitepress because it cannot use the default versioning.
+function determine_deploy_subfolder(deploy_decision, versions::Nothing)
+    # Non-versioned docs: deploy to root unless it's a preview
+    deploy_decision.is_preview ? deploy_decision.subfolder : nothing
+end
+
+function determine_deploy_subfolder(deploy_decision, versions::AbstractVector)
+    deploy_decision.subfolder
 end
 
 function rm_and_add_symlink(target, link)


### PR DESCRIPTION
This PR is intended to allow DocumenterVitepress to deploy multiple vitepress builds of the same docs. This doesn't mesh with the current versioning behavior that Documenter allows, so I've refactored the places where `versions` is used with dispatchable functions instead of if blocks. I know that these were not intended to be public API, and maybe they can become sort of a shadow-API that only DocumenterVitepress uses, but this was the smallest change that I could think of to solve our issues without forking or reimplementing too much Documenter deploy logic.

You can see the functions created here used in this draft PR https://github.com/LuxDL/DocumenterVitepress.jl/pull/246/

I would like to get some feedback whether these changes are going to be considered or if we have to deal with things differently on the DocumenterVitepress side