### PR TITLE
Allow specifying a global default for `@meta` block settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* Added `meta` keyword to `makedocs` which allows to specify default values for `@meta` blocks. This can be used to alter the default values for anything that can be configured via a `@meta` block for all pages of the documentation. E.g. this can be used to set `CollapsedDocStrings = true` on all pages. ([#2512], [#2697])
+
 ### Changed
 
 * Work around GitHub rate limiting of link checks by passing `GITHUB_TOKEN` when applicable and available. ([#2729])
@@ -2046,6 +2050,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2499]: https://github.com/JuliaDocs/Documenter.jl/issues/2499
 [#2505]: https://github.com/JuliaDocs/Documenter.jl/issues/2505
 [#2511]: https://github.com/JuliaDocs/Documenter.jl/issues/2511
+[#2512]: https://github.com/JuliaDocs/Documenter.jl/issues/2512
 [#2513]: https://github.com/JuliaDocs/Documenter.jl/issues/2513
 [#2514]: https://github.com/JuliaDocs/Documenter.jl/issues/2514
 [#2526]: https://github.com/JuliaDocs/Documenter.jl/issues/2526
@@ -2091,6 +2096,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2692]: https://github.com/JuliaDocs/Documenter.jl/issues/2692
 [#2693]: https://github.com/JuliaDocs/Documenter.jl/issues/2693
 [#2695]: https://github.com/JuliaDocs/Documenter.jl/issues/2695
+[#2697]: https://github.com/JuliaDocs/Documenter.jl/issues/2697
 [#2701]: https://github.com/JuliaDocs/Documenter.jl/issues/2701
 [#2710]: https://github.com/JuliaDocs/Documenter.jl/issues/2710
 [#2714]: https://github.com/JuliaDocs/Documenter.jl/issues/2714

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -312,6 +312,8 @@ page. Currently recognized keys:
   When `false` (default), unnamed blocks will each have a separate sandbox module where the code gets evaluated.
   In either case, named blocks always have their own sandbox module, shared by the blocks with the same name.
 
+Global default values for each of these can also be set via the `meta` keyword of [`makedocs`](@ref).
+
 Example:
 
 ````markdown

--- a/src/doctests.jl
+++ b/src/doctests.jl
@@ -14,7 +14,7 @@ struct DocTestContext
     file::String
     doc::Documenter.Document
     meta::Dict{Symbol, Any}
-    DocTestContext(file::String, doc::Documenter.Document) = new(file, doc, Dict())
+    DocTestContext(file::String, doc::Documenter.Document) = new(file, doc, copy(doc.user.meta))
 end
 
 """

--- a/src/documents.jl
+++ b/src/documents.jl
@@ -362,6 +362,7 @@ struct User
     version::String # version string used in the version selector by default
     highlightsig::Bool  # assume leading unlabeled code blocks in docstrings to be Julia.
     draft::Bool
+    meta::Dict{Symbol, Any} # default @meta block data for pages
 end
 
 """
@@ -424,6 +425,7 @@ function Document(;
         version::AbstractString = "",
         highlightsig::Bool = true,
         draft::Bool = false,
+        meta::Dict{Symbol} = Dict{Symbol, Any}(),
         others...
     )
 
@@ -489,6 +491,7 @@ function Document(;
         version,
         highlightsig,
         draft,
+        meta,
     )
     internal = Internal(
         assetsdir(),

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -52,7 +52,7 @@ function expand(doc::Documenter.Document)
     for src in Iterators.flatten([priority_pages, normal_pages])
         page = doc.blueprint.pages[src]
         @debug "Running ExpanderPipeline on $src"
-        empty!(page.globals.meta)
+        copy!(page.globals.meta, doc.user.meta)
         # We need to collect the child nodes here because we will end up changing the structure
         # of the tree in some cases.
         for node in collect(page.mdast.children)

--- a/src/makedocs.jl
+++ b/src/makedocs.jl
@@ -166,6 +166,11 @@ For example, if you have `foo.md` and `bar.md`, `bar.md` would normally be evalu
 Evaluation order among the `expandfirst` pages is according to the order they appear in the
 argument.
 
+**`meta`** can be used to provide default values for the `@meta` blocks executed on every
+page. For example `meta = Dict(:DocTestSetup => :(using MyPackages))` sets `DocTestSetup`
+on every page to the code block `:(using MyPackages)`. This can still be overridden on
+each individual page.
+
 **`draft`** can be set to `true` to build a draft version of the document. In draft mode
 some potentially time-consuming steps are skipped (e.g. running `@example` blocks), which is
 useful when iterating on the documentation. This setting can also be configured per-page

--- a/test/default_meta/src/index.md
+++ b/test/default_meta/src/index.md
@@ -1,0 +1,10 @@
+# Testing
+
+We test the `meta` keyword to `makedocs` by using it to set `DocTestSetup` to
+code which initializes `x`. If and only if that setup block is run, the
+following doctest passes.
+
+```jldoctest
+julia> x
+42
+```

--- a/test/default_meta/tests.jl
+++ b/test/default_meta/tests.jl
@@ -1,0 +1,13 @@
+using Documenter
+using Test
+
+const pages = [
+    "Home" => "index.md",
+]
+
+makedocs(
+    sitename = "Test", pages = pages, doctest = true,
+    meta = Dict(:DocTestSetup => :(x = 42))
+)
+
+# the test is passing the doctest

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,6 +98,10 @@ end
     @info "Building clear_module/tests.jl"
     @quietly include("clear_module/tests.jl")
 
+    # A simple build verifying that default meta data for pages works
+    @info "Building default_meta/tests.jl"
+    @quietly include("default_meta/tests.jl")
+
     # Passing a writer positionally (https://github.com/JuliaDocs/Documenter.jl/issues/1046)
     @test_throws MethodError makedocs(sitename = "", HTML())
 


### PR DESCRIPTION
This allows to e.g. use a common doctest setup block on all pages, thus complementing `DocMeta.setdocmeta!`.

Other nice applications include changing certain settings, such `CollapsedDocStrings = true` globally, or being able to specify `CurrentModule = YourPackageModule` globally.

Resolves #2512. Resolves #2684. Resolves #1253

CC @lgoettgens 


---

This is a first prototype. No documentation or changelog entry yet as the design is still not finalized.

This adds a new kwarg `default_meta` to `makedocs` -- contrary to the discussion in #2512 this expects a `Dict{Symbol,Any}`. The main reasons for doing it this way are:
1. this was the easiest to implement :-) which is important for an MVP
2. arguably this is also the easiest to document and explain (as in: what are the semantics of this option)
3. it is sufficient to set up a basic test, and also sufficient for my primary applications in Oscar.jl
4. it does not preclude us from accepting a quoted code block in the future -- we could simply add support for that *in addition* to what this PR implements...


I've been wondering if it wouldn't be nicer to accept a named tuple instead of (or in addition to?) a `Dict{Symbol,Any}`, the syntax then would look a bit closer to the actual content of a `@meta` block.

Of course accepting actual quoted code blocks would make the input *even closer* to an actual `@meta` block. As I wrote above, we could still add support for that if it turns out someone needs it. When we do, it then should also be easier to resolve the question "when to evaluate the code block" (once at the start? once for each page? something else?) because we'll have a concrete usecase at hand...

That said, I am totally open to change this MVP based on your comments.