### PR TITLE
Load time optimization: download search index asynchronously; make cacheable

### DIFF
--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -771,7 +771,6 @@ function render(doc::Documenter.Document, settings::HTML = HTML())
     end
 
     ctx = HTMLContext(doc, settings)
-    ctx.search_index_js = "search_index.js"
     ctx.themeswap_js = copy_asset("themeswap.js", doc)
     ctx.warner_js = copy_asset("warner.js", doc)
 
@@ -800,9 +799,34 @@ function render(doc::Documenter.Document, settings::HTML = HTML())
         copy_asset("themes/$(theme).css", doc)
     end
 
-    size_limit_successes = map(collect(keys(doc.blueprint.pages))) do page
+    function page_navnode(page)
         idx = findfirst(nn -> nn.page == page, doc.internal.navlist)
         nn = (idx === nothing) ? Documenter.NavNode(page, nothing, nothing) : doc.internal.navlist[idx]
+        nn, idx
+    end
+
+    foreach(keys(doc.blueprint.pages)) do page
+        nn, idx = page_navnode(page)
+        @debug "Indexing $(page) [$(repr(idx))]"
+        generate_index!(ctx, nn)
+    end
+
+    # Make an attempt at avoiding spurious changes to the search index hash.
+    sort!(ctx.search_index; by=r -> (r.src, r.fragment, r.text))
+    search_index_buf = let io = IOBuffer()
+        println(io, "var documenterSearchIndex = {\"docs\":")
+        # convert Vector{SearchRecord} to a JSON string + do additional JS escaping
+        println(io, JSDependencies.json_jsescape(ctx.search_index), "\n}")
+        take!(io)
+    end
+    # Put the index's hash in its filename so it can have a long max-age.
+    ctx.search_index_js = "search_index_$(dataslug(search_index_buf)).js"
+    open(joinpath(doc.user.build, ctx.search_index_js), "w") do io
+        write(io, search_index_buf)
+    end
+
+    size_limit_successes = map(collect(keys(doc.blueprint.pages))) do page
+        nn, idx = page_navnode(page)
         @debug "Rendering $(page) [$(repr(idx))]"
         render_page(ctx, nn)
     end
@@ -836,12 +860,6 @@ function render(doc::Documenter.Document, settings::HTML = HTML())
     end
     # Check that all HTML files are smaller or equal to size_threshold option
     all(size_limit_successes) || throw(HTMLSizeThresholdError())
-
-    open(joinpath(doc.user.build, ctx.search_index_js), "w") do io
-        println(io, "var documenterSearchIndex = {\"docs\":")
-        # convert Vector{SearchRecord} to a JSON string + do additional JS escaping
-        println(io, JSDependencies.json_jsescape(ctx.search_index), "\n}")
-    end
 
     write_inventory(doc, ctx)
 
@@ -1027,7 +1045,7 @@ function render_head(ctx, navnode)
             :src => RD.requirejs_cdn,
             Symbol("data-main") => relhref(src, ctx.documenter_js),
         ],
-        script[:src => relhref(src, ctx.search_index_js)],
+        script[:src => relhref(src, ctx.search_index_js), :async],
 
         script[:src => relhref(src, "siteinfo.js")],
         script[:src => relhref(src, "../versions.js")],
@@ -1700,10 +1718,6 @@ end
 function domify(dctx::DCtx)
     ctx, navnode = dctx.ctx, dctx.navnode
     return map(getpage(ctx, navnode).mdast.children) do node
-        rec = searchrecord(ctx, navnode, node)
-        if !isnothing(rec)
-            push!(ctx.search_index, rec)
-        end
         domify(dctx, node, node.element)
     end
 end
@@ -1848,6 +1862,14 @@ function domify(::DCtx, ::Node, rawnode::Documenter.RawNode)
     return rawnode.name === :html ? DOM.Tag(Symbol("#RAW#"))(rawnode.text) : DOM.Node[]
 end
 
+function generate_index!(ctx::HTMLContext, navnode::Documenter.NavNode)
+    map(getpage(ctx, navnode).mdast.children) do node
+        rec = searchrecord(ctx, navnode, node)
+        if !isnothing(rec)
+            push!(ctx.search_index, rec)
+        end
+    end
+end
 
 # Utilities
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
If you have not visited https://docs.julialang.org for 10 minutes, there is a very noticeable delay as all of the assets hosted by GitHub are either validated or redownloaded.  The worst offender is `search_index.js`, which is 4.4 MiB (1 MiB gzipped).

This PR does two things to make the situation a little better:
- We block rendering until the search index is fully loaded, even though `search.js` handles asynchronously loading the index just fine. This is a simple matter of making the script tag `async`.
- The search index becomes stale absurdly quickly.  Unfortunately, GitHub pages sets `Cache-Control: max-age=600` on everything it hosts, so we're mostly stuck with this situation there. We can still make it a little better for docs hosted elsewhere by putting the search index's hash into its filename, so it can stay fresh indefinitely.

Before, with slow internet and render blocking network requested boxed in red:
![Screenshot 2025-05-06 at 4 23 48 PM](https://github.com/user-attachments/assets/24cf666d-023c-46e5-ad16-335d8a2fe3bb)

After:
![Screenshot 2025-05-06 at 4 24 01 PM](https://github.com/user-attachments/assets/932fc80b-6208-404a-a359-1b58012d81a2)
