### PR TITLE
Adapt wording regarding `deploy_repo` and `repo_preview`

### DIFF
--- a/src/deploydocs.jl
+++ b/src/deploydocs.jl
@@ -146,7 +146,7 @@ forks.
 It defaults to the value of `branch`.
 
 **`repo_previews`** can be used to override the remote repository to which pull request previews are
-deployed. If this is unset, it will be the same as `deploy_repo` (if that is set) or `repo` otherwise.
+deployed. If this is not set, it will be the same as `deploy_repo` (if that is set) or `repo` otherwise.
 The expected format of the argument is the same as for `repo`.
 
 !!! note

--- a/src/deploydocs.jl
+++ b/src/deploydocs.jl
@@ -145,9 +145,9 @@ forks.
 **`branch_previews`** is the branch to which pull request previews are deployed.
 It defaults to the value of `branch`.
 
-**`repo_previews`** is the remote repository to which pull request previews are
-deployed. It defaults to the value of `repo`, and when specified manually, must
-follow its formatting scheme.
+**`repo_previews`** can be used to override the remote repository to which pull request previews are
+deployed. If this is unset, it will be the same as `deploy_repo` (if that is set) or `repo` otherwise.
+The expected format of the argument is the same as for `repo`.
 
 !!! note
     Pull requests made from forks will not have previews.


### PR DESCRIPTION
A small docs follow-up to https://github.com/JuliaDocs/Documenter.jl/pull/2692. I haven't seen this before that got merged, but I think that currently the docstring differs from the functionality. (Apart from that I am really looking forward for a release with this change!)

https://github.com/JuliaDocs/Documenter.jl/pull/2692 set the default for both `deploy_repo` and `repo_previews` to `nothing` (instead of `repo_previews = repo` previously), but the explanation of `repo_previews` didn't get adapted accordingly.
Furthermore, it should be documented that `repo_previews` first falls back to `deploy_repo` and only after that to `repo` (cf https://github.com/JuliaDocs/Documenter.jl/blob/fcee2bfb2ff1ea8c88858fee784caa7b113efe82/src/deployconfig.jl#L232)

cc @goerz @mortenpi @vchuravy 