### PR TITLE
Fix LaTeXWriter with local images on Windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,6 +71,10 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: fontist/setup-fontist@v2
+        if: matrix.os == 'windows-latest'
+      - run: fontist install "DejaVu"
+        if: matrix.os == 'windows-latest'
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,8 +61,14 @@ jobs:
           path-to-lcov: lcov.info
 
   latex:
-    name: "PDF/LaTeX backend"
-    runs-on: ubuntu-latest
+    name: "PDF/LaTeX backend - ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,13 +71,15 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.0.0"
-        if: matrix.os == 'windows-latest'
-      - uses: fontist/setup-fontist@v2
-        if: matrix.os == 'windows-latest'
-      - run: fontist install --formula "DejaVu"
+      - name: "Download and install DejaVu fonts"
+        run: |
+          Invoke-WebRequest "https://github.com/dejavu-fonts/dejavu-fonts/releases/download/version_2_37/dejavu-fonts-ttf-2.37.zip" -OutFile "DejaVu.zip"
+          Expand-Archive -Path "DejaVu.zip" -DestinationPath "."
+          $fonts = (New-Object -ComObject Shell.Application).Namespace(0x14)
+          foreach ($file in gci -Path ".\dejavu-fonts-ttf-2.37\ttf" "*.ttf")
+          {
+            $fonts.CopyHere($file.fullname)
+          }
         if: matrix.os == 'windows-latest'
       - uses: julia-actions/setup-julia@v2
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -99,6 +99,7 @@ jobs:
             upquote
             tabulary
             tcolorbox
+        if: matrix.os == 'windows-latest'
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -108,8 +108,6 @@ jobs:
         run: |
           using Pkg
           Pkg.instantiate()
-          Pkg.develop(PackageSpec(path=pwd()))
-          Pkg.add(["IOCapture", "tectonic_jll"])
       - name: Run test/examples/tests_latex.jl
         run: julia --color=yes --project=test/examples --code-coverage test/examples/tests_latex.jl
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -99,7 +99,6 @@ jobs:
             upquote
             tabulary
             tcolorbox
-        if: matrix.os == 'windows-latest'
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -81,6 +81,21 @@ jobs:
             $fonts.CopyHere($file.fullname)
           }
         if: matrix.os == 'windows-latest'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+        if: matrix.os == 'windows-latest'
+      - uses: teatimeguest/setup-texlive-action@v3
+        with:
+          packages: |
+            scheme-medium
+            hyperref
+            minted
+            newunicodechar
+            transparent
+            upquote
+            tabulary
+            tcolorbox
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -127,7 +127,7 @@ jobs:
           path-to-lcov: lcov.info
       - uses: actions/upload-artifact@v4
         with:
-          name: PDFs
+          name: "PDFs-${{ matrix.os }}"
           path: test/examples/builds/*/*.pdf
 
   themes:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,6 +71,10 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.0.0"
+        if: matrix.os == 'windows-latest'
       - uses: fontist/setup-fontist@v2
         if: matrix.os == 'windows-latest'
       - run: fontist install "DejaVu"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -85,6 +85,9 @@ jobs:
         with:
           python-version: "3.13"
         if: matrix.os == 'windows-latest'
+      - name: "install pygments for tectonic"
+        run: pip install pygments
+        if: matrix.os == 'windows-latest'
       - uses: teatimeguest/setup-texlive-action@v3
         with:
           packages: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -77,7 +77,7 @@ jobs:
         if: matrix.os == 'windows-latest'
       - uses: fontist/setup-fontist@v2
         if: matrix.os == 'windows-latest'
-      - run: fontist install "DejaVu"
+      - run: fontist install --formula "DejaVu"
         if: matrix.os == 'windows-latest'
       - uses: julia-actions/setup-julia@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * In Julia v1.12, the queries used by `clear_module!` will now be versioned by world, allowing the deleting of bindings to work correctly. ([#2693])
+* Fixed an issue when building PDFs with local images on Windows ([#2434])
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+* Fixed an issue when building PDFs with local images on Windows. ([#2434])
+
 ## Version [v1.11.0] - 2025-05-09
 
 ### Added
@@ -19,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * In Julia v1.12, the queries used by `clear_module!` will now be versioned by world, allowing the deleting of bindings to work correctly. ([#2693])
-* Fixed an issue when building PDFs with local images on Windows ([#2434])
 
 ### Other
 

--- a/src/latex/LaTeXWriter.jl
+++ b/src/latex/LaTeXWriter.jl
@@ -110,7 +110,7 @@ function render(doc::Documenter.Document, settings::LaTeX = LaTeX())
     if isempty(doc.user.sitename) # otherwise, the latex compiler will terminate with a cryptic "There's no line here to end" error
         error(
             """
-            LaTeXWriter needs a non-empty `sitename` passed to `makedocs`, otherwise the LaTeX build will error!  
+            LaTeXWriter needs a non-empty `sitename` passed to `makedocs`, otherwise the LaTeX build will error!
             Please pass e.g. `sitename = "Some Site Name"` as a keyword argument to `makedocs`.
             """
         )
@@ -735,7 +735,7 @@ function latex(io::Context, node::Node, image::Documenter.LocalImage)
     wrapblock(io, "figure") do
         _println(io, "\\centering")
         wrapinline(io, "includegraphics[max width=\\linewidth]") do
-            _print(io, image.path)
+            _print(io, replace(image.path, "\\" => "/"))
         end
         _println(io)
         wrapinline(io, "caption") do

--- a/test/examples/Project.toml
+++ b/test/examples/Project.toml
@@ -2,3 +2,6 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 IOCapture = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
 tectonic_jll = "d7dd28d6-a5e6-559c-9131-7eb760cdacc5"
+
+[sources]
+Documenter = {path = "../.."}

--- a/test/examples/Project.toml
+++ b/test/examples/Project.toml
@@ -1,4 +1,0 @@
-[deps]
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-IOCapture = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
-tectonic_jll = "d7dd28d6-a5e6-559c-9131-7eb760cdacc5"

--- a/test/examples/Project.toml
+++ b/test/examples/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+IOCapture = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
+tectonic_jll = "d7dd28d6-a5e6-559c-9131-7eb760cdacc5"

--- a/test/examples/tests_latex.jl
+++ b/test/examples/tests_latex.jl
@@ -2,10 +2,13 @@ using Test
 
 # DOCUMENTER_TEST_EXAMPLES can be used to control which builds are performed in
 # make.jl, and we need to set it to the relevant LaTeX builds.
-ENV["DOCUMENTER_TEST_EXAMPLES"] =
-    "latex latex_simple latex_cover_page latex_toc_style latex_simple_tectonic " *
-    "latex_showcase"
-
+if Sys.iswindows() && get(ENV, "GITHUB_ACTIONS", nothing) == "true"
+    ENV["DOCUMENTER_TEST_EXAMPLES"] = "latex_simple_tectonic"
+else
+    ENV["DOCUMENTER_TEST_EXAMPLES"] =
+        "latex latex_simple latex_cover_page latex_toc_style latex_simple_tectonic " *
+        "latex_showcase"
+end
 # When the file is run separately we need to include make.jl which actually builds
 # the docs and defines a few modules that are referred to in the docs. The make.jl
 # has to be expected in the context of the Main module.
@@ -27,35 +30,45 @@ else
 end
 
 @testset "Examples/LaTeX" begin
-    @testset "PDF/LaTeX: simple" begin
-        doc = Main.examples_latex_simple_doc
-        @test isa(doc, Documenter.Documenter.Document)
-        let build_dir = joinpath(examples_root, "builds", "latex_simple")
-            @test joinpath(build_dir, "DocumenterLaTeXSimple-1.2.3.pdf") |> isfile
+    if !(Sys.iswindows() && get(ENV, "GITHUB_ACTIONS", nothing) == "true")
+        @testset "PDF/LaTeX: simple" begin
+            doc = Main.examples_latex_simple_doc
+            @test isa(doc, Documenter.Documenter.Document)
+            let build_dir = joinpath(examples_root, "builds", "latex_simple")
+                @test joinpath(build_dir, "DocumenterLaTeXSimple-1.2.3.pdf") |> isfile
+            end
         end
-    end
 
-    @testset "PDF/LaTeX" begin
-        doc = Main.examples_latex_doc
-        @test isa(doc, Documenter.Documenter.Document)
-        let build_dir = joinpath(examples_root, "builds", "latex")
-            @test joinpath(build_dir, "DocumenterLaTeX$(tagsuffix).pdf") |> isfile
+        @testset "PDF/LaTeX" begin
+            doc = Main.examples_latex_doc
+            @test isa(doc, Documenter.Documenter.Document)
+            let build_dir = joinpath(examples_root, "builds", "latex")
+                @test joinpath(build_dir, "DocumenterLaTeX$(tagsuffix).pdf") |> isfile
+            end
         end
-    end
 
-    @testset "PDF/LaTeX: Custom Cover Page" begin
-        doc = Main.examples_latex_cover_page
-        @test isa(doc, Documenter.Documenter.Document)
-        let build_dir = joinpath(examples_root, "builds", "latex_cover_page")
-            @test joinpath(build_dir, "DocumenterLaTeX$(tagsuffix).pdf") |> isfile
+        @testset "PDF/LaTeX: Custom Cover Page" begin
+            doc = Main.examples_latex_cover_page
+            @test isa(doc, Documenter.Documenter.Document)
+            let build_dir = joinpath(examples_root, "builds", "latex_cover_page")
+                @test joinpath(build_dir, "DocumenterLaTeX$(tagsuffix).pdf") |> isfile
+            end
         end
-    end
 
-    @testset "PDF/LaTeX: Custom TOC Style" begin
-        doc = Main.examples_latex_toc_style
-        @test isa(doc, Documenter.Documenter.Document)
-        let build_dir = joinpath(examples_root, "builds", "latex_toc_style")
-            @test joinpath(build_dir, "DocumenterLaTeX$(tagsuffix).pdf") |> isfile
+        @testset "PDF/LaTeX: Custom TOC Style" begin
+            doc = Main.examples_latex_toc_style
+            @test isa(doc, Documenter.Documenter.Document)
+            let build_dir = joinpath(examples_root, "builds", "latex_toc_style")
+                @test joinpath(build_dir, "DocumenterLaTeX$(tagsuffix).pdf") |> isfile
+            end
+        end
+
+        @testset "PDF/LaTeX: showcase" begin
+            doc = Main.examples_latex_showcase_doc
+            @test isa(doc, Documenter.Documenter.Document)
+            let build_dir = joinpath(examples_root, "builds", "latex_showcase")
+                @test joinpath(build_dir, "DocumenterLaTeXShowcase-1.2.3.pdf") |> isfile
+            end
         end
     end
 
@@ -64,14 +77,6 @@ end
         @test isa(doc, Documenter.Documenter.Document)
         let build_dir = joinpath(examples_root, "builds", "latex_simple_tectonic")
             @test joinpath(build_dir, "DocumenterLaTeXSimpleTectonic-1.2.3.pdf") |> isfile
-        end
-    end
-
-    @testset "PDF/LaTeX: showcase" begin
-        doc = Main.examples_latex_showcase_doc
-        @test isa(doc, Documenter.Documenter.Document)
-        let build_dir = joinpath(examples_root, "builds", "latex_showcase")
-            @test joinpath(build_dir, "DocumenterLaTeXShowcase-1.2.3.pdf") |> isfile
         end
     end
 end

--- a/test/examples/tests_latex.jl
+++ b/test/examples/tests_latex.jl
@@ -3,10 +3,10 @@ using Test
 # DOCUMENTER_TEST_EXAMPLES can be used to control which builds are performed in
 # make.jl, and we need to set it to the relevant LaTeX builds.
 if Sys.iswindows() && get(ENV, "GITHUB_ACTIONS", nothing) == "true"
-    ENV["DOCUMENTER_TEST_EXAMPLES"] = "latex_simple_tectonic"
+    ENV["DOCUMENTER_TEST_EXAMPLES"] = "latex_simple_nondocker latex_simple_tectonic"
 else
     ENV["DOCUMENTER_TEST_EXAMPLES"] =
-        "latex latex_simple latex_cover_page latex_toc_style latex_simple_tectonic " *
+        "latex latex_simple latex_cover_page latex_toc_style latex_simple_nondocker latex_simple_tectonic " *
         "latex_showcase"
 end
 # When the file is run separately we need to include make.jl which actually builds
@@ -77,6 +77,14 @@ end
         @test isa(doc, Documenter.Documenter.Document)
         let build_dir = joinpath(examples_root, "builds", "latex_simple_tectonic")
             @test joinpath(build_dir, "DocumenterLaTeXSimpleTectonic-1.2.3.pdf") |> isfile
+        end
+    end
+
+    @testset "PDF/LaTeX: native" begin
+        doc = Main.examples_latex_simple_nondocker_doc
+        @test isa(doc, Documenter.Documenter.Document)
+        let build_dir = joinpath(examples_root, "builds", "latex_simple_nondocker")
+            @test joinpath(build_dir, "DocumenterLaTeXSimpleNon-Docker-1.2.3.pdf") |> isfile
         end
     end
 end


### PR DESCRIPTION
LaTeX expects paths to be separated with `/` on all platforms. Using `normpath` changes the separators to `\\` on Windows which then need to be replaced for `includegraphics`.

I've also updated the CI workflow to run the PDF/LaTeX backend on `ubuntu-latest` and `windows-latest`.

Fixes #2434, closes #2440.