### PR TITLE
fix coverallsapp with parallel-finished

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,6 +59,8 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: lcov.info
+          flag-name: test-${{ join(matrix.*, '-') }}
+          parallel: true
 
   latex:
     name: "PDF/LaTeX backend - ${{ matrix.os }}"
@@ -123,6 +125,8 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: lcov.info
+          flag-name: latex-${{ join(matrix.*, '-') }}
+          parallel: true
       - uses: actions/upload-artifact@v4
         with:
           name: "PDFs-${{ matrix.os }}"
@@ -176,6 +180,8 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: lcov.info
+          flag-name: prerender-${{ join(matrix.*, '-') }}
+          parallel: true
 
   docs:
     name: 'Documentation: ${{ matrix.format }}'
@@ -231,7 +237,9 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: lcov.info
-
+          flag-name: linkcheck-${{ join(matrix.*, '-') }}
+          parallel: true
+          
   linkcheck-manual:
     name: "Linkcheck: Documenter manual"
     runs-on: ubuntu-latest
@@ -275,3 +283,13 @@ jobs:
         uses: actions/checkout@v4
       - name: Check spelling
         uses: crate-ci/typos@master
+
+  finish:
+    needs: [test, latex, prerender, linkcheck]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@v2
+      with:
+        parallel-finished: true


### PR DESCRIPTION
coverallsapp is failing on CI sporadically because this is missing (though not reported as failing overall since continue-on-error is set)

e.g. https://github.com/JuliaDocs/Documenter.jl/actions/runs/14962756406/job/42027336887#step:9:123