### PR TITLE
add patch file option

### DIFF
--- a/src/documents.jl
+++ b/src/documents.jl
@@ -315,6 +315,7 @@ struct User
     checkdocs::Symbol # Check objects missing from `@docs` blocks. `:none`, `:exports`, `:public` or `:all`.
     checkdocs_ignored_modules::Vector{Module} # ..and then ignore (some of) them.
     doctestfilters::Vector{<:Any} # Filtering for doctests
+    patchfile::AbstractString # Save patch from documented to true output here
     warnonly::Vector{Symbol} # List of docerror groups that should only warn, rather than cause a build failure
     pages::Vector{Any} # Ordering of document pages specified by the user.
     pagesonly::Bool # Discard any .md pages from processing that are not in .pages
@@ -390,6 +391,7 @@ function Document(;
         checkdocs::Symbol = :all,
         checkdocs_ignored_modules::Vector{Module} = Module[],
         doctestfilters::Vector{<:Any} = Regex[],
+        patchfile::AbstractString = "",
         warnonly::Union{Bool, Symbol, Vector{Symbol}} = Symbol[],
         modules::Union{Module, Vector{Module}} = Module[],
         pages::Vector = Any[],
@@ -457,6 +459,7 @@ function Document(;
         checkdocs,
         checkdocs_ignored_modules,
         doctestfilters,
+        patchfile,
         warnonly,
         pages,
         pagesonly,


### PR DESCRIPTION
Imagine that you have a package with an extensive, up-to-date documentation. Then you modify `show` for some type defined in your package, one that appears in almost all docstrings. (Alternatively, someone else did it in a package you use.) Now many doctests will fail, and you have to edit all them manually. It is for this scenario (that of course has happened to me) that I have added a `patchfile` option to `makedocs`. If one uses the options
```
warnonly = true, patchfile = "doctest.patch"
```
then after running Documenter one gets a patch file (in the `docs` directory) that one can apply to the source code. Assuming that all doctests could be located in the source, this will bring the documentation completely up-to-date.

The patch still needs some polishing, but I first want to inquire if you are interested. One thing one may want to change is how paths are stored in the patch file. Currently I'm using absolute paths.