### PR TITLE
Use symbol :display instead of function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## Version [v1.11.2] - 2025-05-14
 
 ### Fixed
 
@@ -1511,6 +1511,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v1.10.2]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.10.2
 [v1.11.0]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.11.0
 [v1.11.1]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.11.1
+[v1.11.2]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.11.2
 [#198]: https://github.com/JuliaDocs/Documenter.jl/issues/198
 [#245]: https://github.com/JuliaDocs/Documenter.jl/issues/245
 [#487]: https://github.com/JuliaDocs/Documenter.jl/issues/487
@@ -2073,6 +2074,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2710]: https://github.com/JuliaDocs/Documenter.jl/issues/2710
 [#2714]: https://github.com/JuliaDocs/Documenter.jl/issues/2714
 [#2717]: https://github.com/JuliaDocs/Documenter.jl/issues/2717
+[#2721]: https://github.com/JuliaDocs/Documenter.jl/issues/2721
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+* Fixed minor issue where `display` function was a Dict config key for KaTex vs. `:display` Symbol ([#2721])
+
 ## Version [v1.11.1] - 2025-05-13
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Documenter"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.11.1"
+version = "1.11.2"
 
 [deps]
 ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -192,9 +192,9 @@ struct KaTeX <: MathEngine
     function KaTeX(config::Union{Dict, Nothing} = nothing, override = false)
         default = Dict(
             :delimiters => [
-                Dict(:left => raw"$", :right => raw"$", display => false),
-                Dict(:left => raw"$$", :right => raw"$$", display => true),
-                Dict(:left => raw"\[", :right => raw"\]", display => true),
+                Dict(:left => raw"$", :right => raw"$", :display => false),
+                Dict(:left => raw"$$", :right => raw"$$", :display => true),
+                Dict(:left => raw"\[", :right => raw"\]", :display => true),
             ]
         )
         return new((config === nothing) ? default : override ? config : merge(default, config))


### PR DESCRIPTION
I believe these Dict keys are meant to be Symbols rather than the `display` function. Caught in https://github.com/JuliaIO/JSON.jl/actions/runs/14942383442/job/42145192605?pr=374 where JSON.jl will no longer automatically call string on non-string-like Dict keys.