### PR TITLE
Fix non-standard versions in deploydocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,17 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version [v1.11.3] - 2025-05-15
+
+### Fixed
+
+* Fixed the handling of non-standard `versions` arguments of `deploydocs`. ([#2722])
+
 ## Version [v1.11.2] - 2025-05-14
 
 ### Fixed
 
-* Fixed minor issue where `display` function was a Dict config key for KaTex vs. `:display` Symbol ([#2721])
+* Fixed minor issue where `display` function was a Dict config key for KaTex vs. `:display` Symbol. ([#2721])
 
 ## Version [v1.11.1] - 2025-05-13
 
@@ -1512,6 +1518,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v1.11.0]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.11.0
 [v1.11.1]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.11.1
 [v1.11.2]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.11.2
+[v1.11.3]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.11.3
 [#198]: https://github.com/JuliaDocs/Documenter.jl/issues/198
 [#245]: https://github.com/JuliaDocs/Documenter.jl/issues/245
 [#487]: https://github.com/JuliaDocs/Documenter.jl/issues/487
@@ -2075,6 +2082,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2714]: https://github.com/JuliaDocs/Documenter.jl/issues/2714
 [#2717]: https://github.com/JuliaDocs/Documenter.jl/issues/2717
 [#2721]: https://github.com/JuliaDocs/Documenter.jl/issues/2721
+[#2722]: https://github.com/JuliaDocs/Documenter.jl/issues/2722
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Documenter"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.11.2"
+version = "1.11.3"
 
 [deps]
 ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"

--- a/src/deploydocs.jl
+++ b/src/deploydocs.jl
@@ -574,8 +574,15 @@ function determine_deploy_subfolder(deploy_decision, versions::Nothing)
     # Non-versioned docs: deploy to root unless it's a preview
     return deploy_decision.is_preview ? deploy_decision.subfolder : nothing
 end
-
+# Method to handle the standard versions = [...] argument.
 function determine_deploy_subfolder(deploy_decision, versions::AbstractVector)
+    return deploy_decision.subfolder
+end
+# Fallback determine_deploy_subfolder for any non-standard `versions` arguments.
+function determine_deploy_subfolder(deploy_decision, versions::Any)
+    @warn """
+    Using a non-standard versions= argument, but determine_deploy_subfolder() is not implemented.
+    """ typeof(versions) versions
     return deploy_decision.subfolder
 end
 


### PR DESCRIPTION
The Julia manual passes a `struct` as `versions. So we should make sure this keeps working. It's pretty undocumented, so let's add a warning.

X-ref: https://github.com/JuliaLang/julia/pull/58404#issuecomment-2882061362