### PR TITLE
Assets: allow passing direct HTML content into `asset` kwarg (for Pluto support)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Version [v1.13.0] - not yet released
+## Version [v1.13.0] - 2025-06-19
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1544,6 +1544,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v1.11.3]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.11.3
 [v1.11.4]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.11.4
 [v1.12.0]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.12.0
+[v1.13.0]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.13.0
 [#198]: https://github.com/JuliaDocs/Documenter.jl/issues/198
 [#245]: https://github.com/JuliaDocs/Documenter.jl/issues/245
 [#487]: https://github.com/JuliaDocs/Documenter.jl/issues/487

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version [v1.13.0] - not yet released
+
+### Added
+
+* Added new type `RawHTMLHeadContent` to `HTML` format object, which allows to add raw HTML to the head of the HTML output, by passing it as a element in the `assets` keyword argument. ([#2726])
+
 ## Version [v1.12.0] - 2025-06-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2111,6 +2111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2721]: https://github.com/JuliaDocs/Documenter.jl/issues/2721
 [#2722]: https://github.com/JuliaDocs/Documenter.jl/issues/2722
 [#2723]: https://github.com/JuliaDocs/Documenter.jl/issues/2723
+[#2726]: https://github.com/JuliaDocs/Documenter.jl/issues/2726
 [#2729]: https://github.com/JuliaDocs/Documenter.jl/issues/2729
 [#2737]: https://github.com/JuliaDocs/Documenter.jl/issues/2737
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Documenter"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.12.0"
+version = "1.13.0"
 
 [deps]
 ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"

--- a/docs/src/lib/internals/writers.md
+++ b/docs/src/lib/internals/writers.md
@@ -11,7 +11,7 @@ Modules = [
     Documenter.HTMLWriter.RD,
     Documenter.LaTeXWriter,
 ]
-Filter = t -> t !== asset
+Filter = t -> t ∉ (asset, RawHTMLHeadContent)
 Pages = ["writers.jl", "html/HTMLWriter.jl", "html/RD.jl", "html/write_inventory.jl", "latex/LaTeXWriter.jl"]
 ```
 ```@docs

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -26,7 +26,7 @@ Documenter.except
 hide
 Documenter.MissingRemoteError
 asset
-Documenter.RawHTMLHeadContent
+RawHTMLHeadContent
 deploydocs
 doctest
 DocMeta

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -26,7 +26,7 @@ Documenter.except
 hide
 Documenter.MissingRemoteError
 asset
-RawHTMLHeadContent
+Documenter.RawHTMLHeadContent
 deploydocs
 doctest
 DocMeta

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -26,6 +26,7 @@ Documenter.except
 hide
 Documenter.MissingRemoteError
 asset
+RawHTMLHeadContent
 deploydocs
 doctest
 DocMeta

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -93,13 +93,13 @@ module Writers
     import ..HTMLWriter
 end
 
-import .HTMLWriter: HTML, asset
+import .HTMLWriter: HTML, asset, RawHTMLHeadContent
 import .HTMLWriter.RD: KaTeX, MathJax, MathJax2, MathJax3
 import .LaTeXWriter: LaTeX
 
 # User Interface.
 # ---------------
-export makedocs, deploydocs, hide, doctest, DocMeta, asset, Remotes,
+export makedocs, deploydocs, hide, doctest, DocMeta, asset, RawHTMLHeadContent, Remotes,
     KaTeX, MathJax, MathJax2, MathJax3
 
 include("makedocs.jl")

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -115,8 +115,8 @@ end
 """
     RawHTMLHeadContent(content::String)
 
-A type that can be used to pass raw HTML to [`HTML`](@ref), for use in the `<head>` section of
-the HTML document. 
+Raw HTML content to be inserted into the `<head>` section of the HTML document. This type can
+be used in the `assets` keyword of [`HTML`](@ref), just like [`asset`](@ref).
 """
 struct RawHTMLHeadContent <: HTMLHeadContent
     content::String

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -1119,7 +1119,7 @@ function asset_links(src::AbstractString, assets::Vector{<:HTMLHeadContent})
     links = DOM.Node[]
     for asset in assets
         if isa(asset, RawHTMLHeadContent)
-            push!(links, Tag(Symbol("#RAW#"))(asset.content))
+            push!(links, DOM.Tag(Symbol("#RAW#"))(asset.content))
             continue
         end
         class = asset.class

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -92,7 +92,9 @@ const ASSETS_SASS = joinpath(ASSETS, "scss")
 "Directory for the compiled CSS files of the themes."
 const ASSETS_THEMES = joinpath(ASSETS, "themes")
 
-struct HTMLAsset
+abstract type HTMLHeadContent end
+
+struct HTMLAsset <: HTMLHeadContent
     class::Symbol
     uri::String
     islocal::Bool
@@ -108,6 +110,16 @@ struct HTMLAsset
         class in [:ico, :css, :js] || error("Unrecognised asset class $class for `$(uri)`")
         return new(class, uri, islocal, attributes)
     end
+end
+
+"""
+    RawHTMLHeadContent(content::String)
+
+A type that can be used to pass raw HTML to [`HTML`](@ref), for use in the `<head>` section of
+the HTML document. 
+"""
+struct RawHTMLHeadContent <: HTMLHeadContent
+    content::String
 end
 
 """
@@ -469,7 +481,7 @@ struct HTML <: Documenter.Writer
     edit_link::Union{String, Symbol, Nothing}
     repolink::Union{String, Nothing, Default{Nothing}}
     canonical::Union{String, Nothing}
-    assets::Vector{HTMLAsset}
+    assets::Vector{<:HTMLHeadContent}
     analytics::String
     collapselevel::Int
     sidebar_sitename::Bool
@@ -526,7 +538,7 @@ struct HTML <: Documenter.Writer
             prerender, node, highlightjs = prepare_prerendering(prerender, node, highlightjs, highlights)
         end
         assets = map(assets) do asset
-            isa(asset, HTMLAsset) && return asset
+            isa(asset, HTMLHeadContent) && return asset
             isa(asset, AbstractString) && return HTMLAsset(assetclass(asset), asset, true)
             error("Invalid value in assets: $(asset) [$(typeof(asset))]")
         end
@@ -1101,11 +1113,15 @@ function find_preview_image(ctx)
     return nothing
 end
 
-function asset_links(src::AbstractString, assets::Vector{HTMLAsset})
+function asset_links(src::AbstractString, assets::Vector{<:HTMLHeadContent})
     isabspath(src) && @error("Absolute path '$src' passed to asset_links")
     @tags link script
     links = DOM.Node[]
     for asset in assets
+        if isa(asset, RawHTMLHeadContent)
+            push!(links, Tag(Symbol("#RAW#"))(asset.content))
+            continue
+        end
         class = asset.class
         url = asset.islocal ? relhref(src, asset.uri) : asset.uri
         node =

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -281,6 +281,7 @@ function html_doc(
                     asset("https://example.com/resource.js"),
                     asset("http://example.com/fonts?param=foo", class = :css),
                     asset("https://fonts.googleapis.com/css?family=Nanum+Brush+Script&display=swap", class = :css),
+                    RawHTMLHeadContent("<script>console.log('hello from head content! 🌸')</script>")
                 ],
                 prettyurls = true,
                 canonical = "https://example.com/stable",

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -281,7 +281,6 @@ function html_doc(
                     asset("https://example.com/resource.js"),
                     asset("http://example.com/fonts?param=foo", class = :css),
                     asset("https://fonts.googleapis.com/css?family=Nanum+Brush+Script&display=swap", class = :css),
-                    RawHTMLHeadContent("<script>console.log('hello from head content! 🌸')</script>")
                 ],
                 prettyurls = true,
                 canonical = "https://example.com/stable",
@@ -437,6 +436,7 @@ examples_html_local_doc = if "html-local" in EXAMPLE_BUILDS
             assets = [
                 "assets/custom.css",
                 asset("https://plausible.io/js/plausible.js", class = :js, attributes = Dict(Symbol("data-domain") => "example.com", :defer => "")),
+                RawHTMLHeadContent("<script>console.log('hello from head content! 🌸')</script>")
             ],
             prettyurls = false,
             footer = nothing,

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -436,7 +436,7 @@ examples_html_local_doc = if "html-local" in EXAMPLE_BUILDS
             assets = [
                 "assets/custom.css",
                 asset("https://plausible.io/js/plausible.js", class = :js, attributes = Dict(Symbol("data-domain") => "example.com", :defer => "")),
-                RawHTMLHeadContent("<script>console.log('hello from head content! 🌸')</script>")
+                RawHTMLHeadContent("<script>console.log('hello from head content! 🌸')</script>"),
             ],
             prettyurls = false,
             footer = nothing,

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -394,6 +394,11 @@ end
             documenterjs = String(read(joinpath(build_dir, "assets", "documenter.js")))
             @test occursin("languages/julia.min", documenterjs)
             @test occursin("languages/julia-repl.min", documenterjs)
+            let
+                example_output_html = read(joinpath(build_dir, "example-output.html"), String)
+                example_head = match(r"<head>(.*?)</head>"ms, example_output_html).captures[1]
+                @test occursin("<script>console.log('hello from head content! 🌸')</script>", example_head)
+            end
 
             @testset "at-example outputs: $fmt/$size" for ((fmt, size), data) in AT_EXAMPLE_FILES
                 if size === :tiny

--- a/test/htmlwriter.jl
+++ b/test/htmlwriter.jl
@@ -112,6 +112,7 @@ end
 
     # HTML format object
     @test Documenter.HTML() isa Documenter.HTML
+    @test Documenter.HTML(assets = [RawHTMLHeadContent("<!-- hello -->")]) isa Documenter.HTML
     @test_throws ArgumentError Documenter.HTML(collapselevel = -200)
     @test_throws Exception Documenter.HTML(assets = ["foo.js", 10])
     @test_throws ArgumentError Documenter.HTML(footer = "foo\n\nbar")


### PR DESCRIPTION
Hi! 👋

I am working on adding easy Pluto support to Documenter via a plugin 😊 I am not yet sure about the user-facing API, but I got an implementation working where Pluto is embedded inside Documeter pages (alongside existing content). 

# Demo
Here is a WIP demo of the Pluto notebook embedded in Documenter.jl. Note that you can "Edit or run this notebook" with binder!

https://dashing-custard-e9c5cc.netlify.app/

The code for this demo is here: https://github.com/fonsp/Documenter.jl-Pluto-embed-test

# No `<iframe>`
I currently do the embedding **without** `<iframe>`, but with a Custom Element. This is also used in other Pluto-embedding web sites like [Computational Thinking](https://computationalthinking.mit.edu/Fall24/homework/hw1/). The benefit is better performance, better scrolling, accessibility and other UA features, and your notebook content can be indexed by search engines.

For this embedding to work, I need to place content in the `<head>` of the Documenter.jl output HTML. I saw that there is an existing `HTMLAsset` system, but unfortunately this is hard to use in our case: the `<head>` content of Pluto notebooks contains more asset types than just JS, CSS and ICO. We also don't have the `<head>` content in a Julia format: the `<head>` is generated dynamically by our bundler. So to use `HTMLAsset`, we would first need a DOM parser to parse the head content, then convert it into `HTMLAsset` objects...

# Changes
This PR adds the ability to add raw HTML content as an element of the `assets` kwarg, using the new type `RawHTMLHeadContent`. This gives plugins more flexibility in loading `<head>` content.

Take a look at the code changes for the implemented new types.

I'm also happy to hear other ideas for implementing this goal!

# Existing solutions
There are some existing solutions for Pluto in Documenter:
- PlutoStaticHTML.jl (maintained by another Pluto developer). The idea here is different: output as-simple-as-possible static HTML, to make the content match the Documenter.jl style. In some cases, this is exactly what users wants. In other cases, having a true Pluto embed would add consistent styling (WYSIWYG publishing), interactivity, run-with-binder, and more. 
- DemoCards.jl uses PlutoStaticHTML.jl
- Iframe embeds: I believe @adrhill once made a website that embeds Pluto notebooks using iframes. The goal of the new plugin is to have the direct embedding technical benefits described above, plus an easier workflow for adding notebooks to documentation.


