### PR TITLE
Change `rethrow(e)` to `rethrow()`

### DIFF
--- a/src/deploydocs.jl
+++ b/src/deploydocs.jl
@@ -391,7 +391,7 @@ function git_push(
         run(`$(git()) remote add upstream $upstream`)
         try
             run(`$(git()) fetch upstream`)
-        catch e
+        catch
             @error """
             Git failed to fetch $upstream
             This can be caused by a DOCUMENTER_KEY variable that is not correctly set up.

--- a/src/deploydocs.jl
+++ b/src/deploydocs.jl
@@ -398,7 +398,7 @@ function git_push(
             Make sure that the environment variable is properly set up as a Base64-encoded string
             of the SSH private key. You may need to re-generate the keys with DocumenterTools.
             """
-            rethrow(e)
+            rethrow()
         end
 
         try


### PR DESCRIPTION
We don't need to do `rethrow(e)`, because `rethrow()` will correctly rethrow the caught exception.