### PR TITLE
Support non-Base64-encoded keys for `DOCUMENTER_KEY{,PREVIEWS}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Work around GitHub rate limiting of link checks by passing `GITHUB_TOKEN` when applicable and available. ([#2729])
+* Support non-Base64-encoded keys for `DOCUMENTER_KEY{,PREVIEWS}` ([#2737])
 
 ## Version [v1.11.4] - 2025-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Work around GitHub rate limiting of link checks by passing `GITHUB_TOKEN` when applicable and available. ([#2729])
-* Support non-Base64-encoded keys for `DOCUMENTER_KEY{,PREVIEWS}` ([#2737])
+* Support non-Base64-encoded SSH keys for `DOCUMENTER_KEY` and `DOCUMENTER_KEY_PREVIEWS` ([#2737])
 
 ## Version [v1.11.4] - 2025-05-16
 

--- a/src/deployconfig.jl
+++ b/src/deployconfig.jl
@@ -1,7 +1,5 @@
 import JSON
 
-using Base64: base64decode
-
 """
     DeployConfig
 

--- a/src/deployconfig.jl
+++ b/src/deployconfig.jl
@@ -1,5 +1,7 @@
 import JSON
 
+using Base64: base64decode
+
 """
     DeployConfig
 
@@ -53,6 +55,23 @@ This method must be supported by configs that push with SSH, see
 """
 function documenter_key_previews(cfg::DeployConfig)
     return get(ENV, "DOCUMENTER_KEY_PREVIEWS", documenter_key(cfg))
+end
+
+function _decode_key_content(keycontent)
+    # If `keycontent` contains both `-----BEGIN` AND `-----END`, then we assume that it is
+    # a plaintext private key, and we don't try to Base64-decode it.
+    #
+    # Otherwise, we conclude that it must be a Base64-encoded private key, and we try to
+    # Base64-decode it.
+    keycontent_stripped = strip(keycontent)
+    is_plaintext_key = occursin("-----BEGIN", keycontent_stripped) && occursin("-----END", keycontent_stripped)
+    if is_plaintext_key
+        @debug "This looks like a plaintext private key, so we won't try to Base64-decode it"
+        return keycontent_stripped * '\n'
+    else
+        @debug "We conclude that this must be a Base64-encoded private key"
+        return base64decode(keycontent)
+    end
 end
 
 """

--- a/src/deployconfig.jl
+++ b/src/deployconfig.jl
@@ -64,6 +64,7 @@ function _decode_key_content(keycontent)
     is_plaintext_key = occursin("-----BEGIN", keycontent) && occursin("-----END", keycontent)
     if is_plaintext_key
         @debug "This looks like a plaintext private key, so we won't try to Base64-decode it"
+        # The private key file must end in a trailing newline
         return keycontent * '\n'
     else
         @debug "We conclude that this must be a Base64-encoded private key"

--- a/src/deployconfig.jl
+++ b/src/deployconfig.jl
@@ -61,11 +61,10 @@ function _decode_key_content(keycontent)
     #
     # Otherwise, we conclude that it must be a Base64-encoded private key, and we try to
     # Base64-decode it.
-    keycontent_stripped = strip(keycontent)
-    is_plaintext_key = occursin("-----BEGIN", keycontent_stripped) && occursin("-----END", keycontent_stripped)
+    is_plaintext_key = occursin("-----BEGIN", keycontent) && occursin("-----END", keycontent)
     if is_plaintext_key
         @debug "This looks like a plaintext private key, so we won't try to Base64-decode it"
-        return keycontent_stripped * '\n'
+        return keycontent * '\n'
     else
         @debug "We conclude that this must be a Base64-encoded private key"
         return base64decode(keycontent)

--- a/src/deploydocs.jl
+++ b/src/deploydocs.jl
@@ -459,7 +459,7 @@ function git_push(
             else
                 keycontent = documenter_key(deploy_config)
             end
-            write(keyfile, base64decode(keycontent))
+            write(keyfile, _decode_key_content(keycontent))
             chmod(keyfile, 0o600) # user-only rw permissions
         catch e
             @error """


### PR DESCRIPTION
In the days of Travis CI, Travis didn't allow environment variables to contain newlines. Therefore, you would Base64-encode your private key, paste that into Travis, and then Documenter.jl would Base64-decode it.

However, GitHub Actions CI supports environment variables that contain newlines. So, with this PR, it's no longer required to Base64-encode the private key. Instead, you can paste the original plaintext private key (including newlines) into the GitHub Actions web UI, and then there's no need for Documenter.jl to Base64-decode it.

Of course, we continue to support Base64-encoded keys.

## Implementation

We just look for some sentinel phrases, and if we find those, we assume that the key is plaintext (not Base64-encoded).