### PR TITLE
Fix PDF/LaTeX CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,7 +92,7 @@ jobs:
       - name: "install pygments for tectonic"
         run: pip install pygments
         if: matrix.os == 'windows-latest'
-      - uses: teatimeguest/setup-texlive-action@v3
+      - uses: TeX-Live/setup-texlive-action@v3
         with:
           packages: |
             scheme-medium


### PR DESCRIPTION
Apparently the original repository & owning user are completely gone from GitHub now. But there's a fork under the Tex-Live org: https://github.com/TeX-Live/setup-texlive-action