### PR TITLE
Try to print line ranges in a few more errors

### DIFF
--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -715,7 +715,7 @@ function Selectors.runner(::Type{Expanders.EvalBlocks}, node, page, doc)
                 @docerror(
                     doc, :eval_block,
                     """
-                    failed to evaluate `@eval` block in $(Documenter.locrepr(page.source))
+                    failed to evaluate `@eval` block in $(Documenter.locrepr(page.source, lines))
                     ```$(x.info)
                     $(x.code)
                     ```
@@ -732,7 +732,7 @@ function Selectors.runner(::Type{Expanders.EvalBlocks}, node, page, doc)
             # objects, like Paragraph.
             @docerror(
                 doc, :eval_block, """
-                Invalid type of object in @eval in $(Documenter.locrepr(page.source))
+                Invalid type of object in @eval in $(Documenter.locrepr(page.source, lines))
                 ```$(x.info)
                 $(x.code)
                 ```
@@ -1015,10 +1015,11 @@ function Selectors.runner(::Type{Expanders.SetupBlocks}, node, page, doc)
         end
     catch err
         bt = Documenter.remove_common_backtrace(catch_backtrace())
+        lines = Documenter.find_block_in_file(x.code, page.source)
         @docerror(
             doc, :setup_block,
             """
-            failed to run `@setup` block in $(Documenter.locrepr(page.source))
+            failed to run `@setup` block in $(Documenter.locrepr(page.source, lines))
             ```$(x.info)
             $(x.code)
             ```


### PR DESCRIPTION
... but this is just a drop in the bucket. There are sooo many more places that could benefit from showing the lines. And is the best we can do really to search the markdown files via a regex? Line ranges should be kept track of during parsing!

Would it seem realistic to either adjust the Markdown stdlib to do that? Just had a quick look at the code, it seems relatively easy to at least keep track of the name of the originating file (if any) plus the position in the file were an node starts/ends (going from there to line ranges shouldn't be hard either). The main counterargument I can think of would be "this would cause overhead in Markdown parsing even for people who don't need it".

