### PR TITLE
Automation: remove 'Waiting for Author' label in more cases

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -3,6 +3,8 @@ name: Update Status Labels When Author Replies
 on:
   issue_comment:
     types: [created]
+  pull_request_review_comment:
+    types: [created]
 
 permissions:
   issues: write


### PR DESCRIPTION
Namely when a PR review comment is made by the author, which for some reason is treated separately from 'top level' PR comments.


Specifically, this comment https://github.com/JuliaDocs/Documenter.jl/pull/2793#discussion_r2485973607 did not result in the label being removed.