### PR TITLE
Report location of @docs blocks with parsing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Page category is removed from the search index and now everything is in section category. ([#2762], [#2413])
 * Changed the docstring block accordions from a custom implementation to HTML details+summary tag. ([#2772], [#2773])
 * Improved the search tokenizer and custom trimmer to improve search results. ([#1457], [#2114], [#2744])
-* Improved several warning/error messages to (more accurately) report the location (filename, line range) in which the warning/error originated. ([#2803])
+* Improved several warning/error messages to (more accurately) report the location (filename, line range) in which the warning/error originated. ([#2426], [#2803], [#2809])
 
 ### Fixed
 
@@ -2093,6 +2093,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2415]: https://github.com/JuliaDocs/Documenter.jl/issues/2415
 [#2423]: https://github.com/JuliaDocs/Documenter.jl/issues/2423
 [#2424]: https://github.com/JuliaDocs/Documenter.jl/issues/2424
+[#2426]: https://github.com/JuliaDocs/Documenter.jl/issues/2426
 [#2430]: https://github.com/JuliaDocs/Documenter.jl/issues/2430
 [#2434]: https://github.com/JuliaDocs/Documenter.jl/issues/2434
 [#2438]: https://github.com/JuliaDocs/Documenter.jl/issues/2438
@@ -2184,6 +2185,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2787]: https://github.com/JuliaDocs/Documenter.jl/issues/2787
 [#2792]: https://github.com/JuliaDocs/Documenter.jl/issues/2792
 [#2803]: https://github.com/JuliaDocs/Documenter.jl/issues/2803
+[#2809]: https://github.com/JuliaDocs/Documenter.jl/issues/2809
 [#2812]: https://github.com/JuliaDocs/Documenter.jl/issues/2812
 [#2813]: https://github.com/JuliaDocs/Documenter.jl/issues/2813
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,10 @@ end
     @info "Building docsxref/make.jl"
     include("docsxref/make.jl")
 
+    # Warnings
+    @info "Building warnings/make.jl"
+    include("warnings/make.jl")
+
     # Error reporting.
     @info "Building errors/make.jl"
     @quietly include("errors/make.jl")

--- a/test/warnings/make.jl
+++ b/test/warnings/make.jl
@@ -1,0 +1,79 @@
+module WarningTests
+
+# Test warnings
+# see https://github.com/JuliaDocs/Documenter.jl/issues/2805
+
+using Test
+using Documenter
+using IOCapture
+
+isdefined(Main, :Documenter) || @eval Main import Documenter
+
+function run_warnings_test(name::String)
+    captured = IOCapture.capture() do
+        makedocs(;
+            sitename = name,
+            pages = ["index.md", "$name.md"],
+            pagesonly = true,
+            warnonly = true,
+            format = Documenter.HTML(
+                prettyurls = false,
+                inventory_version = "",
+            ),
+        )
+    end
+    @assert isnothing(captured.value)
+
+    # sanitize the output
+    output = captured.output
+    output = replace(output, r"\@ Documenter.*" => "@ Documenter")
+    output = replace(output, "src\\" => "src/")
+    return print(output)
+end
+
+@doc raw"""
+```jldoctest; setup=:(using ..WarningTests)
+julia> WarningTests.run_warnings_test("at-docs")
+[ Info: SetupBuildDirectory: setting up build directory.
+[ Info: Doctest: running doctests.
+[ Info: ExpandTemplates: expanding markdown templates.
+┌ Warning: undefined binding 'Base.nonsenseBindingThatDoesNotExist' in `@docs` block in src/at-docs.md:4-6
+│ ```@docs
+│ Base.nonsenseBindingThatDoesNotExist()
+│ ```
+└ @ Documenter
+┌ Warning: no docs found for 'Base.sin()' in `@docs` block in src/at-docs.md:9-11
+│ ```@docs
+│ Base.sin()
+│ ```
+└ @ Documenter
+┌ Warning: failed to evaluate `Base.sin(::NonsenseTypeThatDoesNotExist)` in `@docs` block in src/at-docs.md:14-16
+│ ```@docs
+│ Base.sin(::NonsenseTypeThatDoesNotExist)
+│ ```
+│   exception =
+│    UndefVarError: `NonsenseTypeThatDoesNotExist` not defined in `Main`
+│    Suggestion: check for spelling errors or missing imports.
+└ @ Documenter
+[ Info: CrossReferences: building cross-references.
+[ Info: CheckDocument: running document checks.
+[ Info: Populate: populating indices.
+[ Info: RenderDocument: rendering document.
+[ Info: HTMLWriter: rendering HTML pages.
+```
+"""
+module AtDocsWarningTests end
+
+fixtests = haskey(ENV, "DOCUMENTER_FIXTESTS")
+
+# run the doctests in Julia >= 1.10 (some outputs have minor difference in
+# older Julia versions, and it just doesn't seem worth the trouble of coping
+# with that "properly")
+VERSION >= v"1.10" && makedocs(;
+    sitename = "",
+    doctest = fixtests ? :fix : :only,
+    modules = [WarningTests],
+    remotes = nothing,
+)
+
+end

--- a/test/warnings/src/at-docs.md
+++ b/test/warnings/src/at-docs.md
@@ -1,0 +1,16 @@
+# Test warnings in `@docs` block
+
+Binding that does not exist.
+```@docs
+Base.nonsenseBindingThatDoesNotExist()
+```
+
+Binding that exists but has no documentation.
+```@docs
+Base.sin()
+```
+
+Syntax error due to invalid type in argument list.
+```@docs
+Base.sin(::NonsenseTypeThatDoesNotExist)
+```

--- a/test/warnings/src/index.md
+++ b/test/warnings/src/index.md
@@ -1,0 +1,3 @@
+# Landing page
+
+This is here to avoid a warning about a missing landing page.


### PR DESCRIPTION
In particular, show the precise location where the error occurred.

Resolves #2426

I tested it locally but it still needs a test. Will add one later.

UPDATE: tests added. More so, this now resolves #2805 in so far as it adds a framework for adding tests for warning messages. I've used it here to test the warnings I am improving here, and have a couple more ready for a follow-up PR. That said, it's not "done" in so far as it does not yet cover *all* kinds of warnings; but that seems to me more like an open-ended project anyway.