### PR TITLE
jldoctest: be more generous about empty lines: allow them at the start, allow omitting them between adjacent `julia>` prompts

### DIFF
--- a/docs/src/showcase.md
+++ b/docs/src/showcase.md
@@ -378,6 +378,20 @@ julia> f(3)
 9
 ```
 
+```jldoctest
+
+julia> a = 1;
+julia> a + 1
+2
+
+julia> a + 2
+3
+
+julia> println("Test:\n          YES!")
+Test:
+          YES!
+```
+
 If you write them as a ````` ```jldoctest ````` code block, Documenter can make sure that the doctest has not become outdated. See [Doctests](@ref) for more information.
 
 Script-style doctests are supported too:


### PR DESCRIPTION
- allow empty lines at start of jldoctest
- allow omitting empty lines between two adjacent `julia>` prompts

These are minor usability errors, "paper cuts" if you will, that have annoyed me repeatedly in the past, and clearly also other people:

Resolves #2031
Resolves #2083
Resolves #2679
Alternative to and hence closes #2808

(I am waiting with changelog and test cases until I know which direction we'll take)