### PR TITLE
Add test for 'Unexpected Julia interpolation' warnings

### DIFF
--- a/test/examples/src/index.md
+++ b/test/examples/src/index.md
@@ -614,14 +614,6 @@ Also in block quotes:
 > ##### Heading 5
 > ###### Heading 6
 
-# JuliaValue
-
-It is possible to create pseudo-interpolations with the `Markdown` parser: $foo.
-
-$([1 2 3; 4 5 6])
-
-They do not get evaluated.
-
 # Admonitions
 
 !!! note "'note' admonition"

--- a/test/warnings/make.jl
+++ b/test/warnings/make.jl
@@ -64,6 +64,39 @@ julia> WarningTests.run_warnings_test("at-docs")
 """
 module AtDocsWarningTests end
 
+@doc raw"""
+```jldoctest; setup=:(using ..WarningTests)
+julia> WarningTests.run_warnings_test("dollar")
+[ Info: SetupBuildDirectory: setting up build directory.
+[ Info: Doctest: running doctests.
+[ Info: ExpandTemplates: expanding markdown templates.
+[ Info: CrossReferences: building cross-references.
+[ Info: CheckDocument: running document checks.
+[ Info: Populate: populating indices.
+[ Info: RenderDocument: rendering document.
+[ Info: HTMLWriter: rendering HTML pages.
+┌ Warning:     Unexpected Julia interpolation in the Markdown. This probably means that you have an
+│     unbalanced or un-escaped $ in the text.
+│
+│     To write the dollar sign, escape it with `\$`
+│
+│     We don't have the file or line number available, but we got given the value:
+│
+│     `foo` which is of type `Symbol`
+└ @ Documenter
+┌ Warning:     Unexpected Julia interpolation in the Markdown. This probably means that you have an
+│     unbalanced or un-escaped $ in the text.
+│
+│     To write the dollar sign, escape it with `\$`
+│
+│     We don't have the file or line number available, but we got given the value:
+│
+│     `[1 2 3; 4 5 6]` which is of type `Expr`
+└ @ Documenter
+```
+"""
+module UnbalancedDollarWarningTests end
+
 fixtests = haskey(ENV, "DOCUMENTER_FIXTESTS")
 
 # run the doctests in Julia >= 1.10 (some outputs have minor difference in

--- a/test/warnings/src/dollar.md
+++ b/test/warnings/src/dollar.md
@@ -1,0 +1,7 @@
+# JuliaValue
+
+It is possible to create pseudo-interpolations with the `Markdown` parser: $foo.
+
+$([1 2 3; 4 5 6])
+
+They do not get evaluated.


### PR DESCRIPTION
I'd like to have this to properly test the changes in PR #2793, which modifies the output being tested here.