### PR TITLE
Set version to 1.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
-### Changed
-
-* The `-g` is now passed to `curl` when checking links, to disable globbing, which could cause undesirable behavior when checking links containing characters like for example `[`, `{`, `&` or `?`. ([#2839], [#2842])
+## Version [v1.16.1] - 2025-11-21
 
 ### Fixed
 
+* The `-g` is now passed to `curl` when checking links, to disable globbing, which could cause undesirable behavior when checking links containing characters like for example `[`, `{`, `&` or `?`. ([#2839], [#2842])
 * Fixed insufficient paragraph spacing in HTML output for `@docs` blocks. ([#2845, #2847])
 * Don't expand `details` admonition by default. ([#2846, #2847])
 
@@ -1615,6 +1612,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v1.14.1]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.14.1
 [v1.15.0]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.15.0
 [v1.16.0]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.16.0
+[v1.16.1]: https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.16.1
 [#198]: https://github.com/JuliaDocs/Documenter.jl/issues/198
 [#245]: https://github.com/JuliaDocs/Documenter.jl/issues/245
 [#487]: https://github.com/JuliaDocs/Documenter.jl/issues/487
@@ -2226,9 +2224,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2816]: https://github.com/JuliaDocs/Documenter.jl/issues/2816
 [#2817]: https://github.com/JuliaDocs/Documenter.jl/issues/2817
 [#2827]: https://github.com/JuliaDocs/Documenter.jl/issues/2827
-[#2845]: https://github.com/JuliaDocs/Documenter.jl/issues/2845
-[#2846]: https://github.com/JuliaDocs/Documenter.jl/issues/2846
-[#2847]: https://github.com/JuliaDocs/Documenter.jl/issues/2847
+[#2839]: https://github.com/JuliaDocs/Documenter.jl/issues/2839
+[#2842]: https://github.com/JuliaDocs/Documenter.jl/issues/2842
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Documenter"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.16.0"
+version = "1.16.1"
 
 [deps]
 ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"


### PR DESCRIPTION
## Pre-release

 - [x] Change the version number in `Project.toml`
   * If the release is breaking, increment MAJOR
   * If the release adds a new user-visible feature, increment MINOR
   * Otherwise (bug-fixes, documentation improvements), increment PATCH
 - [x] Update `CHANGELOG.md`, following the existing style (in particular, make sure that the change log for this version has the correct version number and date).
 - [x] Run `make changelog`, to make sure that all the issue references in `CHANGELOG.md` are up to date.
 - [x] Check that the commit messages in this PR do not contain `[ci skip]`
 - [x] Check that the [regression-tests workflow](https://github.com/JuliaDocs/Documenter.jl/actions/workflows/regression-tests.yml) did not reveal any changes that broke extensions (this should run as part of the CI suite, but can also be triggered manually).

## The release

 - [x] After merging the pull request, tag the release. There are two options for this:

   1. [Comment `[at]JuliaRegistrator register` on the GitHub commit.](https://github.com/JuliaRegistries/Registrator.jl#via-the-github-app)
   2. Use [JuliaHub's package registration feature](https://help.juliahub.com/juliahub/stable/contribute/#registrator) to trigger the registration.

   Either of those should automatically publish a new version to the Julia registry.
 - Once registered, the `TagBot.yml` workflow should create a tag, and rebuild the documentation for this tag.
 - These steps can take quite a bit of time (1 hour or more), so don't be surprised if the new documentation takes a while to appear.