### PR TITLE
Add error handling for result display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added `Remotes.Forgejo` for specifying a `Remote` hosted on a Forgejo instance (such as codeberg.org). ([#2857])
 
+### Fixed
+
+* Added error handling for `@example` block result display to avoid crashing when `display_dict` fails. ([#2876])
+
 ### Changed
 
 * reduced time complexity from O(n^2) to O(n) to improve the initial load time for search ([#2875])

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -905,7 +905,12 @@ function Selectors.runner(::Type{Expanders.ExampleBlocks}, node, page, doc)
     input = droplines(x.code)
 
     # Generate different  in different formats and let each writer select
-    output = Base.invokelatest(Documenter.display_dict, result, context = :color => ansicolor)
+   output = try
+        Base.invokelatest(Documenter.display_dict, result, context = :color => ansicolor)
+    catch err
+        @error "Problem displaying result on page $(page.source): $(err)"
+        Dict(MIME"text/plain"(), "Error displaying result")
+    end
     # Remove references to gensym'd module from text/plain
     m = MIME"text/plain"()
     if haskey(output, m)

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -905,7 +905,7 @@ function Selectors.runner(::Type{Expanders.ExampleBlocks}, node, page, doc)
     input = droplines(x.code)
 
     # Generate different  in different formats and let each writer select
-   output = try
+    output = try
         Base.invokelatest(Documenter.display_dict, result, context = :color => ansicolor)
     catch err
         @error "Problem displaying result on page $(page.source): $(err)"

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -909,7 +909,7 @@ function Selectors.runner(::Type{Expanders.ExampleBlocks}, node, page, doc)
         Base.invokelatest(Documenter.display_dict, result, context = :color => ansicolor)
     catch err
         @error "Problem displaying result on page $(page.source): $(err)"
-        Dict(MIME"text/plain"(), "Error displaying result")
+        Dict(MIME"text/plain"() => "Error displaying result")
     end
     # Remove references to gensym'd module from text/plain
     m = MIME"text/plain"()


### PR DESCRIPTION
Handle errors that happen when a result gets displayed in an example block (via `display_dict`).

This often crops up when trying to latexify things, and the idea is that it should cause an error but not crash the doc build.  I'm not sure how you are supposed to log the error such that `warnonly` specifiers will catch it, though, so some help there would be great.