### PR TITLE
Add LaTeX `show_log` option and dump logs on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The version selector now also preserves the anchor (hash) when switching between documentation versions. Additionally, the outdated/dev version warning banner now also tries to keep you on the same page (and position) when linking to the latest stable release. ([#2880])
 * Added `Remotes.Forgejo` for specifying a `Remote` hosted on a Forgejo instance (such as codeberg.org). ([#2857])
 * Doctests now default to the `parser_for_module` of the module that the docstring appears in, allowing modules that set their syntax version via `Base.Experimental.@set_syntax_version` to have their doctests parsed with the correct syntax automatically. Also added support for `DocTestSyntax` metadata and per-block `syntax=` attributes to explicitly specify a syntax version. ([#2874])
+* Added a `show_log` keyword for `Documenter.LaTeX` to print LaTeX compiler logs to stdout when PDF compilation fails, and support for forcing this via `DOCUMENTER_LATEX_SHOW_LOGS` in CI environments. ([#1697])
 
 ### Changed
 
@@ -1917,6 +1918,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1693]: https://github.com/JuliaDocs/Documenter.jl/issues/1693
 [#1695]: https://github.com/JuliaDocs/Documenter.jl/issues/1695
 [#1696]: https://github.com/JuliaDocs/Documenter.jl/issues/1696
+[#1697]: https://github.com/JuliaDocs/Documenter.jl/issues/1697
 [#1698]: https://github.com/JuliaDocs/Documenter.jl/issues/1698
 [#1699]: https://github.com/JuliaDocs/Documenter.jl/issues/1699
 [#1704]: https://github.com/JuliaDocs/Documenter.jl/issues/1704

--- a/docs/src/man/other-formats.md
+++ b/docs/src/man/other-formats.md
@@ -95,6 +95,19 @@ makedocs(
 )
 ```
 
+If you are building in CI and want compiler logs printed directly to the job output on
+failures, you can enable:
+
+```julia
+makedocs(format = Documenter.LaTeX(show_log = true), ...)
+```
+
+You can also force this behavior via environment variable:
+
+```bash
+export DOCUMENTER_LATEX_SHOW_LOGS=1
+```
+
 ## [Custom LaTeX style](@id custom-latex)
 
 The PDF/LaTeX backend works by generating a TeX file based on the input Markdown files.


### PR DESCRIPTION
Resolves #1697.

Created by Codex.

Includes #2879 so that I can see if it works with the PDF error log for the Julia manual 