### PR TITLE
Add Right TOC

### DIFF
--- a/assets/html/scss/documenter/_variables.scss
+++ b/assets/html/scss/documenter/_variables.scss
@@ -80,6 +80,8 @@ $body-size: 16px !default;
 $documenter-max-width: 50rem !default;
 $documenter-sidebar-width: 18rem !default;
 
+$documenter-toc-width:12 rem !default;
+
 $documenter-sidebar-main-gap: 2rem !default;
 $documenter-main-padding-right: 1rem !default;
 $documenter-main-padding: 1rem !default;

--- a/assets/html/scss/documenter/layout/_all.scss
+++ b/assets/html/scss/documenter/layout/_all.scss
@@ -1,3 +1,4 @@
 @import "main";
 @import "sidebar";
 @import "search";
+@import "toc";

--- a/assets/html/scss/documenter/layout/_main.scss
+++ b/assets/html/scss/documenter/layout/_main.scss
@@ -3,6 +3,7 @@
  * The main container is <div> that is identified by id #documenter.
  */
 #documenter {
+  display:flex;
   .docs-main {
     > article {
       h1,h2,h3,h4,h5,h6{
@@ -113,7 +114,7 @@
         }
       }
     }
-
+    
     // Footnotes
     section.footnotes {
       border-top: 1px solid $border;

--- a/assets/html/scss/documenter/layout/_toc.scss
+++ b/assets/html/scss/documenter/layout/_toc.scss
@@ -1,0 +1,64 @@
+//Right side Table of Contents
+
+.docs-toc {
+  position: sticky;
+  top: 5rem;
+  width: $documenter-toc-width;
+
+  margin-left: 2rem;
+  padding: 1rem 0 1rem 1rem;
+  border-left: 1px solid $border;
+  font-size: 0.95rem;
+
+  max-height: calc(100vh - 7rem);
+  overflow-y: auto;
+  overflow-x: hidden;
+  scroll-behavior: smooth;
+  scrollbar-width: thin;
+
+
+  @include touch {
+    display: none;
+  }
+
+  @media screen and (max-width: 1350px) {
+    display: none;
+  }
+
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  li {
+    margin: 0.35rem 0;
+    line-height: 1.4;
+  }
+
+  a {
+    text-decoration: none;
+    color: $text;
+    display: block;
+  }
+
+  a:hover {
+    text-decoration: underline;
+  }
+
+  .docs-toc-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-bottom: 0.75rem;
+    display: block;
+  }
+
+  li.toplevel {
+    font-weight: 600;
+  }
+
+  li:not(.toplevel) {
+    margin-left: 0.75rem;
+    font-size: 0.9rem;
+  }
+}

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -992,10 +992,11 @@ function render_page(ctx, navnode)
     head = render_head(ctx, navnode)
     sidebar = render_sidebar(ctx, navnode)
     navbar = render_navbar(ctx, navnode, true)
+    toc = render_toc(ctx, navnode)
     article = render_article(ctx, navnode)
     footer = render_footer(ctx, navnode)
     extras = render_extras(ctx, navnode)
-    htmldoc = render_html(ctx, head, sidebar, navbar, article, footer, extras)
+    htmldoc = render_html(ctx, head, sidebar, navbar, toc, article, footer, extras)
     return write_html(ctx, navnode, htmldoc)
 end
 
@@ -1005,7 +1006,7 @@ end
 """
 Renders the main `<html>` tag.
 """
-function render_html(ctx, head, sidebar, navbar, article, footer, extras)
+function render_html(ctx, head, sidebar, navbar, toc, article, footer, extras)
     @tags html body div
     return DOM.HTMLDocument(
         html[:lang => ctx.settings.lang](
@@ -1014,6 +1015,7 @@ function render_html(ctx, head, sidebar, navbar, article, footer, extras)
                 div["#documenter"](
                     sidebar,
                     div[".docs-main"](navbar, article, footer),
+                    toc,
                     render_settings(),
                 ),
             ),
@@ -1465,6 +1467,36 @@ function render_navbar(ctx, navnode, edit_page_link::Bool)
 
     # Construct the main <header> node that should be the first element in div.docs-main
     return header[".docs-navbar"](navbar_left, breadcrumb, navbar_right)
+end
+
+function render_toc(ctx,navnode)
+    @tags div span ul li a
+
+    if navnode===nothing || navnode.page===nothing
+        return DOM.Node("")
+    end
+
+    page=getpage(ctx,navnode.page)
+    subs=collect_subsections(page.mdast)
+
+    if isempty(subs)
+        return DOM.Node("")
+    end
+
+    dctx=DCtx(ctx,navnode,true)
+
+    toc_items=map(subs) do s
+        istoplevel, anchor, text=s
+        liclass=istoplevel ? ".toplevel" : ""
+
+        li[liclass](a[".tocitem", :href => anchor](span(domify(dctx, text.children))))
+    end
+
+    toc_list=ul[".page-toc"](toc_items)
+
+    return div[".docs-toc"](
+        span[".toc-title"]("On this page"),toc_list
+    )
 end
 
 """


### PR DESCRIPTION

<img width="1910" height="922" alt="toc" src="https://github.com/user-attachments/assets/4211cc45-32f8-4d9b-a587-0027ae8ba8e3" />
This PR adds a table of contents on the right side of every page. I have only included the h2 headings but as mentioned in #1688, would be repetitive. 

I have modified the `HTMLWriter.jl` file by adding a function that uses almost the same logic as the function `navitem`, which is used by the sidebar to display the h2 subheadings. 

I kept the UI simple, for demonstration purposes, it can be improved, but might require changes to be made in `HTMLWriter.jl`. 

Referred to #1715 for `CSS` styling. 

Note: I have used AI to refine my code. 