### PR TITLE
Change type of .assets type to Vector{HTMLHeadContent} (for Pluto support)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Support self-hosted GitHub instances. ([#2755])
+* Change type of `HTML.assets` field to `Vector{HTMLHeadContent}` to allow configuring dynamically. ([#2925])
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Support self-hosted GitHub instances. ([#2755])
-* Change type of `HTML.assets` field to `Vector{HTMLHeadContent}` to allow configuring dynamically. ([#2925])
+
+### Changed
+
+* Change type of `HTML.assets` field to `Vector{HTMLHeadContent}` to allow configuring dynamically in plugins. ([#2925])
 
 ### Fixed
 

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -541,12 +541,11 @@ struct HTML <: Documenter.Writer
         if prerender
             prerender, node, highlightjs = prepare_prerendering(prerender, node, highlightjs, highlights)
         end
-        assets = HTMLHeadContent[
-            isa(asset, HTMLHeadContent) ? asset :
-                isa(asset, AbstractString) ? HTMLAsset(assetclass(asset), asset, true) :
-                error("Invalid value in assets: $(asset) [$(typeof(asset))]")
-                for asset in assets
-        ]
+        assets = map(assets) do asset
+            isa(asset, HTMLHeadContent) && return asset
+            isa(asset, AbstractString) && return HTMLAsset(assetclass(asset), asset, true)
+            error("Invalid value in assets: $(asset) [$(typeof(asset))]")
+        end
         # Handle edit_branch deprecation
         if !isa(edit_branch, Default)
             isa(edit_link, Default) || error("Can't specify edit_branch (deprecated) and edit_link simultaneously")

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -483,7 +483,7 @@ struct HTML <: Documenter.Writer
     edit_link::Union{String, Symbol, Nothing}
     repolink::Union{String, Nothing, Default{Nothing}}
     canonical::Union{String, Nothing}
-    assets::Vector{<:HTMLHeadContent}
+    assets::Vector{HTMLHeadContent}
     analytics::String
     collapselevel::Int
     sidebar_sitename::Bool
@@ -541,11 +541,12 @@ struct HTML <: Documenter.Writer
         if prerender
             prerender, node, highlightjs = prepare_prerendering(prerender, node, highlightjs, highlights)
         end
-        assets = map(assets) do asset
-            isa(asset, HTMLHeadContent) && return asset
-            isa(asset, AbstractString) && return HTMLAsset(assetclass(asset), asset, true)
+        assets = HTMLHeadContent[
+            isa(asset, HTMLHeadContent) ? asset :
+            isa(asset, AbstractString) ? HTMLAsset(assetclass(asset), asset, true) :
             error("Invalid value in assets: $(asset) [$(typeof(asset))]")
-        end
+            for asset in assets
+        ]
         # Handle edit_branch deprecation
         if !isa(edit_branch, Default)
             isa(edit_link, Default) || error("Can't specify edit_branch (deprecated) and edit_link simultaneously")

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -543,9 +543,9 @@ struct HTML <: Documenter.Writer
         end
         assets = HTMLHeadContent[
             isa(asset, HTMLHeadContent) ? asset :
-            isa(asset, AbstractString) ? HTMLAsset(assetclass(asset), asset, true) :
-            error("Invalid value in assets: $(asset) [$(typeof(asset))]")
-            for asset in assets
+                isa(asset, AbstractString) ? HTMLAsset(assetclass(asset), asset, true) :
+                error("Invalid value in assets: $(asset) [$(typeof(asset))]")
+                for asset in assets
         ]
         # Handle edit_branch deprecation
         if !isa(edit_branch, Default)


### PR DESCRIPTION
Hi! After a long delay (sorry) I am picking up the DocumenterPluto.jl project again (from https://github.com/JuliaDocs/Documenter.jl/pull/2726). 

This PR changes the type of `assets` to be a simple `Vector{HTMLHeadContent}`, instead of being possibly a vector of subtypes.

This allows my extension to `push!` into the `assets` dynamically, regardless of the vector type that it currently has.