### PR TITLE
Fix duplicate elseif condition in interpret_repo_and_remotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed a duplicate `elseif` condition in `interpret_repo_and_remotes` that made the branch handling the case where the git repository root is nested inside a `remotes` path unreachable. ([#2868])
 * Fixed headers hidden by the navbar. ([#2905])
 * Tightened `@ref` classification so references are matched more consistently by syntax, with header labels still taking precedence over docstrings and mistaken header/id references less likely to resolve as docstrings. ([#2678])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* Fixed a duplicate `elseif` condition in `interpret_repo_and_remotes` that made the branch handling the case where the git repository root is nested inside a `remotes` path unreachable. ([#2868])
+* Fixed an `Unexpected repository roots` error when `makedocs` runs in a Git repository nested inside a directory configured in `remotes`; the repository's own remote is now used for the main repository, and the `remotes` entry applies to the surrounding paths. ([#2868])
 * Fixed headers hidden by the navbar. ([#2905])
 * Tightened `@ref` classification so references are matched more consistently by syntax, with header labels still taking precedence over docstrings and mistaken header/id references less likely to resolve as docstrings. ([#2678])
 
@@ -2275,6 +2275,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2849]: https://github.com/JuliaDocs/Documenter.jl/issues/2849
 [#2854]: https://github.com/JuliaDocs/Documenter.jl/issues/2854
 [#2857]: https://github.com/JuliaDocs/Documenter.jl/issues/2857
+[#2868]: https://github.com/JuliaDocs/Documenter.jl/issues/2868
 [#2871]: https://github.com/JuliaDocs/Documenter.jl/issues/2871
 [#2874]: https://github.com/JuliaDocs/Documenter.jl/issues/2874
 [#2875]: https://github.com/JuliaDocs/Documenter.jl/issues/2875

--- a/src/documents.jl
+++ b/src/documents.jl
@@ -624,7 +624,7 @@ function interpret_repo_and_remotes(; root, repo, remotes)
             # with remotes. In that case, the remote in `remotes` takes precedence as well.
             @debug "Remotes: `remotes` takes precedence over automatically determined remote" makedocs_root_remoteref makedocs_root_repo makedocs_root_remote repo_normalized
             makedocs_root_remote = makedocs_root_remoteref.remote
-        elseif startswith(makedocs_root_remoteref.root, makedocs_root_repo)
+        elseif startswith(makedocs_root_repo, makedocs_root_remoteref.root)
             # In this case we determined that root of the repository is more specific than
             # whatever we found in remotes. So the main remote will be determined from the Git
             # repository. This will be a no-op, except that `repo` argument may override the

--- a/test/repolinks.jl
+++ b/test/repolinks.jl
@@ -229,6 +229,24 @@ end
     )
 )
 
+@testset "remotes parent directory covers repo root" begin
+    @debug Test.get_testset()
+    # This tests the branch where makedocs_root_repo (git repo root) is a subdirectory of
+    # makedocs_root_remoteref.root (a path in `remotes`). The git repo remote should win
+    # for the main remote, and the parent remotes entry covers everything else underneath.
+    doc = Documenter.Document(
+        root = joinpath(mainrepo, "docs"),
+        remotes = Dict(
+            tmproot => (Remotes.GitHub("ParentOrg", "ParentRepo.jl"), "parent-commit"),
+        )
+    )
+    @test doc.user.remote == Remotes.GitHub("TestOrg", "TestRepo.jl")
+    @test edit_url(doc, joinpath(mainrepo, "foo"); rev = nothing) ==
+        "https://github.com/TestOrg/TestRepo.jl/blob/$(mainrepo_commit)/foo"
+    @test edit_url(doc, joinpath(extdirectory, "foo"); rev = nothing) ==
+        "https://github.com/ParentOrg/ParentRepo.jl/blob/parent-commit/extdirectory/foo"
+end
+
 rm(tmproot, recursive = true, force = true)
 
 include("repolink_helpers.jl")


### PR DESCRIPTION
The second elseif branch had the same condition as the first (startswith(makedocs_root_remoteref.root, makedocs_root_repo)), but its comment described the opposite case: the git repo root being more specific (nested deeper) than the remotes path. Fix it to use startswith(makedocs_root_repo, makedocs_root_remoteref.root). Fixes #2868