### PR TITLE
Fix LaTeXWriter not stripping $$ delimiters from text/latex MIME output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Fixed headers hidden by the navbar. ([#2905])
+* Fixed `LaTeXWriter` writing `text/latex` MIME output verbatim when wrapped in `$$` or `\[...\]` around a display math environment (e.g. `\begin{equation}`), which caused a "Bad math environment delimiter" LaTeX error. ([#2923])
 * Tightened `@ref` classification so references are matched more consistently by syntax, with header labels still taking precedence over docstrings and mistaken header/id references less likely to resolve as docstrings. ([#2678])
 
 ## Version [v1.17.0] - 2026-02-20

--- a/src/latex/LaTeXWriter.jl
+++ b/src/latex/LaTeXWriter.jl
@@ -467,6 +467,24 @@ end
 
 # Select the "best" representation for LaTeX output.
 using Base64: base64decode
+
+function _strip_latex_math_delimiters(latex::AbstractString)
+    m_bracket = match(r"\s*\\\[(.*)\\\]\s*"s, latex)
+    if m_bracket !== nothing
+        inner = m_bracket[1]
+        if occursin(r"^\s*\\begin\{"s, inner)
+            return lstrip(inner)
+        end
+    end
+    m_dollars = match(r"^\s*(\${1,2})([^\$]*)\1\s*$"s, latex)
+    if m_dollars !== nothing
+        inner = m_dollars[2]
+        if occursin(r"^\s*\\begin\{"s, inner)
+            return lstrip(inner)
+        end
+    end
+    return latex
+end
 latex(io::Context, node::Node, ::Documenter.MultiOutput) = latex(io, node.children)
 function latex(io::Context, node::Node, moe::Documenter.MultiOutputElement)
     return Base.invokelatest(latex, io, node, moe.element)
@@ -494,8 +512,7 @@ function latex(io::Context, ::Node, d::Dict{MIME, Any})
             """
         )
     elseif haskey(d, MIME"text/latex"())
-        # If it has a latex MIME, just write it out directly.
-        content = d[MIME("text/latex")]
+        content = _strip_latex_math_delimiters(d[MIME("text/latex")])
         if startswith(content, "\\begin{tabular}")
             # This is a hacky fix for the printing of DataFrames (or any type
             # that produces a {tabular} environment). The biggest problem is

--- a/src/latex/LaTeXWriter.jl
+++ b/src/latex/LaTeXWriter.jl
@@ -473,17 +473,17 @@ function _strip_latex_math_delimiters(latex::AbstractString)
     if m_bracket !== nothing
         inner = m_bracket[1]
         if occursin(r"^\s*\\begin\{"s, inner)
-            return strip(inner)
+            return strip(inner), true
         end
     end
     m_dollars = match(r"^\s*(\${1,2})([^\$]*)\1\s*$"s, latex)
     if m_dollars !== nothing
         inner = m_dollars[2]
         if occursin(r"^\s*\\begin\{"s, inner)
-            return strip(inner)
+            return strip(inner), true
         end
     end
-    return latex
+    return latex, false
 end
 latex(io::Context, node::Node, ::Documenter.MultiOutput) = latex(io, node.children)
 function latex(io::Context, node::Node, moe::Documenter.MultiOutputElement)
@@ -512,7 +512,10 @@ function latex(io::Context, ::Node, d::Dict{MIME, Any})
             """
         )
     elseif haskey(d, MIME"text/latex"())
-        content = _strip_latex_math_delimiters(d[MIME("text/latex")])
+        content, was_stripped = _strip_latex_math_delimiters(d[MIME("text/latex")])
+        if was_stripped
+            @warn "LaTeX output wraps a display math environment (e.g. \\begin{equation}) inside \$\$ or \\[...\\] delimiters, which is invalid LaTeX. The outer delimiters have been removed. Please fix the `show(io, MIME\"text/latex\"(), ...)` method of the relevant type."
+        end
         if startswith(content, "\\begin{tabular}")
             # This is a hacky fix for the printing of DataFrames (or any type
             # that produces a {tabular} environment). The biggest problem is

--- a/src/latex/LaTeXWriter.jl
+++ b/src/latex/LaTeXWriter.jl
@@ -473,14 +473,14 @@ function _strip_latex_math_delimiters(latex::AbstractString)
     if m_bracket !== nothing
         inner = m_bracket[1]
         if occursin(r"^\s*\\begin\{"s, inner)
-            return lstrip(inner)
+            return strip(inner)
         end
     end
     m_dollars = match(r"^\s*(\${1,2})([^\$]*)\1\s*$"s, latex)
     if m_dollars !== nothing
         inner = m_dollars[2]
         if occursin(r"^\s*\\begin\{"s, inner)
-            return lstrip(inner)
+            return strip(inner)
         end
     end
     return latex

--- a/test/latexwriter.jl
+++ b/test/latexwriter.jl
@@ -148,6 +148,25 @@ end
     end
 end
 
+@testset "LaTeX: _strip_latex_math_delimiters" begin
+    strip = LaTeXWriter._strip_latex_math_delimiters
+    eq = "\\begin{equation}\nx^2\n\\end{equation}"
+    # Strips \[...\] and $$...$$ when inner content has a \begin{} environment
+    @test strip("\\[$eq\\]") == eq
+    @test strip("\$\$$eq\$\$") == eq
+    @test strip("  \\[ $eq \\]  ") == eq
+    @test strip("  \$\$ $eq \$\$  ") == eq
+    # Does NOT strip when inner content has no \begin{} environment
+    for content in ["x^2", "\\frac{1}{2}", "\\left[\\begin{array}{c}1\\end{array}\\right]"]
+        @test strip("\\[$content\\]") == "\\[$content\\]"
+        @test strip("\$\$$content\$\$") == "\$\$$content\$\$"
+        @test strip("\$$content\$") == "\$$content\$"
+    end
+    # Unchanged when no delimiters present
+    @test strip(eq) == eq
+    @test strip("x^2") == "x^2"
+end
+
 @testset "dump latex log" begin
     mktempdir() do tmp
         output = cd(tmp) do

--- a/test/latexwriter.jl
+++ b/test/latexwriter.jl
@@ -152,19 +152,19 @@ end
     strip = LaTeXWriter._strip_latex_math_delimiters
     eq = "\\begin{equation}\nx^2\n\\end{equation}"
     # Strips \[...\] and $$...$$ when inner content has a \begin{} environment
-    @test strip("\\[$eq\\]") == eq
-    @test strip("\$\$$eq\$\$") == eq
-    @test strip("  \\[ $eq \\]  ") == eq
-    @test strip("  \$\$ $eq \$\$  ") == eq
+    @test strip("\\[$eq\\]") == (eq, true)
+    @test strip("\$\$$eq\$\$") == (eq, true)
+    @test strip("  \\[ $eq \\]  ") == (eq, true)
+    @test strip("  \$\$ $eq \$\$  ") == (eq, true)
     # Does NOT strip when inner content has no \begin{} environment
     for content in ["x^2", "\\frac{1}{2}", "\\left[\\begin{array}{c}1\\end{array}\\right]"]
-        @test strip("\\[$content\\]") == "\\[$content\\]"
-        @test strip("\$\$$content\$\$") == "\$\$$content\$\$"
-        @test strip("\$$content\$") == "\$$content\$"
+        @test strip("\\[$content\\]") == ("\\[$content\\]", false)
+        @test strip("\$\$$content\$\$") == ("\$\$$content\$\$", false)
+        @test strip("\$$content\$") == ("\$$content\$", false)
     end
     # Unchanged when no delimiters present
-    @test strip(eq) == eq
-    @test strip("x^2") == "x^2"
+    @test strip(eq) == (eq, false)
+    @test strip("x^2") == ("x^2", false)
 end
 
 @testset "dump latex log" begin


### PR DESCRIPTION
When a type's show(io, ::MIME\"text/latex\", ...) wraps output in \$\$
or \\[...\\] around a display math environment (e.g. ModelingToolkit),
LaTeXWriter was writing the content verbatim. This caused a 'Bad math
environment delimiter' LaTeX error because both \$\$ and \\begin{equation}
try to open math mode.
Add _strip_latex_math_delimiters which strips outer \$\$/\\[...\\] delimiters
only when the inner content already contains a \\begin{...} environment.
Plain math content like \$\$ \\left[...\\right] \$\$ is left unchanged.
Fixes #2923