### PR TITLE
Give preview cleanup workflow write permissions

### DIFF
--- a/.github/workflows/ClearPreview.yml
+++ b/.github/workflows/ClearPreview.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: write
+
 jobs:
   doc-preview-cleanup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I noticed it's failing here: https://github.com/JuliaDocs/Documenter.jl/actions/runs/26463328854/job/77919032349