### PR TITLE
Split executable template expansion stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Change type of `HTML.assets` field to `Vector{HTMLHeadContent}` to allow configuring dynamically in plugins. ([#2925])
+* Expand non-executable markdown templates before executable `@eval`, `@example`, `@repl`, and `@setup` templates, so page-level `@meta` settings apply before executable templates run.
 
 ### Fixed
 

--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -145,6 +145,7 @@ When you run that you should see the following output
 [ Info: SetupBuildDirectory: setting up build directory.
 [ Info: Doctest: running doctests.
 [ Info: ExpandTemplates: expanding markdown templates.
+[ Info: ExpandExecutableTemplates: expanding executable markdown templates.
 [ Info: CrossReferences: building cross-references.
 [ Info: CheckDocument: running document checks.
 [ Info: Populate: populating indices.

--- a/src/builder_pipeline.jl
+++ b/src/builder_pipeline.jl
@@ -15,6 +15,7 @@ module Builder
     - [`SetupBuildDirectory`](@ref)
     - [`Doctest`](@ref)
     - [`ExpandTemplates`](@ref)
+    - [`ExpandExecutableTemplates`](@ref)
     - [`CheckDocument`](@ref)
     - [`Populate`](@ref)
     - [`RenderDocument`](@ref)
@@ -33,9 +34,14 @@ module Builder
     abstract type Doctest <: DocumentPipeline end
 
     """
-    Executes a sequence of actions on each node of the parsed markdown files in turn.
+    Expands non-executable markdown templates in the parsed markdown files.
     """
     abstract type ExpandTemplates <: DocumentPipeline end
+
+    """
+    Expands executable markdown templates in the parsed markdown files.
+    """
+    abstract type ExpandExecutableTemplates <: DocumentPipeline end
 
     """
     Finds and sets URLs for each `@ref` link in the document to the correct destinations.
@@ -62,6 +68,7 @@ end
 Selectors.order(::Type{Builder.SetupBuildDirectory}) = 1.0
 Selectors.order(::Type{Builder.Doctest}) = 1.1
 Selectors.order(::Type{Builder.ExpandTemplates}) = 2.0
+Selectors.order(::Type{Builder.ExpandExecutableTemplates}) = 2.1
 Selectors.order(::Type{Builder.CrossReferences}) = 3.0
 Selectors.order(::Type{Builder.CheckDocument}) = 4.0
 Selectors.order(::Type{Builder.Populate}) = 5.0
@@ -221,7 +228,14 @@ end
 function Selectors.runner(::Type{Builder.ExpandTemplates}, doc::Documenter.Document)
     is_doctest_only(doc, "ExpandTemplates") && return
     @info "ExpandTemplates: expanding markdown templates."
-    expand(doc)
+    expand_templates(doc)
+    return
+end
+
+function Selectors.runner(::Type{Builder.ExpandExecutableTemplates}, doc::Documenter.Document)
+    is_doctest_only(doc, "ExpandExecutableTemplates") && return
+    @info "ExpandExecutableTemplates: expanding executable markdown templates."
+    expand_executable_templates(doc)
     return
 end
 

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -37,40 +37,73 @@ function clear_modules!(d::Dict{Symbol, Any})
     return
 end
 
-function expand(doc::Documenter.Document)
+function ordered_expander_pages(doc::Documenter.Document; warn_missing::Bool = true)
     expandfirst = map(normpath, doc.user.expandfirst)
     priority_pages = filter(expandfirst) do src
         if src in keys(doc.blueprint.pages)
             return true
         else
-            @warn "$(src) in expandfirst does not exist"
+            warn_missing && @warn "$(src) in expandfirst does not exist"
             return false
         end
     end
     normal_pages = filter(src -> !(src in priority_pages), keys(doc.blueprint.pages))
     normal_pages = sort([src for src in normal_pages])
     @debug "pages" keys(doc.blueprint.pages) priority_pages normal_pages
-    for src in Iterators.flatten([priority_pages, normal_pages])
+    return Iterators.flatten([priority_pages, normal_pages])
+end
+
+function expand_page!(pipeline, nested_pipeline, page, doc)
+    # We need to collect the child nodes here because we will end up changing the structure
+    # of the tree in some cases.
+    for node in collect(page.mdast.children)
+        Selectors.dispatch(pipeline, node, page, doc)
+        expand_recursively(node, page, doc, nested_pipeline)
+    end
+    return
+end
+
+function expand_templates(doc::Documenter.Document)
+    for src in ordered_expander_pages(doc)
         page = doc.blueprint.pages[src]
         @debug "Running ExpanderPipeline on $src"
         copy!(page.globals.meta, doc.user.meta)
-        # We need to collect the child nodes here because we will end up changing the structure
-        # of the tree in some cases.
-        for node in collect(page.mdast.children)
-            Selectors.dispatch(Expanders.ExpanderPipeline, node, page, doc)
-            expand_recursively(node, page, doc)
-        end
+        expand_page!(Expanders.ExpanderPipeline, Expanders.NestedExpanderPipeline, page, doc)
+    end
+    return
+end
+
+function expand_executable_templates(doc::Documenter.Document)
+    for src in ordered_expander_pages(doc; warn_missing = false)
+        page = doc.blueprint.pages[src]
+        @debug "Running ExecutableExpanderPipeline on $src"
+        expand_page!(
+            Expanders.ExecutableExpanderPipeline,
+            Expanders.NestedExecutableExpanderPipeline,
+            page,
+            doc,
+        )
         pagecheck(doc, page)
         clear_modules!(page.globals.meta)
     end
     return
 end
 
+function expand(doc::Documenter.Document)
+    expand_templates(doc)
+    expand_executable_templates(doc)
+    return
+end
+
 """
-Similar to `expand()`, but recursively calls itself on all descendants of `node`
-and applies `NestedExpanderPipeline` instead of `ExpanderPipeline`.
+Similar to `expand_page!`, but recursively calls itself on all descendants of `node`
+and applies the supplied nested expander pipeline.
 """
 function expand_recursively(node, page, doc)
+    return expand_recursively(node, page, doc, Expanders.NestedExpanderPipeline)
+end
+
+function expand_recursively(node, page, doc, nested_pipeline)
     if typeof(node.element) in (
             MarkdownAST.Admonition,
             MarkdownAST.BlockQuote,
@@ -78,8 +111,8 @@ function expand_recursively(node, page, doc)
             MarkdownAST.List,
         )
         for child in node.children
-            Selectors.dispatch(Expanders.NestedExpanderPipeline, child, page, doc)
-            expand_recursively(child, page, doc)
+            Selectors.dispatch(nested_pipeline, child, page, doc)
+            expand_recursively(child, page, doc, nested_pipeline)
         end
     end
     return
@@ -119,18 +152,17 @@ module Expanders
     import ..Documenter.Selectors
 
     """
-    The default node expander "pipeline", which consists of the following expanders:
+    The node expander "pipeline" for non-executable markdown templates.
+
+    It consists of the following expanders:
 
     - [`TrackHeaders`](@ref)
     - [`MetaBlocks`](@ref)
     - [`DocsBlocks`](@ref)
     - [`AutoDocsBlocks`](@ref)
-    - [`EvalBlocks`](@ref)
     - [`IndexBlocks`](@ref)
     - [`ContentsBlocks`](@ref)
-    - [`ExampleBlocks`](@ref)
-    - [`SetupBlocks`](@ref)
-    - [`REPLBlocks`](@ref)
+    - [`RawBlocks`](@ref)
 
     """
     abstract type ExpanderPipeline <: Selectors.AbstractSelector end
@@ -141,6 +173,27 @@ module Expanders
     See also [`expand_recursively`](@ref `Documenter.expand_recursively`).
     """
     abstract type NestedExpanderPipeline <: ExpanderPipeline end
+
+    """
+    The node expander "pipeline" for executable markdown templates.
+
+    It consists of the following expanders:
+
+    - [`EvalBlocks`](@ref)
+    - [`ExampleBlocks`](@ref)
+    - [`REPLBlocks`](@ref)
+    - [`SetupBlocks`](@ref)
+
+    """
+    abstract type ExecutableExpanderPipeline <: Selectors.AbstractSelector end
+
+    """
+    The subset of [executable node expanders](@ref `ExecutableExpanderPipeline`) which also
+    apply in nested contexts.
+
+    See also [`expand_recursively`](@ref `Documenter.expand_recursively`).
+    """
+    abstract type NestedExecutableExpanderPipeline <: ExecutableExpanderPipeline end
 
     """
     Tracks all `Markdown.Header` nodes found in the parsed markdown files and stores an
@@ -206,7 +259,7 @@ module Expanders
     ```
     ````
     """
-    abstract type EvalBlocks <: NestedExpanderPipeline end
+    abstract type EvalBlocks <: NestedExecutableExpanderPipeline end
 
     """
     Parses each code block where the language is `@raw`.
@@ -262,7 +315,7 @@ module Expanders
     ```
     ````
     """
-    abstract type ExampleBlocks <: NestedExpanderPipeline end
+    abstract type ExampleBlocks <: NestedExecutableExpanderPipeline end
 
     """
     Similar to the [`ExampleBlocks`](@ref) expander, but inserts a Julia REPL prompt before each
@@ -276,7 +329,7 @@ module Expanders
     ```
     ````
     """
-    abstract type REPLBlocks <: NestedExpanderPipeline end
+    abstract type REPLBlocks <: NestedExecutableExpanderPipeline end
 
     """
     Similar to the [`ExampleBlocks`](@ref) expander, but hides all output in the final document.
@@ -287,7 +340,7 @@ module Expanders
     ```
     ````
     """
-    abstract type SetupBlocks <: NestedExpanderPipeline end
+    abstract type SetupBlocks <: NestedExecutableExpanderPipeline end
 end
 
 Selectors.order(::Type{Expanders.TrackHeaders}) = 1.0
@@ -318,6 +371,8 @@ Selectors.matcher(::Type{Expanders.RawBlocks}, node, page, doc) = iscode(node, r
 
 Selectors.runner(::Type{Expanders.ExpanderPipeline}, node, page, doc) = nothing
 Selectors.runner(::Type{Expanders.NestedExpanderPipeline}, node, page, doc) = nothing
+Selectors.runner(::Type{Expanders.ExecutableExpanderPipeline}, node, page, doc) = nothing
+Selectors.runner(::Type{Expanders.NestedExecutableExpanderPipeline}, node, page, doc) = nothing
 
 # Track Headers.
 # --------------

--- a/test/examples/make.jl
+++ b/test/examples/make.jl
@@ -244,6 +244,7 @@ htmlbuild_pages = Any[
     "example-output.md",
     "fonts.md",
     "issue491.md",
+    "staged-expansion.md",
     "linenumbers.md",
     "EditURL" => [
         "editurl/good.md",

--- a/test/examples/src/staged-expansion.md
+++ b/test/examples/src/staged-expansion.md
@@ -1,0 +1,28 @@
+# Staged Expansion
+
+Tests that non-executable templates are expanded before executable templates.
+
+```@example
+staged_meta_value = "meta_stage"
+```
+
+```@example
+staged_meta_value * "_shared"
+```
+
+```@setup staged-execution
+stage_prefix = "expanded"
+```
+
+```@eval staged-execution
+import Markdown
+Markdown.parse(stage_prefix * "-eval-shared")
+```
+
+```@example staged-execution
+println(stage_prefix, "-example-shared")
+```
+
+```@meta
+ShareDefaultModule = true
+```

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -86,7 +86,7 @@ all_md_files_in_src = let srcdir = joinpath(@__DIR__, "src"), mdfiles = String[]
     end
     mdfiles
 end
-@test length(all_md_files_in_src) == 29
+@test length(all_md_files_in_src) == 30
 
 @testset "Examples" begin
     @testset "HTML: deploy/$name" for (doc, name) in [
@@ -181,6 +181,14 @@ end
             @test occursin("expanded_example", issue_491)
             @test occursin("expanded_setup", issue_491)
             @test occursin("<p>expanded_raw</p>", issue_491)
+
+            # Staged expansion
+            @test isfile(joinpath(build_dir, "staged-expansion", "index.html"))
+            staged_expansion = read(joinpath(build_dir, "staged-expansion", "index.html"), String)
+
+            @test occursin("meta_stage_shared", staged_expansion)
+            @test occursin("expanded-eval-shared", staged_expansion)
+            @test occursin("expanded-example-shared", staged_expansion)
 
             # CollapsedDocStrings
             if name == "html"

--- a/test/warnings/make.jl
+++ b/test/warnings/make.jl
@@ -66,6 +66,7 @@ julia> WarningTests.run_warnings_test("at-docs")
 │    1 !in 2
 │    #└────┘ ── extra tokens after end of expression
 └ @ Documenter
+[ Info: ExpandExecutableTemplates: expanding executable markdown templates.
 [ Info: CrossReferences: building cross-references.
 [ Info: CheckDocument: running document checks.
 [ Info: Populate: populating indices.
@@ -94,6 +95,7 @@ julia> WarningTests.run_warnings_test("at-eval")
 [ Info: SetupBuildDirectory: setting up build directory.
 [ Info: Doctest: running doctests.
 [ Info: ExpandTemplates: expanding markdown templates.
+[ Info: ExpandExecutableTemplates: expanding executable markdown templates.
 ┌ Warning: failed to parse code block in src/at-eval.md:13-15
 │   exception =
 │    ParseError:
@@ -132,6 +134,7 @@ julia> WarningTests.run_warnings_test("at-example")
 [ Info: SetupBuildDirectory: setting up build directory.
 [ Info: Doctest: running doctests.
 [ Info: ExpandTemplates: expanding markdown templates.
+[ Info: ExpandExecutableTemplates: expanding executable markdown templates.
 ┌ Warning: failed to parse code block in src/at-example.md:13-15
 │   exception =
 │    ParseError:
@@ -160,6 +163,7 @@ julia> WarningTests.run_warnings_test("at-meta")
 [ Info: SetupBuildDirectory: setting up build directory.
 [ Info: Doctest: running doctests.
 [ Info: ExpandTemplates: expanding markdown templates.
+[ Info: ExpandExecutableTemplates: expanding executable markdown templates.
 [ Info: CrossReferences: building cross-references.
 [ Info: CheckDocument: running document checks.
 [ Info: Populate: populating indices.
@@ -177,6 +181,7 @@ julia> WarningTests.run_warnings_test("at-repl")
 [ Info: SetupBuildDirectory: setting up build directory.
 [ Info: Doctest: running doctests.
 [ Info: ExpandTemplates: expanding markdown templates.
+[ Info: ExpandExecutableTemplates: expanding executable markdown templates.
 ┌ Warning: failed to parse code block in src/at-repl.md:13-15
 │   exception =
 │    ParseError:
@@ -201,6 +206,7 @@ julia> WarningTests.run_warnings_test("at-setup")
 [ Info: SetupBuildDirectory: setting up build directory.
 [ Info: Doctest: running doctests.
 [ Info: ExpandTemplates: expanding markdown templates.
+[ Info: ExpandExecutableTemplates: expanding executable markdown templates.
 ┌ Warning: In src/at-setup.md:13-15: `@setup` block has an unsupported keyword argument: typo
 └ @ Documenter
 ┌ Warning: failed to run `@setup` block in src/at-setup.md:18-20
@@ -251,6 +257,7 @@ julia> WarningTests.run_warnings_test("doctest")
 │ ```
 └ @ Documenter
 [ Info: ExpandTemplates: expanding markdown templates.
+[ Info: ExpandExecutableTemplates: expanding executable markdown templates.
 [ Info: CrossReferences: building cross-references.
 [ Info: CheckDocument: running document checks.
 [ Info: Populate: populating indices.
@@ -268,6 +275,7 @@ julia> WarningTests.run_warnings_test("dollar")
 [ Info: SetupBuildDirectory: setting up build directory.
 [ Info: Doctest: running doctests.
 [ Info: ExpandTemplates: expanding markdown templates.
+[ Info: ExpandExecutableTemplates: expanding executable markdown templates.
 [ Info: CrossReferences: building cross-references.
 [ Info: CheckDocument: running document checks.
 [ Info: Populate: populating indices.


### PR DESCRIPTION
## Summary

* split markdown template expansion into separate non-executable and executable builder stages
* run `@eval`, `@example`, `@repl`, and `@setup` after non-executable templates while preserving nested expansion support
* add staged example coverage, update pipeline log expectations, and document the behavior change in the guide and changelog

## Validation

* Targeted `DOCUMENTER_TEST_EXAMPLES=html` example build with staged expansion assertions
* `test/warnings/make.jl`
* `test/pipeline.jl`
* `git diff --check`

Runic formatting was attempted, but the local `@runic` environment failed to precompile due to a `JuliaSyntax` `unknown Kind name "cartesian_iterator"` error.

## AI Assistance

This change was prepared with assistance from OpenAI Codex.
