### PR TITLE
Add workflow_dispatch to yml to allow manual runs

### DIFF
--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -57,7 +57,7 @@ on:
       - master # update to match your development branch (master, main, dev, trunk, ...)
     tags: '*'
   pull_request:
-
+  workflow_dispatch:
 jobs:
   build:
     # These permissions are needed to:

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -58,6 +58,7 @@ on:
     tags: '*'
   pull_request:
   workflow_dispatch:
+
 jobs:
   build:
     # These permissions are needed to:


### PR DESCRIPTION
I added  `workflow_dispatch:` to the documentation.yml example. This allows to run this manually as well.

See https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch and https://github.com/orgs/community/discussions/58022