### PR TITLE
Support arbitrary `[content](@id name)` anchors (#745)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Support self-hosted GitHub instances. ([#2755])
+* The `[content](@id name)` syntax can now attach a named, cross-referenceable anchor to arbitrary inline content (such as text or a thumbnail image), not just headers. These anchors resolve via `@ref`, share a single id namespace with header labels, and are written to the `objects.inv` inventory as `std:label` entries. ([#745])
 
 ### Changed
 
@@ -1664,6 +1665,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#697]: https://github.com/JuliaDocs/Documenter.jl/issues/697
 [#706]: https://github.com/JuliaDocs/Documenter.jl/issues/706
 [#744]: https://github.com/JuliaDocs/Documenter.jl/issues/744
+[#745]: https://github.com/JuliaDocs/Documenter.jl/issues/745
 [#756]: https://github.com/JuliaDocs/Documenter.jl/issues/756
 [#764]: https://github.com/JuliaDocs/Documenter.jl/issues/764
 [#774]: https://github.com/JuliaDocs/Documenter.jl/issues/774

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -294,6 +294,33 @@ document more than once is disallowed.
     Both user-defined and internally generated header reference labels take precedence over
     docstring references, in case there is a conflict.
 
+### Anchors on arbitrary content
+
+The `[content](@id name)` syntax is not restricted to headers: it can attach a named anchor
+to arbitrary inline content, turning it into a cross-reference target. This is useful, for
+example, to link a thumbnail image to the section or figure it previews:
+
+```markdown
+A named anchor on inline text: [some text](@id my-anchor).
+
+A clickable thumbnail that is itself an anchor target:
+
+[![thumbnail](assets/thumb.png)](@id figure-1)
+
+... elsewhere ...
+
+Jump to [the anchored text](@ref my-anchor) or [Figure 1](@ref figure-1).
+```
+
+Unlike the header form, the link wrapping the content is *not* removed: the content is
+rendered as usual, wrapped in an anchor (`<a id="...">` in HTML, `\hypertarget` in
+``\LaTeX``) that `@ref` links can point to.
+
+These anchors share a single id namespace with header `@id` labels (so a duplicate id is
+reported the same way a duplicate header is), and they are written into the `objects.inv`
+inventory as `std:label` entries, which means other projects can link to them with
+[`@extref`](@ref) via the `DocumenterInterLinks` plugin.
+
 ### `@extref` link
 
 Using the [`DocumenterInterLinks` plugin](https://github.com/JuliaDocs/DocumenterInterLinks.jl#readme),

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -313,7 +313,7 @@ Jump to [the anchored text](@ref my-anchor) or [Figure 1](@ref figure-1).
 ```
 
 Unlike the header form, the link wrapping the content is *not* removed: the content is
-rendered as usual, wrapped in an anchor (`<a id="...">` in HTML, `\hypertarget` in
+rendered as usual, wrapped in an anchor (`<span id="...">` in HTML, `\hypertarget` in
 ``\LaTeX``) that `@ref` links can point to.
 
 These anchors share a single id namespace with header `@id` labels (so a duplicate id is

--- a/src/documents.jl
+++ b/src/documents.jl
@@ -245,6 +245,19 @@ struct LocalImage <: AbstractDocumenterInline
 end
 Base.show(io::IO, image::LocalImage) = print(io, "Documenter.LocalImage(\"", image.path, "\")")
 
+"""
+Represents a named anchor attached to arbitrary inline content via the `[content](@id name)`
+syntax. Unlike a header anchor ([`AnchoredHeader`](@ref)), this can wrap any inline content
+(text, images, code) so that it becomes a cross-reference target for `[text](@ref name)`.
+
+The wrapped content is stored as the child nodes of the `MarkdownAST.Node` holding this
+element, mirroring how [`PageLink`](@ref) replaces a `MarkdownAST.Link` in place.
+"""
+struct AnchoredInline <: AbstractDocumenterInline
+    anchor::Anchor
+end
+Base.show(io::IO, ::AnchoredInline) = print(io, "Documenter.AnchoredInline([...])")
+
 # Navigation
 # ----------------------
 
@@ -1031,7 +1044,10 @@ function populate!(contents::ContentsNode, document::Document)
                 page = relpath(anchor.file, dirname(contents.build))
                 # Note: This only filters based on contents.depth and *not* contents.mindepth.
                 #       Instead the writers who support this adjust this when rendering.
-                if _isvalid(page, contents.pages) && anchor.object.level ≤ contents.depth
+                # Only headers participate in `@contents` listings. The same AnchorMap also
+                # holds arbitrary `[content](@id name)` anchors (whose `.object` is not a
+                # Heading), which must be skipped here.
+                if _isvalid(page, contents.pages) && anchor.object isa MarkdownAST.Heading && anchor.object.level ≤ contents.depth
                     push!(contents.elements, (anchor.order, page, anchor))
                 end
             end
@@ -1130,6 +1146,7 @@ end
 
 # Extend MDFlatten.mdflatten to support the Documenter-specific elements
 MDFlatten.mdflatten(io, node::MarkdownAST.Node, ::AnchoredHeader) = MDFlatten.mdflatten(io, node.children)
+MDFlatten.mdflatten(io, node::MarkdownAST.Node, ::AnchoredInline) = MDFlatten.mdflatten(io, node.children)
 MDFlatten.mdflatten(io, node::MarkdownAST.Node, e::SetupNode) = MDFlatten.mdflatten(io, node, MarkdownAST.CodeBlock(e.name, e.code))
 MDFlatten.mdflatten(io, node::MarkdownAST.Node, e::RawNode) = MDFlatten.mdflatten(io, node, MarkdownAST.CodeBlock("@raw $(e.name)", e.text))
 MDFlatten.mdflatten(io, node::MarkdownAST.Node, e::AbstractDocumenterBlock) = MDFlatten.mdflatten(io, node, e.codeblock)

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -336,7 +336,7 @@ function Selectors.runner(::Type{Expanders.TrackHeaders}, node, page, doc)
         link_node = first(node.children)
         MarkdownAST.unlink!(link_node)
         append!(node.children, link_node.children)
-        text = match(NAMEDHEADER_REGEX, link_node.element.destination)[1]
+        text = match(NAMED_ANCHOR_REGEX, link_node.element.destination)[1]
     else
         # TODO: remove this hack (replace with mdflatten?)
         ast = MarkdownAST.@ast MarkdownAST.Document() do
@@ -1122,13 +1122,16 @@ iscode(x::MarkdownAST.CodeBlock, r::Regex) = occursin(r, x.info)
 iscode(x::MarkdownAST.CodeBlock, lang) = x.info == lang
 iscode(x, lang) = false
 
-const NAMEDHEADER_REGEX = r"^@id (.+)$"
+# Matches the destination of an `@id` link, both for named headers (`# [H](@id name)`,
+# handled by TrackHeaders) and for inline anchors on arbitrary content (handled by
+# collect_named_anchors!).
+const NAMED_ANCHOR_REGEX = r"^@id (.+)$"
 
 function namedheader(node::Node)
     @assert node.element isa MarkdownAST.Heading
     if length(node.children) == 1 && first(node.children).element isa MarkdownAST.Link
         url = first(node.children).element.destination
-        return occursin(NAMEDHEADER_REGEX, url)
+        return occursin(NAMED_ANCHOR_REGEX, url)
     else
         return false
     end
@@ -1142,7 +1145,7 @@ end
 function collect_named_anchors!(page, doc)
     for node in AbstractTrees.PreOrderDFS(page.mdast)
         node.element isa MarkdownAST.Link || continue
-        m = match(NAMEDHEADER_REGEX, node.element.destination)
+        m = match(NAMED_ANCHOR_REGEX, node.element.destination)
         isnothing(m) && continue
         # Links that are the sole child of a Heading are header anchors, handled (and removed
         # from the tree) by TrackHeaders; guard against re-registering one here.

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -1150,7 +1150,10 @@ function collect_named_anchors!(page, doc)
         if !isnothing(parent) && parent.element isa MarkdownAST.Heading && length(parent.children) == 1
             continue
         end
-        id = String(m[1])
+        # Slugify the id exactly as TrackHeaders does for named headers, so that inline and
+        # header `@id` anchors share identical id semantics (and never emit an invalid HTML
+        # id, e.g. one containing spaces).
+        id = Documenter.slugify(String(m[1]))
         anchor = Documenter.anchor_add!(doc.internal.headers, node.element, id, page.build)
         node.element = Documenter.AnchoredInline(anchor)
         anchor.node = node

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -60,6 +60,11 @@ function expand(doc::Documenter.Document)
             Selectors.dispatch(Expanders.ExpanderPipeline, node, page, doc)
             expand_recursively(node, page, doc)
         end
+        # Register arbitrary `[content](@id name)` anchors. This runs after the per-node
+        # expansion above (so header `@id` links have already been consumed by TrackHeaders)
+        # and, crucially, before the CrossReferences pipeline stage, so that `@ref`s to these
+        # anchors — including forward references to later pages — can be resolved.
+        collect_named_anchors!(page, doc)
         pagecheck(doc, page)
         clear_modules!(page.globals.meta)
     end
@@ -1127,6 +1132,30 @@ function namedheader(node::Node)
     else
         return false
     end
+end
+
+# Walk the whole page tree and turn every `[content](@id name)` link on non-header content
+# into an `AnchoredInline`, registering the anchor in the same AnchorMap used for headers.
+# Reusing `doc.internal.headers` means these anchors share a single id namespace with headers
+# (so collisions are caught by the existing uniqueness checks), resolve through the existing
+# `@ref` header pipeline, and are written to the `objects.inv` inventory automatically.
+function collect_named_anchors!(page, doc)
+    for node in AbstractTrees.PreOrderDFS(page.mdast)
+        node.element isa MarkdownAST.Link || continue
+        m = match(NAMEDHEADER_REGEX, node.element.destination)
+        isnothing(m) && continue
+        # Links that are the sole child of a Heading are header anchors, handled (and removed
+        # from the tree) by TrackHeaders; guard against re-registering one here.
+        parent = node.parent
+        if !isnothing(parent) && parent.element isa MarkdownAST.Heading && length(parent.children) == 1
+            continue
+        end
+        id = String(m[1])
+        anchor = Documenter.anchor_add!(doc.internal.headers, node.element, id, page.build)
+        node.element = Documenter.AnchoredInline(anchor)
+        anchor.node = node
+    end
+    return
 end
 
 # Remove any `# hide` lines, leading/trailing blank lines, and trailing whitespace.

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -1833,6 +1833,12 @@ function domify(dctx::DCtx, node::Node, ah::Documenter.AnchoredHeader)
     )
 end
 
+function domify(dctx::DCtx, node::Node, ai::Documenter.AnchoredInline)
+    @tags a
+    id = lstrip(Documenter.anchor_fragment(ai.anchor), '#')
+    return a[:id => id](domify(dctx, node.children))
+end
+
 struct ListBuilder
     es::Vector
 end

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -1834,9 +1834,13 @@ function domify(dctx::DCtx, node::Node, ah::Documenter.AnchoredHeader)
 end
 
 function domify(dctx::DCtx, node::Node, ai::Documenter.AnchoredInline)
-    @tags a
+    @tags span
     id = lstrip(Documenter.anchor_fragment(ai.anchor), '#')
-    return a[:id => id](domify(dctx, node.children))
+    # A `<span id=...>` (rather than `<a id=...>`) so the anchored content renders exactly as
+    # it would without the anchor: it is a valid fragment/scroll target, but avoids link
+    # styling on non-link content and nesting an <a> inside the content (which may itself be a
+    # link or image).
+    return span[:id => id](domify(dctx, node.children))
 end
 
 struct ListBuilder

--- a/src/html/write_inventory.jl
+++ b/src/html/write_inventory.jl
@@ -135,7 +135,10 @@ end
 # dispname for :std:label
 function _get_inventory_dispname(doc, ctx, name::AbstractString, anchor::Documenter.Anchor)
     dispname = mdflatten(anchor.node)
-    if dispname == name
+    # `-` is the inventory convention for "display name is the same as the name". Empty
+    # content (e.g. `[](@id name)`) has no display name, so use `-` rather than emitting a
+    # trailing-empty field.
+    if isempty(dispname) || dispname == name
         dispname = "-"
     end
     return dispname

--- a/src/latex/LaTeXWriter.jl
+++ b/src/latex/LaTeXWriter.jl
@@ -353,6 +353,16 @@ function latex(io::Context, node::Node, ah::Documenter.AnchoredHeader)
     return
 end
 
+function latex(io::Context, node::Node, ai::Documenter.AnchoredInline)
+    # A `\hypertarget` (matching the `\hyperlinkref` emitted for a resolved `@ref`, see the
+    # PageLink method) wrapping the anchored inline content.
+    id = _hash(Documenter.anchor_label(ai.anchor))
+    _print(io, "\\hypertarget{", id, "}{")
+    latex(io, node.children)
+    _print(io, "}")
+    return
+end
+
 ## Documentation Nodes.
 
 function latex(io::Context, node::Node, ::Documenter.DocsNodesBlock)

--- a/test/crossreferences.jl
+++ b/test/crossreferences.jl
@@ -105,6 +105,16 @@ end
     @test occursin("my-anchor std:label", inv)
     @test occursin("fig-anchor std:label", inv)
 
+    # The id is slugified exactly like a header `@id`, so an id with spaces/mixed case
+    # yields a valid HTML id and resolves via its slug (matching header behaviour).
+    tmp = build_doc([
+        "index.md" => "# H\n\n[content](@id My Anchor Name).\n\nRef: [x](@ref My-Anchor-Name).\n",
+    ])
+    html = read(joinpath(tmp, "build", "index.html"), String)
+    @test occursin("<a id=\"My-Anchor-Name\">", html)
+    @test !occursin("id=\"My Anchor Name\"", html)
+    @test occursin("href=\"#My-Anchor-Name\"", html)
+
     # Forward/cross-page reference to an inline anchor defined on a later page.
     tmp = build_doc([
         "a.md" => "# A\n\nSee [target](@ref cross-anchor).\n",

--- a/test/crossreferences.jl
+++ b/test/crossreferences.jl
@@ -96,8 +96,8 @@ end
         """,
     ])
     html = read(joinpath(tmp, "build", "index.html"), String)
-    @test occursin("<a id=\"my-anchor\">", html)
-    @test occursin("<a id=\"fig-anchor\">", html)
+    @test occursin("<span id=\"my-anchor\">", html)
+    @test occursin("<span id=\"fig-anchor\">", html)
     @test occursin("href=\"#my-anchor\"", html)
     @test occursin("href=\"#fig-anchor\"", html)
     # The anchors are written to the inventory as std:label entries.
@@ -111,7 +111,7 @@ end
         "index.md" => "# H\n\n[content](@id My Anchor Name).\n\nRef: [x](@ref My-Anchor-Name).\n",
     ])
     html = read(joinpath(tmp, "build", "index.html"), String)
-    @test occursin("<a id=\"My-Anchor-Name\">", html)
+    @test occursin("<span id=\"My-Anchor-Name\">", html)
     @test !occursin("id=\"My Anchor Name\"", html)
     @test occursin("href=\"#My-Anchor-Name\"", html)
 

--- a/test/crossreferences.jl
+++ b/test/crossreferences.jl
@@ -57,4 +57,68 @@ end
         (kind = :explicit_header_id, target = "DocsReferencingMain.g", slug = "DocsReferencingMain.g")
 end
 
+# Arbitrary anchors on inline content via `[content](@id name)` (issue #745).
+@testset "Inline @id anchors" begin
+    using CodecZlib: ZlibDecompressor, transcode
+
+    function build_doc(files::Vector{Pair{String, String}}; kwargs...)
+        tmp = mktempdir()
+        src = joinpath(tmp, "src")
+        mkpath(joinpath(src, "assets"))
+        write(joinpath(src, "assets", "logo.png"), "\x89PNG\r\n\x1a\n")
+        for (name, content) in files
+            write(joinpath(src, name), content)
+        end
+        Documenter.makedocs(;
+            root = tmp, sitename = "T", pages = [f.first for f in files],
+            format = Documenter.HTML(edit_link = nothing, disable_git = true, inventory_version = "1.0"),
+            remotes = nothing, kwargs...,
+        )
+        return tmp
+    end
+
+    function read_inventory(tmp)
+        bytes = read(joinpath(tmp, "build", "objects.inv"))
+        hdrend = findlast(codeunits("zlib.\n"), bytes)
+        return String(transcode(ZlibDecompressor, bytes[(last(hdrend) + 1):end]))
+    end
+
+    # Happy path: inline text anchor + a thumbnail-image anchor, both referenced.
+    tmp = build_doc([
+        "index.md" => """
+        # Header
+
+        Inline anchor: [my target](@id my-anchor) mid-sentence.
+
+        Thumbnail: [![thumb](assets/logo.png)](@id fig-anchor)
+
+        Refs: [go to target](@ref my-anchor) and [see figure](@ref fig-anchor).
+        """,
+    ])
+    html = read(joinpath(tmp, "build", "index.html"), String)
+    @test occursin("<a id=\"my-anchor\">", html)
+    @test occursin("<a id=\"fig-anchor\">", html)
+    @test occursin("href=\"#my-anchor\"", html)
+    @test occursin("href=\"#fig-anchor\"", html)
+    # The anchors are written to the inventory as std:label entries.
+    inv = read_inventory(tmp)
+    @test occursin("my-anchor std:label", inv)
+    @test occursin("fig-anchor std:label", inv)
+
+    # Forward/cross-page reference to an inline anchor defined on a later page.
+    tmp = build_doc([
+        "a.md" => "# A\n\nSee [target](@ref cross-anchor).\n",
+        "b.md" => "# B\n\nHere: [the target](@id cross-anchor).\n",
+    ])
+    @test occursin("href=\"../b/#cross-anchor\"", read(joinpath(tmp, "build", "a", "index.html"), String))
+
+    # `@contents` must not trip over inline anchors sharing the header AnchorMap.
+    @test (build_doc(["index.md" => "# Top\n\n```@contents\n```\n\n## Sec\n\n[t](@id inline-a).\n"]); true)
+
+    # A referenced duplicate id is an error, not a silent pick.
+    @test_throws Exception build_doc([
+        "index.md" => "# H\n\n[a](@id dup) and [b](@id dup).\n\nRef: [x](@ref dup).\n",
+    ])
+end
+
 end

--- a/test/crossreferences.jl
+++ b/test/crossreferences.jl
@@ -129,6 +129,30 @@ end
     @test_throws Exception build_doc([
         "index.md" => "# H\n\n[a](@id dup) and [b](@id dup).\n\nRef: [x](@ref dup).\n",
     ])
+
+    # Inline anchors are found inside nested containers (admonitions, lists, ...).
+    tmp = build_doc([
+        "index.md" => """
+        # H
+
+        !!! note
+            An [anchored note](@id in-admon).
+
+        * a list item with [an anchor](@id in-list)
+
+        Refs: [x](@ref in-admon) and [y](@ref in-list).
+        """,
+    ])
+    html = read(joinpath(tmp, "build", "index.html"), String)
+    @test occursin("<span id=\"in-admon\">", html)
+    @test occursin("<span id=\"in-list\">", html)
+
+    # An inline id sharing the header namespace collides with a header slug of the same name.
+    @test_throws Exception build_doc(["index.md" => "# Foo\n\ntext [x](@id Foo).\n\nRef: [r](@ref Foo).\n"])
+
+    # An empty-content anchor `[](@id name)` uses `-` as its inventory display name.
+    tmp = build_doc(["index.md" => "# H\n\n[](@id empty1)\n\nRef [r](@ref empty1).\n"])
+    @test any(l -> startswith(l, "empty1 std:label -1 ") && endswith(strip(l), " -"), split(read_inventory(tmp), '\n'))
 end
 
 end

--- a/test/examples/src/xrefs.md
+++ b/test/examples/src/xrefs.md
@@ -11,6 +11,9 @@ Named x-refs:
 * [docstring target](@ref Mod.func)
 * [docstring target via backticks](@ref `Mod.func`)
 * [string target](@ref "X-ref target")
+* [inline anchor target](@ref inline-anchor-target)
+
+Inline anchor on arbitrary (non-header) content: [an anchored phrase](@id inline-anchor-target).
 
 ## X-ref target
 

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -232,6 +232,14 @@ end
                             @test item.dispname == "X-ref target with id"
                             @test DocInventories.uri(item) == "xrefs/#xreftarget"
                         end
+                        # Inline `[content](@id name)` anchor on non-header content (#745)
+                        item = inv[":std:label:`inline-anchor-target`"]
+                        @test !isnothing(item)
+                        if !isnothing(item)
+                            @test item.name == "inline-anchor-target"
+                            @test item.dispname == "an anchored phrase"
+                            @test DocInventories.uri(item) == "xrefs/#inline-anchor-target"
+                        end
                         item = inv[":std:label:`Markdown-files-with-spaces`"]
                         @test !isnothing(item)
                         if !isnothing(item)


### PR DESCRIPTION
Closes #745.

## What this does

Generalizes the `@id` mechanism — currently limited to top-level headers — so `[content](@id name)` can attach a named, cross-referenceable anchor to **arbitrary inline content** (text, images). For example, the original use case in this issue: a thumbnail image that jumps to a full-size figure.

```markdown
An inline text anchor: [some phrase](@id my-anchor).

A clickable thumbnail that is itself an anchor target:
[![thumbnail](assets/thumb.png)](@id figure-1)

... elsewhere, on any page ...
Jump to [the phrase](@ref my-anchor) or [Figure 1](@ref figure-1).
```

This follows the direction suggested here by @ettersi (reuse `@id` for consistency with header labels) and @mortenpi (the at-id lookup is currently restricted to headings; generalizing it).

## Behavior

- Resolves through the existing `@ref` pipeline, including forward and cross-page references.
- Shares a single id namespace with header `@id` labels, so a duplicate id (header/header, header/inline, or inline/inline) is caught by the existing uniqueness check.
- Ids are slugified exactly as header `@id`s are, so `[x](@id My Anchor)` yields a valid `My-Anchor` id.
- Written to the `objects.inv` inventory as `std:label` entries, so other projects can reach them via `DocumenterInterLinks` `@extref` — addressing the inventory requests from @moble and @goerz.
- Rendered as `<span id="...">` in HTML and `\hypertarget` in LaTeX (matching the `\hyperlinkref` emitted for a resolved `@ref`). A `<span>` (rather than `<a id>`) keeps the anchored content visually unchanged and avoids nesting an `<a>` inside content that may itself be a link or image.

## Implementation

- New `AnchoredInline` inline element (`documents.jl`).
- `collect_named_anchors!` (`expander_pipeline.jl`) walks each page during template expansion — before the cross-reference stage — and rewrites non-header `@id` links, registering them in the same `AnchorMap` as headers.
- `@contents` population skips non-heading anchors that now share that map.
- HTML and LaTeX writer methods for `AnchoredInline`.

## Tests & docs

- Integration tests in `test/crossreferences.jl` covering HTML output, inventory entries, cross-page references, nesting in admonitions/lists, header-slug collisions, id slugification, empty-content anchors, and duplicate-id failure.
- An inline anchor added to the `examples/` build, with an `objects.inv` assertion via `DocInventories` in `test/examples/tests.jl` (exercises the real HTML + LaTeX integration path).
- A new "Anchors on arbitrary content" section in `man/syntax.md`, plus a CHANGELOG entry.
- Full test suite passes locally.

## Notes for reviewers

- **Naming:** the anchors are stored in `doc.internal.headers` (reusing the header machinery, per the discussion above), which makes that field name a bit of a misnomer now. Happy to rename it to `doc.internal.anchors` throughout if you'd prefer.
- **Scope:** this handles inline `@id` links in page Markdown. Anchors inside docstrings / `@example` output (which live in off-tree ASTs) and block-level anchoring (e.g. labeling a table or equation, as @odow / @moble mentioned) are out of scope here and would be natural follow-ups.

## Demo

*(screenshots of a small demo site — inline text anchor, a thumbnail-gallery that jumps to full-size figures across pages, and the decoded `objects.inv` — to be added.)*
