### PR TITLE
Make it clearer that `modules` argument is needed for doctests in docstrings

### DIFF
--- a/docs/src/man/doctests.md
+++ b/docs/src/man/doctests.md
@@ -6,9 +6,14 @@ examples from becoming outdated, incorrect, or misleading. It is recommended tha
 a package's examples as possible be runnable by Documenter's doctest.
 Doctest failures during [`makedocs`](@ref) are fatal by default, but can be turned into just warnings by passing `warnonly=:doctest` to `makedocs`.
 
-
 This section of the manual outlines how to go about enabling doctests for code blocks in
 your package's documentation.
+
+!!! note "Doctests in docstrings"
+
+    This page mostly describes `jldoctest` code blocks that are directly included in your Markdown files.
+    `jldoctest` code blocks can also be included inside docstrings.
+    However, you will need to add the top-level module containing those docstrings to [`makedocs`](@ref)'s `modules` keyword argument in order for Documenter to find and run them.
 
 ## "Script" Examples
 


### PR DESCRIPTION
When `jldoctest` code block is placed in a docstring it's not run unless `makedocs` is given `modules=[MyModule]`. That's fine, but the only mention of this requirement is under an unassuming heading called 'Module-level metadata'

https://documenter.juliadocs.org/stable/man/doctests/#Module-level-metadata

which makes it pretty hard to find (at least I really struggled to find it).

Besides, I only knew to look for it because I already knew that this sort of thing was possible to do. For a newcomer they might not even realise that it's possible to add a doctest in a docstring.

This PR adds a larger note at the top so that it's just more obvious.