### PR TITLE
Allow the output keyword argument for jldoctest blocks again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* `jldoctest; output = false` no longer warns about an unsupported keyword argument: `output` was accidentally left out of the allowed keyword list when fenced code block header parsing was unified. ([#2912])
 * Fixed headers hidden by the navbar. ([#2905])
 * Tightened `@ref` classification so references are matched more consistently by syntax, with header labels still taking precedence over docstrings and mistaken header/id references less likely to resolve as docstrings. ([#2678])
 
@@ -2279,6 +2280,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2880]: https://github.com/JuliaDocs/Documenter.jl/issues/2880
 [#2889]: https://github.com/JuliaDocs/Documenter.jl/issues/2889
 [#2905]: https://github.com/JuliaDocs/Documenter.jl/issues/2905
+[#2912]: https://github.com/JuliaDocs/Documenter.jl/issues/2912
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* `jldoctest; output = false` no longer warns about an unsupported keyword argument: `output` was accidentally left out of the allowed keyword list when fenced code block header parsing was unified. ([#2912])
 * Fixed headers hidden by the navbar. ([#2905])
 * Tightened `@ref` classification so references are matched more consistently by syntax, with header labels still taking precedence over docstrings and mistaken header/id references less likely to resolve as docstrings. ([#2678])
 
@@ -2280,7 +2279,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2880]: https://github.com/JuliaDocs/Documenter.jl/issues/2880
 [#2889]: https://github.com/JuliaDocs/Documenter.jl/issues/2889
 [#2905]: https://github.com/JuliaDocs/Documenter.jl/issues/2905
-[#2912]: https://github.com/JuliaDocs/Documenter.jl/issues/2912
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/src/doctests.jl
+++ b/src/doctests.jl
@@ -112,7 +112,7 @@ function _doctest(ctx::DocTestContext, block::MarkdownAST.CodeBlock)
 
         success, name, d = parse_codeblock_args(
             "jldoctest", block, ctx.doc, source;
-            allowed_kwargs = [:setup, :teardown, :filter, :syntax],
+            allowed_kwargs = [:setup, :teardown, :filter, :syntax, :output],
         )
         success || return false
 


### PR DESCRIPTION
The unified fenced code block header parsing (#2912) validates jldoctest
keyword arguments against an allowed list, but `output` — documented for
suppressing the rendered output of script-style doctests, and still
consumed by doctest_replace! — was accidentally left out, so every
`jldoctest; output = false` block warned about an unsupported keyword.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
