### PR TITLE
Fix linkcheck CI failures

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -32,6 +32,10 @@ linkcheck_ignore = [
 if get(ENV, "GITHUB_ACTIONS", nothing) == "true"
     # It seems that CTAN blocks GitHub Actions?
     push!(linkcheck_ignore, "https://ctan.org/pkg/minted")
+    # Times out from Actions runners (curl exit 28).
+    push!(linkcheck_ignore, "https://www.chiark.greenend.org.uk/~sgtatham/putty/")
+    # Codeberg answers 403 to Actions runners.
+    push!(linkcheck_ignore, r"^https://codeberg.org")
 end
 
 makedocs(

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -32,8 +32,6 @@ linkcheck_ignore = [
 if get(ENV, "GITHUB_ACTIONS", nothing) == "true"
     # It seems that CTAN blocks GitHub Actions?
     push!(linkcheck_ignore, "https://ctan.org/pkg/minted")
-    # Times out from Actions runners (curl exit 28).
-    push!(linkcheck_ignore, "https://www.chiark.greenend.org.uk/~sgtatham/putty/")
     # Codeberg answers 403 to Actions runners.
     push!(linkcheck_ignore, r"^https://codeberg.org")
 end

--- a/test/online/online_githubcheck.jl
+++ b/test/online/online_githubcheck.jl
@@ -6,6 +6,22 @@ using Test
 
 include("../repolink_helpers.jl")
 
+# A Document with a single remote that looks like it was guessed from the registry, so
+# that githubcheck queries the GitHub API for it. Using a synthetic remote rather than a
+# live package keeps the failure modes reproducible -- a real package that happens to be
+# untagged today gets tagged tomorrow.
+const MARKDOWNAST_UUID = Base.UUID("d0879d2d-cac2-40c8-9cee-1863dc0c7391")
+function synthetic_remote_doc(version::VersionNumber, tree_hash::AbstractString)
+    doc = Documenter.Document(; sitename = "sitename", linkcheck = true)
+    # Not a real path; githubcheck only ever uses it as a dictionary key.
+    root = joinpath(@__DIR__, "synthetic-package-root")
+    doc.internal.src_to_uuid[root] = MARKDOWNAST_UUID
+    doc.internal.uuid_to_version_info[MARKDOWNAST_UUID] = (version, tree_hash)
+    remote = Documenter.Remotes.GitHub("JuliaDocs", "MarkdownAST.jl")
+    Documenter.addremote!(doc, Documenter.RemoteRepository(root, remote, "v$(version)"))
+    return doc
+end
+
 @testset "Online githubcheck" begin
     @testset "Success" begin
         src = convert(
@@ -30,26 +46,15 @@ include("../repolink_helpers.jl")
         @test doc.internal.errors == Set{Symbol}()
     end
 
-    @testset "Failure" begin
-        src = convert(
-            MarkdownAST.Node,
-            md"""
-            ```@meta
-            CurrentModule = Main.OnlineGithubCheckTests.TestHelperModule
-            ```
-            This doc will not pass the checks because this version isn't tagged
-            ```@docs
-            RegistryInstances
-            ```
-            """
-        )
-        doc, html = render_expand_doc(src)
+    @testset "Failure: no such tag" begin
+        doc = synthetic_remote_doc(v"999.999.999", "0"^40)
+        @test_logs (:error,) @test githubcheck(doc) === nothing
+        @test doc.internal.errors == Set{Symbol}([:linkcheck_remotes])
+    end
 
-        # Links to repo
-        re = r"<a[^>]+ href=['\"]?https://github.com/JuliaRegistries/RegistryInstances.jl"
-        @test occursin(re, string(html))
-
-        # Gets an error on check
+    @testset "Failure: tree hash mismatch" begin
+        # v0.1.2 exists, but not with this tree hash.
+        doc = synthetic_remote_doc(v"0.1.2", "0"^40)
         @test_logs (:error,) @test githubcheck(doc) === nothing
         @test doc.internal.errors == Set{Symbol}([:linkcheck_remotes])
     end


### PR DESCRIPTION
Two unrelated linkcheck failures on CI which we just ignore

- `https://www.chiark.greenend.org.uk/~sgtatham/putty/` times out (and I've seen this often in the past)
- `https://codeberg.org` returns 403 from runners (200 from a normal machine).

**`test/online/online_githubcheck.jl`** — the "Failure" testset relied on RegistryInstances being at an untagged version. But that isn't something we can rely on forever. So instead the tests now build a synthetic remote instead, with the desired properties we want to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
