### PR TITLE
Drop trailing slash from documenter/deploy status URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed headers hidden by the navbar. ([#2905])
 * Tightened `@ref` classification so references are matched more consistently by syntax, with header labels still taking precedence over docstrings and mistaken header/id references less likely to resolve as docstrings. ([#2678])
+* The `documenter/deploy` commit status now links to the deployed documentation without a trailing slash. ([#2964])
 
 ## Version [v1.17.0] - 2026-02-20
 
@@ -2279,6 +2280,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2880]: https://github.com/JuliaDocs/Documenter.jl/issues/2880
 [#2889]: https://github.com/JuliaDocs/Documenter.jl/issues/2889
 [#2905]: https://github.com/JuliaDocs/Documenter.jl/issues/2905
+[#2964]: https://github.com/JuliaDocs/Documenter.jl/issues/2964
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/src/deployconfig.jl
+++ b/src/deployconfig.jl
@@ -540,6 +540,29 @@ function post_status(gha::GitHubActions; type, subfolder = nothing, kwargs...)
     end
 end
 
+function github_status_json(type, pages_url, subfolder = nothing)
+    json = Dict{String, Any}("context" => "documenter/deploy", "state" => type)
+    if type == "pending"
+        json["description"] = "Documentation build in progress"
+    elseif type == "success"
+        json["description"] = "Documentation build succeeded"
+        # no trailing slash, because a public-to-private redirect in front of a private
+        # GitHub Pages site can 404 on the trailing-slash form
+        target_url = String(rstrip(pages_url, '/'))
+        if !isempty(target_url) && subfolder !== nothing
+            target_url *= "/$(subfolder)"
+        end
+        json["target_url"] = target_url
+    elseif type == "error"
+        json["description"] = "Documentation build errored"
+    elseif type == "failure"
+        json["description"] = "Documentation build failed"
+    else
+        error("unsupported type: $type")
+    end
+    return json
+end
+
 function post_github_status(gha::GitHubActions, type::S, sha::S, subfolder = nothing) where {S <: String}
     try
         if Sys.which("curl") === nothing
@@ -557,24 +580,7 @@ function post_github_status(gha::GitHubActions, type::S, sha::S, subfolder = not
         push!(cmd.exec, "-H", "Authorization: token $(auth)")
         push!(cmd.exec, "-H", "User-Agent: Documenter.jl")
         push!(cmd.exec, "-H", "Content-Type: application/json")
-        json = Dict{String, Any}("context" => "documenter/deploy", "state" => type)
-        if type == "pending"
-            json["description"] = "Documentation build in progress"
-        elseif type == "success"
-            json["description"] = "Documentation build succeeded"
-            target_url = gha.github_pages_url
-            if !isempty(target_url) && subfolder !== nothing
-                target_url = rstrip(target_url, '/') * "/$(subfolder)/"
-            end
-            json["target_url"] = target_url
-        elseif type == "error"
-            json["description"] = "Documentation build errored"
-        elseif type == "failure"
-            json["description"] = "Documentation build failed"
-        else
-            error("unsupported type: $type")
-        end
-        push!(cmd.exec, "-d", JSON.json(json))
+        push!(cmd.exec, "-d", JSON.json(github_status_json(type, gha.github_pages_url, subfolder)))
         push!(cmd.exec, "$(gha.github_api)/repos/$(source_owner)/$(source_repo)/statuses/$(sha)")
         # Run the command (silently)
         io = IOBuffer()

--- a/test/deployconfig.jl
+++ b/test/deployconfig.jl
@@ -543,6 +543,27 @@ end
         ) do
             @test_logs (:warn, "curl not found in PATH, cannot post status") Documenter.post_github_status(Documenter.GitHubActions("pages.selfhosted/something/JuliaDocs/Documenter.jl"), "type", "sha")
         end
+
+        # Check the status payload built for the GitHub API
+        let pages_url = "https://juliadocs.github.io/Documenter.jl/"
+            json = Documenter.github_status_json("success", pages_url)
+            @test json["state"] == "success"
+            @test json["context"] == "documenter/deploy"
+            @test json["description"] == "Documentation build succeeded"
+            @test json["target_url"] == "https://juliadocs.github.io/Documenter.jl"
+
+            json = Documenter.github_status_json("success", pages_url, "previews/PR123")
+            @test json["target_url"] == "https://juliadocs.github.io/Documenter.jl/previews/PR123"
+
+            json = Documenter.github_status_json("success", "", "previews/PR123")
+            @test json["target_url"] == ""
+
+            json = Documenter.github_status_json("pending", pages_url)
+            @test json["description"] == "Documentation build in progress"
+            @test !haskey(json, "target_url")
+
+            @test_throws ErrorException Documenter.github_status_json("nonsense", pages_url)
+        end
     end
 end
 
@@ -1569,7 +1590,7 @@ end
             end
             logged = read(seek(buffer, 0), String)
             @test occursin(r"""`curl -sX POST -H 'Authorization: token SGVsbG8sIHdvcmxkLg==' -H 'User-Agent: Documenter.jl' -H 'Content-Type: application/json' -d '{.+?}' badurl://api.github.com/repos/JuliaDocs/Documenter.jl/statuses/407d4b94`""", logged)
-            @test occursin(r"""`.+?{.*?\"target_url":"https://JuliaDocs.github.io/Documenter.jl/".*?}'.+?`""", logged)
+            @test occursin(r"""`.+?{.*?\"target_url":"https://JuliaDocs.github.io/Documenter.jl".*?}'.+?`""", logged)
             @test occursin(r"""`.+?{.*?\"context\":\"documenter/deploy\".*?}'.+?`""", logged)
             @test occursin(r"""`.+?{.*?\"description\":\"Documentation build succeeded\".*?}'.+?`""", logged)
             @test occursin(r"""`.+?{.*?\"state\":\"success\".*?}'.+?`""", logged)
@@ -1598,7 +1619,7 @@ end
             end
             logged = read(seek(buffer, 0), String)
             @test occursin(r"""`curl -sX POST -H 'Authorization: token SGVsbG8sIHdvcmxkLg==' -H 'User-Agent: Documenter.jl' -H 'Content-Type: application/json' -d '{.+?}' badurl://api.github.com/repos/JuliaDocs/Documenter.jl/statuses/407d4b94`""", logged)
-            @test occursin(r"""`.+?{.*?\"target_url":"https://JuliaDocs.github.io/Documenter.jl/".*?}'.+?`""", logged)
+            @test occursin(r"""`.+?{.*?\"target_url":"https://JuliaDocs.github.io/Documenter.jl".*?}'.+?`""", logged)
             @test occursin(r"""`.+?{.*?\"context\":\"documenter/deploy\".*?}'.+?`""", logged)
             @test occursin(r"""`.+?{.*?\"description\":\"Documentation build succeeded\".*?}'.+?`""", logged)
             @test occursin(r"""`.+?{.*?\"state\":\"success\".*?}'.+?`""", logged)


### PR DESCRIPTION
I found that if this URL ends with a slash, redirect on privately hosted documentation to the random url that github uses doesn't work. For public ones, it doesn't seem to matter which one it is.

Code was generated with Claude Opus 5