### PR TITLE
Exclude putty homepage from linkcheck

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -32,6 +32,8 @@ linkcheck_ignore = [
 if get(ENV, "GITHUB_ACTIONS", nothing) == "true"
     # It seems that CTAN blocks GitHub Actions?
     push!(linkcheck_ignore, "https://ctan.org/pkg/minted")
+    # Putty homepage times out from Actions runners (curl exit 28).
+    push!(linkcheck_ignore, "https://www.chiark.greenend.org.uk/~sgtatham/putty/")
     # Codeberg answers 403 to Actions runners.
     push!(linkcheck_ignore, r"^https://codeberg.org")
 end


### PR DESCRIPTION
It times out quite a lot in GH Actions CI. Like, today, for *all* my PRs.

I already wanted to do this in PR #2959 but @mortenpi thought it was intermittent.

Alas, it doesn't seem like it is. Some logs where it failed
- https://github.com/JuliaDocs/Documenter.jl/actions/runs/32716108824/job/97397583216
- https://github.com/JuliaDocs/Documenter.jl/actions/runs/32701256260/job/97353061811?pr=2965 (even after a restart)
- https://github.com/JuliaDocs/Documenter.jl/actions/runs/32700700870/job/97351426837
- ... I could add half a dozen more

And here it failed on `master` on August 14 (ironically this includes the merge commit for my PR #2959):
- https://github.com/JuliaDocs/Documenter.jl/actions/runs/31787900079/job/94727867452
- https://github.com/JuliaDocs/Documenter.jl/actions/runs/31818091529/job/94824489717


