### PR TITLE
Add a maintained TeX Live container image

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -98,15 +98,7 @@ jobs:
         if: matrix.os == 'windows-latest'
       - uses: zauguin/install-texlive@v4
         with:
-          packages: |
-            scheme-medium
-            hyperref
-            minted
-            newunicodechar
-            transparent
-            upquote
-            tabulary
-            tcolorbox
+          package_file: docker/texlive-packages.txt
       - uses: julia-actions/setup-julia@v3
         with:
           version: '1'

--- a/.github/workflows/DockerImage.yml
+++ b/.github/workflows/DockerImage.yml
@@ -1,0 +1,102 @@
+name: Docker image
+
+# Builds and publishes ghcr.io/juliadocs/documenter-latex, the TeX toolchain used by
+# Documenter.LaTeX(platform = "docker"). Pull requests do not publish; the `latex` job
+# in CI.yml builds the image from source and runs the PDF test suite against it, so a
+# change to docker/ is validated before it lands here.
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'docker/**'
+      - '.github/workflows/DockerImage.yml'
+  schedule:
+    # Weekly, to pick up TeX Live and Debian security updates.
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+
+env:
+  # A moving tag, pinned by DOCKER_IMAGE in src/latex/LaTeXWriter.jl. Bump both
+  # together, and only when the image changes in a way older Documenter releases
+  # cannot cope with.
+  IMAGE: ghcr.io/juliadocs/documenter-latex
+  IMAGE_VERSION: '1'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  # One job per architecture on a native runner: TeX Live's format generation is
+  # slow enough that emulating arm64 through QEMU would take hours.
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: docker
+          platforms: ${{ matrix.platform }}
+          # Untagged: the tags are attached to the merged manifest in the next job.
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache-${{ matrix.arch }},mode=max
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          retention-days: 1
+
+  merge:
+    name: Publish multi-arch manifest
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: digest-*
+          merge-multiple: true
+          path: /tmp/digests
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create manifest list
+        run: |
+          # The date tag is immutable, so a broken rebuild can always be rolled back to.
+          docker buildx imagetools create \
+            --tag "$IMAGE:$IMAGE_VERSION" \
+            --tag "$IMAGE:$IMAGE_VERSION-$(date -u +%Y%m%d)" \
+            --tag "$IMAGE:latest" \
+            $(printf "$IMAGE@sha256:%s " $(ls /tmp/digests))

--- a/.typos.toml
+++ b/.typos.toml
@@ -2,4 +2,5 @@
 fo = "fo"
 ket = "ket"
 trun = "trun"
+unx = "unx"  # install-tl-unx.tar.gz, the TeX Live installer on CTAN
 varius = "varius"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,9 @@ RUN apt-get update && \
 COPY texlive-packages.txt /tmp/texlive-packages.txt
 
 # scheme-infraonly installs only tlmgr itself; the actual package set then comes
-# from texlive-packages.txt, so it stays in sync with the native CI install.
+# from texlive-packages.txt, so it stays in sync with the native CI install. That
+# file must stay a bare list: zauguin/install-texlive passes it to tlmgr verbatim,
+# so a comment in it becomes a package name (see docker/README.md).
 # `tlmgr path add` symlinks the binaries into /usr/local/bin, which keeps the image
 # architecture-independent (no .../bin/x86_64-linux on PATH). It has to run after
 # the packages, since it only links what is installed at the time.
@@ -56,7 +58,7 @@ RUN set -eux; \
     /tmp/install-tl/install-tl \
         --profile=/tmp/texlive.profile \
         --repository="$TEXLIVE_MIRROR"; \
-    tlmgr install $(sed 's/#.*//' /tmp/texlive-packages.txt); \
+    tlmgr install $(cat /tmp/texlive-packages.txt); \
     tlmgr path add; \
     rm -rf /tmp/install-tl /tmp/texlive.profile /tmp/texlive-packages.txt
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,76 @@
+# ghcr.io/juliadocs/documenter-latex
+#
+# A TeX toolchain for Documenter.jl's PDF backend. It deliberately contains no
+# Julia: Documenter runs on the host and only shells out to a container for the
+# .tex -> .pdf step. See docker/README.md.
+FROM debian:trixie-slim
+
+# `image.source` is what links the published package to this repository on GHCR,
+# so the package inherits its permissions and links back to the Dockerfile.
+LABEL org.opencontainers.image.source="https://github.com/JuliaDocs/Documenter.jl"
+LABEL org.opencontainers.image.description="TeX toolchain for Documenter.jl's PDF backend"
+LABEL org.opencontainers.image.licenses="MIT"
+
+# Installed from CTAN rather than from Debian, whose texlive-* packages trail
+# upstream by a year or more.
+ARG TEXLIVE_MIRROR=https://mirror.ctan.org/systems/texlive/tlnet
+ARG JULIAMONO_VERSION=0.63.2
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# fonts-dejavu-core: documenter.sty selects DejaVu Sans / Sans Mono via fontspec.
+# python3-pygments: provides the `pygmentize` that minted shells out to.
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        ca-certificates \
+        fontconfig \
+        fonts-dejavu-core \
+        perl \
+        python3-pygments \
+        wget \
+        xz-utils && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY texlive-packages.txt /tmp/texlive-packages.txt
+
+# scheme-infraonly installs only tlmgr itself; the actual package set then comes
+# from texlive-packages.txt, so it stays in sync with the native CI install.
+# `tlmgr path add` symlinks the binaries into /usr/local/bin, which keeps the image
+# architecture-independent (no .../bin/x86_64-linux on PATH). It has to run after
+# the packages, since it only links what is installed at the time.
+RUN set -eux; \
+    mkdir /tmp/install-tl; \
+    wget -qO- "$TEXLIVE_MIRROR/install-tl-unx.tar.gz" | \
+        tar xz --strip-components=1 -C /tmp/install-tl; \
+    printf '%s\n' \
+        'selected_scheme scheme-infraonly' \
+        'TEXDIR /usr/local/texlive' \
+        'TEXMFLOCAL /usr/local/texlive/texmf-local' \
+        'TEXMFSYSCONFIG /usr/local/texlive/texmf-config' \
+        'TEXMFSYSVAR /usr/local/texlive/texmf-var' \
+        'instopt_adjustpath 1' \
+        'tlpdbopt_install_docfiles 0' \
+        'tlpdbopt_install_srcfiles 0' \
+        'tlpdbopt_sys_bin /usr/local/bin' \
+        > /tmp/texlive.profile; \
+    /tmp/install-tl/install-tl \
+        --profile=/tmp/texlive.profile \
+        --repository="$TEXLIVE_MIRROR"; \
+    tlmgr install $(sed 's/#.*//' /tmp/texlive-packages.txt); \
+    tlmgr path add; \
+    rm -rf /tmp/install-tl /tmp/texlive.profile /tmp/texlive-packages.txt
+
+# Not used by the default template, but available to anyone overriding the
+# monospace font in a custom preamble.
+RUN set -eux; \
+    mkdir -p /usr/local/share/fonts/juliamono; \
+    wget -qO- "https://github.com/cormullion/juliamono/releases/download/v${JULIAMONO_VERSION}/JuliaMono-ttf.tar.gz" | \
+        tar xz -C /usr/local/share/fonts/juliamono; \
+    fc-cache -f
+
+# Documenter copies the build tree to /tmp/build inside the container and copies
+# the PDF back out, so nothing here ever writes into the host's mounted tree.
+# Running as a non-root user keeps that true even for a custom entrypoint.
+RUN useradd --create-home documenter
+USER documenter
+WORKDIR /home/documenter

--- a/docker/README.md
+++ b/docker/README.md
@@ -19,9 +19,19 @@ Documenter version.
 | JuliaMono | not used by default; available to custom preambles |
 | Pygments (`pygmentize`) | the `minted` backend for source highlighting |
 
-`texlive-packages.txt` is shared with the `zauguin/install-texlive` step in
-`.github/workflows/CI.yml`, so the containerised and natively installed TeX
-toolchains cannot drift apart.
+[`texlive-packages.txt`](texlive-packages.txt) is shared with the
+`zauguin/install-texlive` step in `.github/workflows/CI.yml`, so the containerised
+and natively installed TeX toolchains cannot drift apart. Keep it a bare list, one
+package per line: that action passes the file to `tlmgr` verbatim, so a `#` comment
+in it becomes a package name and the install silently comes out wrong. Its entries
+are, and why:
+
+| Package | Why |
+| --- | --- |
+| `scheme-medium` | `latexmk`, `lualatex`, `fontspec`, `polyglossia`, `amsmath`, `graphicx`, … |
+| `collection-latexextra` | The predecessor image was built on Debian's `texlive-latex-extra`; dropping it would silently break custom preambles that work today. Also supplies `mwe`, whose `example-image` the cover page test uses. |
+| `hyperref`, `minted`, `newunicodechar`, `tabulary`, `tcolorbox` | Requested explicitly by `assets/latex/documenter.sty` |
+| `transparent`, `upquote` | Pulled in by generated documents rather than by `documenter.sty` |
 
 ## Using it
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,70 @@
+# `ghcr.io/juliadocs/documenter-latex`
+
+A TeX toolchain for Documenter's PDF backend, used by
+
+```julia
+makedocs(format = Documenter.LaTeX(platform = "docker"), ...)
+```
+
+Documenter itself runs on the host; only the `.tex` → `.pdf` step happens in the
+container. The image therefore contains no Julia and is not tied to a Julia or
+Documenter version.
+
+## Contents
+
+| Component | Why |
+| --- | --- |
+| TeX Live, installed from CTAN | `latexmk`, `lualatex`, and the packages in [`texlive-packages.txt`](texlive-packages.txt) |
+| DejaVu Sans / Sans Mono | selected by `assets/latex/documenter.sty` via `fontspec` |
+| JuliaMono | not used by default; available to custom preambles |
+| Pygments (`pygmentize`) | the `minted` backend for source highlighting |
+
+`texlive-packages.txt` is shared with the `zauguin/install-texlive` step in
+`.github/workflows/CI.yml`, so the containerised and natively installed TeX
+toolchains cannot drift apart.
+
+## Using it
+
+Documenter runs `docker`, which must be in `PATH`; the image is pulled on first use.
+On GitHub Actions no setup step is required, since `ubuntu-*` runners ship with
+Docker.
+
+To point Documenter at a different image, for instance one adding a LaTeX package
+your custom preamble needs:
+
+```julia
+makedocs(format = Documenter.LaTeX(platform = "docker", image = "myorg/my-latex:1"), ...)
+```
+
+A custom image must provide `bash`, `latexmk`, `lualatex`, the packages listed in
+`texlive-packages.txt`, and a writable `/tmp`. Documenter mounts the build tree at
+`/mnt`, copies it to `/tmp/build` inside the container, and copies the PDF back out,
+so it never writes into the mounted directory.
+
+The mounted directory is `mktempdir()`, so a Docker installation that only shares
+selected host paths has to be configured to share the system temporary directory.
+An unshared path is bind-mounted as an empty directory rather than refused, which is
+what the `was mounted empty` error reports.
+
+## Maintaining it
+
+`.github/workflows/DockerImage.yml` publishes `linux/amd64` and `linux/arm64` on
+every push to `master` that touches `docker/`, and weekly to pick up TeX Live and
+Debian security updates. Pull requests do not publish.
+
+Tags:
+
+* `:1` — the moving tag pinned by `DOCKER_IMAGE` in `src/latex/LaTeXWriter.jl`.
+  Bump both together, and only for a change older Documenter releases cannot cope
+  with.
+* `:1-YYYYMMDD` — immutable, so a broken rebuild can be rolled back to.
+* `:latest`.
+
+To build it locally:
+
+```bash
+docker build -t documenter-latex:test docker/
+```
+
+The predecessor, `juliadocs/documenter-latex:0.1` on Docker Hub, is unmaintained;
+its Dockerfile lives in the archived `JuliaDocs/DocumenterLaTeX.jl` repository.

--- a/docker/texlive-packages.txt
+++ b/docker/texlive-packages.txt
@@ -1,27 +1,9 @@
-# TeX Live packages required by Documenter's PDF backend.
-#
-# Consumed by two places, which is the point of keeping it in one file:
-#   * docker/Dockerfile         -> tlmgr install
-#   * .github/workflows/CI.yml  -> zauguin/install-texlive (package_file)
-#
-# Both accept a whitespace-separated list with `#` comments. Dependencies are
-# resolved by tlmgr, so only direct requirements belong here.
-
-scheme-medium     # latexmk, lualatex, fontspec, polyglossia, amsmath, graphicx, ...
-
-# Explicitly requested by assets/latex/documenter.sty:
+scheme-medium
+collection-latexextra
 hyperref
-minted            # source highlighting; shells out to pygmentize
+minted
 newunicodechar
 tabulary
 tcolorbox
-
-# Pulled in by generated documents rather than by documenter.sty:
 transparent
 upquote
-
-# Not needed by Documenter's own output, but the predecessor image was built on
-# Debian's texlive-latex-extra, so dropping it would silently break custom
-# preambles that have always worked. Also supplies `mwe`, whose example-image is
-# used by the cover page test.
-collection-latexextra

--- a/docker/texlive-packages.txt
+++ b/docker/texlive-packages.txt
@@ -1,0 +1,27 @@
+# TeX Live packages required by Documenter's PDF backend.
+#
+# Consumed by two places, which is the point of keeping it in one file:
+#   * docker/Dockerfile         -> tlmgr install
+#   * .github/workflows/CI.yml  -> zauguin/install-texlive (package_file)
+#
+# Both accept a whitespace-separated list with `#` comments. Dependencies are
+# resolved by tlmgr, so only direct requirements belong here.
+
+scheme-medium     # latexmk, lualatex, fontspec, polyglossia, amsmath, graphicx, ...
+
+# Explicitly requested by assets/latex/documenter.sty:
+hyperref
+minted            # source highlighting; shells out to pygmentize
+newunicodechar
+tabulary
+tcolorbox
+
+# Pulled in by generated documents rather than by documenter.sty:
+transparent
+upquote
+
+# Not needed by Documenter's own output, but the predecessor image was built on
+# Debian's texlive-latex-extra, so dropping it would silently break custom
+# preambles that have always worked. Also supplies `mwe`, whose example-image is
+# used by the cover page test.
+collection-latexextra


### PR DESCRIPTION
The image behind `Documenter.LaTeX(platform = "docker")` is built from an [archived repository](https://github.com/JuliaDocs/DocumenterLaTeX.jl/blob/master/docker/Dockerfile) on Ubuntu 18.04 and was last updated seven years ago. It never installed the DejaVu fonts that documenter.sty selects, so the PDF silently falls back to substitutes.

Add a replacement built from `docker/` in this repository and published to ghcr.io/juliadocs/documenter-latex. Keeping it here lets the TeX package list be a single file shared with the native `install-texlive` step in CI, and lets a Dockerfile change be validated by Documenter's own PDF test suite before it is published rather than after.

TeX Live is installed from CTAN rather than from Debian, whose texlive-* packages trail upstream by a year or more. collection-latexextra is included because the predecessor was built on Debian's texlive-latex-extra, and dropping it would silently break custom preambles that work today.

Nothing points at the new image yet, so that it can be published and made public before Documenter starts pulling it.

Resolves #2073.
Closes #2092.

## Action required from a JuliaDocs org admin

The first run of `DockerImage.yml` creates `ghcr.io/juliadocs/documenter-latex` as a **private** org-level package. Someone with admin rights (so not me) must then set it to public (Package settings → Danger Zone → Change package visibility). This is a one-time step; later pushes keep the setting. It is not optional: nothing pulling this image authenticates to GHCR — not the `docs` PDF job here, and not any user running `platform = "docker"` — so while the package is private, every PDF build fails to pull it. If the org restricts package creation or public visibility under Settings → Packages, that needs relaxing first.

**Please do not merge #2971 until this package is published and public**, or its
`Documentation: pdf` job will fail.

Prepared with AI assistance (Claude Opus 5).
