### PR TITLE
Use the new LaTeX container image

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -79,6 +79,10 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Both parents of the pull request's merge commit, so the step below can
+          # diff this change against its base.
+          fetch-depth: 2
       - name: "Download and install DejaVu fonts"
         run: |
           Invoke-WebRequest "https://github.com/dejavu-fonts/dejavu-fonts/releases/download/version_2_37/dejavu-fonts-ttf-2.37.zip" -OutFile "DejaVu.zip"
@@ -99,6 +103,30 @@ jobs:
       - uses: zauguin/install-texlive@v4
         with:
           package_file: docker/texlive-packages.txt
+      # A change to docker/ is tested against the image built from it, before
+      # DockerImage.yml publishes that image. Every other change uses the published
+      # one, so unrelated pull requests only pay a pull. Windows runners have no
+      # Docker and skip these examples (see test/examples/tests_latex.jl).
+      - name: Check whether this change touches docker/
+        id: image
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          if git diff --name-only HEAD^1 HEAD | grep -q '^docker/'; then
+            echo "rebuild=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "rebuild=false" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: docker/setup-buildx-action@v3
+        if: steps.image.outputs.rebuild == 'true'
+      - name: Build the LaTeX container image
+        if: steps.image.outputs.rebuild == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: docker
+          load: true
+          tags: documenter-latex:ci
+          # Populated by DockerImage.yml; a cache miss only costs build time.
+          cache-from: type=registry,ref=ghcr.io/juliadocs/documenter-latex:buildcache-amd64
       - uses: julia-actions/setup-julia@v3
         with:
           version: '1'
@@ -110,6 +138,8 @@ jobs:
           Pkg.instantiate()
       - name: Run test/examples/tests_latex.jl
         run: julia --color=yes --project=test/examples --code-coverage test/examples/tests_latex.jl
+        env:
+          DOCUMENTER_LATEX_DOCKER_IMAGE: ${{ steps.image.outputs.rebuild == 'true' && 'documenter-latex:ci' || '' }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Support self-hosted GitHub instances. ([#2755])
+* Added an `image` keyword to `Documenter.LaTeX` to select the container image used by `platform = "docker"`, overridable via the `DOCUMENTER_LATEX_DOCKER_IMAGE` environment variable. ([#2888])
 
 ### Changed
 
 * Change type of `HTML.assets` field to `Vector{HTMLHeadContent}` to allow configuring dynamically in plugins. ([#2925])
+* `Documenter.LaTeX(platform = "docker")` now uses `ghcr.io/juliadocs/documenter-latex`, which is built from `docker/` in this repository and rebuilt weekly, instead of the unmaintained `juliadocs/documenter-latex:0.1` image on Docker Hub. ([#2888])
 
 ### Fixed
 
@@ -2220,6 +2222,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2674]: https://github.com/JuliaDocs/Documenter.jl/issues/2674
 [#2675]: https://github.com/JuliaDocs/Documenter.jl/issues/2675
 [#2676]: https://github.com/JuliaDocs/Documenter.jl/issues/2676
+[#2678]: https://github.com/JuliaDocs/Documenter.jl/issues/2678
 [#2679]: https://github.com/JuliaDocs/Documenter.jl/issues/2679
 [#2682]: https://github.com/JuliaDocs/Documenter.jl/issues/2682
 [#2683]: https://github.com/JuliaDocs/Documenter.jl/issues/2683
@@ -2277,8 +2280,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2874]: https://github.com/JuliaDocs/Documenter.jl/issues/2874
 [#2875]: https://github.com/JuliaDocs/Documenter.jl/issues/2875
 [#2880]: https://github.com/JuliaDocs/Documenter.jl/issues/2880
+[#2888]: https://github.com/JuliaDocs/Documenter.jl/issues/2888
 [#2889]: https://github.com/JuliaDocs/Documenter.jl/issues/2889
 [#2905]: https://github.com/JuliaDocs/Documenter.jl/issues/2905
+[#2925]: https://github.com/JuliaDocs/Documenter.jl/issues/2925
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/docker/README.md
+++ b/docker/README.md
@@ -60,7 +60,8 @@ what the `was mounted empty` error reports.
 
 `.github/workflows/DockerImage.yml` publishes `linux/amd64` and `linux/arm64` on
 every push to `master` that touches `docker/`, and weekly to pick up TeX Live and
-Debian security updates. Pull requests do not publish.
+Debian security updates. Pull requests do not publish: the `latex` job in `CI.yml`
+builds the image from source and runs the PDF test suite against it instead.
 
 Tags:
 
@@ -70,10 +71,12 @@ Tags:
 * `:1-YYYYMMDD` — immutable, so a broken rebuild can be rolled back to.
 * `:latest`.
 
-To build it locally:
+To build and test locally:
 
 ```bash
 docker build -t documenter-latex:test docker/
+DOCUMENTER_LATEX_DOCKER_IMAGE=documenter-latex:test \
+  julia --project=test/examples test/examples/tests_latex.jl
 ```
 
 The predecessor, `juliadocs/documenter-latex:0.1` on Docker Hub, is unmaintained;

--- a/docs/src/man/other-formats.md
+++ b/docs/src/man/other-formats.md
@@ -57,13 +57,10 @@ makedocs(
     ...)
 ```
 
-### Compiling using docker image
+### Compiling in a container
 
-It is also possible to use a prebuilt [docker image](https://hub.docker.com/r/juliadocs/documenter-latex/)
-to compile the `.tex` file. The image contains all of the required installs described in the section
-above. The only requirement for using the image is that `docker` is installed and available for
-the builder to call. You also need to tell Documenter to use the docker image, instead of natively
-installed tex which is the default. This is done with the `LaTeX` specifier:
+Instead of installing a TeX toolchain, the `.tex` file can be compiled in a prebuilt
+container image that already contains everything listed above:
 
 ```julia
 using Documenter
@@ -73,14 +70,21 @@ makedocs(
 )
 ```
 
-If you build the documentation on Travis you need to add
+The only requirement is that `docker` is installed and available in `PATH`; the image
+itself is pulled on first use. GitHub Actions `ubuntu-*` runners ship with Docker, so
+no extra workflow step is needed.
 
-```yaml
-services:
-  - docker
+The default image is [`ghcr.io/juliadocs/documenter-latex`](https://github.com/JuliaDocs/Documenter.jl/tree/master/docker),
+which is maintained alongside Documenter. A different one can be selected with the
+`image` keyword, for instance to add a LaTeX package that a custom preamble needs:
+
+```julia
+using Documenter
+makedocs(
+    format = Documenter.LaTeX(platform = "docker", image = "myorg/my-latex:1"),
+    ...
+)
 ```
-
-to your `.travis.yml` file.
 
 ### Compiling to LaTeX only
 

--- a/src/latex/LaTeXWriter.jl
+++ b/src/latex/LaTeXWriter.jl
@@ -16,6 +16,20 @@ module LaTeXWriter
 import ...Documenter: Documenter
 using MarkdownAST: MarkdownAST, Node
 
+const DOCKER_IMAGE = "ghcr.io/juliadocs/documenter-latex:1"
+
+# Lets CI point the docker platform at an image built from docker/Dockerfile in
+# the same run, before it has been published. Empty counts as unset, so a workflow
+# can pass the variable through unconditionally.
+function default_docker_image()
+    image = get(ENV, "DOCUMENTER_LATEX_DOCKER_IMAGE", "")
+    return isempty(image) ? DOCKER_IMAGE : image
+end
+
+# Where the build tree is copied to inside the container. Fixed so that the PDF
+# can be copied back out without knowing the image's user or home directory.
+const CONTAINER_BUILD_DIR = "/tmp/build"
+
 """
     Documenter.LaTeX(; kwargs...)
 
@@ -46,6 +60,12 @@ considered to be deprecated), or to an empty string if `TRAVIS_TAG` is unset.
 
 **`tectonic`** path to a `tectonic` executable used for compilation.
 
+**`image`** the container image used when `platform = "docker"`. Defaults to
+`$(DOCKER_IMAGE)`, or to the value of the `DOCUMENTER_LATEX_DOCKER_IMAGE` environment
+variable if that is set. A custom image must provide `latexmk`, `lualatex`, `bash`, the LaTeX
+packages listed under "Compiling using natively installed latex" in the manual, and a
+writable `/tmp`.
+
 **`show_log`** if `true`, dump the generated LaTeX log files to stdout when PDF compilation
 fails. This can be useful in CI where temporary build directories are not preserved. If
 the environment variable `DOCUMENTER_LATEX_SHOW_LOGS` is set, log dumping is always enabled.
@@ -57,15 +77,17 @@ struct LaTeX <: Documenter.Writer
     version::String
     tectonic::Union{Cmd, String, Nothing}
     show_log::Bool
+    image::String
     function LaTeX(;
             platform = "native",
             version = get(ENV, "TRAVIS_TAG", ""),
             tectonic = nothing,
             show_log = false,
+            image = default_docker_image(),
         )
         platform ∈ ("native", "tectonic", "docker", "none") || throw(ArgumentError("unknown platform: $platform"))
         show_log = show_log || haskey(ENV, "DOCUMENTER_LATEX_SHOW_LOGS")
-        return new(platform, string(version), tectonic, show_log)
+        return new(platform, string(version), tectonic, show_log, image)
     end
 end
 
@@ -190,8 +212,6 @@ function latex_fileprefix(doc::Documenter.Document, settings::LaTeX)
     return replace(fileprefix, " " => "")
 end
 
-const DOCKER_IMAGE_TAG = "0.1"
-
 function compile_tex(doc::Documenter.Document, settings::LaTeX, fileprefix::String)
     if settings.platform == "native"
         Sys.which("latexmk") === nothing && (@error "LaTeXWriter: latexmk command not found."; return false)
@@ -222,17 +242,26 @@ function compile_tex(doc::Documenter.Document, settings::LaTeX, fileprefix::Stri
         end
     elseif settings.platform == "docker"
         Sys.which("docker") === nothing && (@error "LaTeXWriter: docker command not found."; return false)
-        @info "LaTeXWriter: using docker to compile tex."
+        image = settings.image
+        @info "LaTeXWriter: using docker to compile tex." image
+        # The `test -f` turns a silently empty bind mount -- the usual symptom of a
+        # Docker installation that has not been given access to the host's temporary
+        # directory -- into a pointed error instead of a confusing LaTeX failure.
         script = """
-        mkdir /home/zeptodoctor/build
-        cd /home/zeptodoctor/build
+        set -e
+        mkdir -p $(CONTAINER_BUILD_DIR)
+        cd $(CONTAINER_BUILD_DIR)
         cp -r /mnt/. .
+        test -f $(fileprefix).tex || {
+            echo "$(pwd()) was mounted empty; check that Docker can access it."
+            exit 1
+        }
         latexmk -f -interaction=batchmode -halt-on-error -view=none -lualatex -shell-escape $(fileprefix).tex
         """
         try
-            piperun(`docker run -itd -u zeptodoctor --name latex-container -v $(pwd()):/mnt/ --rm juliadocs/documenter-latex:$(DOCKER_IMAGE_TAG)`, clearlogs = true)
-            piperun(`docker exec -u zeptodoctor latex-container bash -c $(script)`)
-            piperun(`docker cp latex-container:/home/zeptodoctor/build/$(fileprefix).pdf .`)
+            piperun(`docker run -itd --name latex-container -v $(pwd()):/mnt/ --rm $(image)`, clearlogs = true)
+            piperun(`docker exec latex-container bash -c $(script)`)
+            piperun(`docker cp latex-container:$(CONTAINER_BUILD_DIR)/$(fileprefix).pdf .`)
             return true
         catch err
             settings.show_log && dump_latex_log(fileprefix)

--- a/test/latexwriter.jl
+++ b/test/latexwriter.jl
@@ -179,5 +179,21 @@ end
     end
 end
 
+@testset "container image" begin
+    @test Documenter.LaTeX(platform = "docker").image == LaTeXWriter.DOCKER_IMAGE
+    @test Documenter.LaTeX(platform = "docker", image = "foo:1").image == "foo:1"
+
+    withenv("DOCUMENTER_LATEX_DOCKER_IMAGE" => "bar:2") do
+        @test Documenter.LaTeX(platform = "docker").image == "bar:2"
+        # An explicit keyword still wins over the environment.
+        @test Documenter.LaTeX(platform = "docker", image = "foo:1").image == "foo:1"
+    end
+
+    # Empty counts as unset, so CI can pass the variable through unconditionally.
+    withenv("DOCUMENTER_LATEX_DOCKER_IMAGE" => "") do
+        @test Documenter.LaTeX(platform = "docker").image == LaTeXWriter.DOCKER_IMAGE
+    end
+end
+
 
 end


### PR DESCRIPTION
Stacked on #2970, which adds the image. **Do not merge until`ghcr.io/juliadocs/documenter-latex` is published and public.**

Points `platform = "docker"` at `ghcr.io/juliadocs/documenter-latex` instead of the unmaintained `juliadocs/documenter-latex:0.1` on Docker Hub.

Adds an `image` keyword so a custom image can be selected, plus a `DOCUMENTER_LATEX_DOCKER_IMAGE` environment variable, which is how CI tests an image that is not in the registry yet. The container's build directory moves from a hardcoded `/home/zeptodoctor` to `/tmp/build`, so a custom image need not reproduce that user.

The `latex` CI job now rebuilds the image from `docker/` whenever a change touches it and runs the PDF examples against the result. Thus a Dockerfile change is covered *before* `DockerImage.yml` publishes it. Unrelated pull requests pull the published image instead.

Resolves #979.
Resolves #2888.

Prepared with AI assistance (Claude Opus 5).