### PR TITLE
Report regression test failures on master as an issue

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -10,12 +10,34 @@ on:
       - '*/*-runci'
     tags: '*'
   pull_request:
-    paths:
-      - '.github/workflows/regression-tests.yml'
-      - 'Project.toml'
+    # 'labeled' so that adding the opt-in label to an open PR starts a new run
+    types: [opened, synchronize, reopened, labeled]
 jobs:
+  # The path filter that used to live on the `pull_request` trigger lives here
+  # instead: a trigger-level filter would keep the workflow from starting at
+  # all, leaving no place to check for the opt-in label.
+  gate:
+    name: 'Gate'
+    runs-on: ubuntu-latest
+    outputs:
+      run-tests: ${{ steps.decide.outputs.run-tests }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            ci:
+              - '.github/workflows/regression-tests.yml'
+              - 'Project.toml'
+      - id: decide
+        run: |
+          echo "run-tests=${{ github.event_name != 'pull_request' || steps.filter.outputs.ci == 'true' || contains(github.event.pull_request.labels.*.name, 'Run Regression Tests') }}" >> "$GITHUB_OUTPUT"
+
   test-dependent-packages:
     name: Tests / ${{ matrix.package }}
+    needs: gate
+    if: needs.gate.outputs.run-tests == 'true'
     runs-on: ubuntu-latest
     env:
       PACKAGE: ${{ matrix.package }}
@@ -46,6 +68,8 @@ jobs:
 
   test-documentation-build:
     name: "Docs / ${{ matrix.package }}"
+    needs: gate
+    if: needs.gate.outputs.run-tests == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -84,6 +108,8 @@ jobs:
 
   test-julia-manual-build:
     name: "Julia Manual"
+    needs: gate
+    if: needs.gate.outputs.run-tests == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -1,6 +1,9 @@
 name: 'Regression Tests'
 on:
   workflow_dispatch:
+  schedule:
+    # Once a week on Monday morning; scheduled runs always use `master`
+    - cron: '17 5 * * 1'
   push:
     branches:
       - master
@@ -136,3 +139,87 @@ jobs:
         with:
           name: "regression-tests-julia-manual"
           path: julia/doc/_build/html
+
+  # Report the outcome of a run on `master` (scheduled, merged or dispatched) by
+  # opening an issue, and close that issue once the tests pass again. Runs on
+  # pull requests are ignored: they must neither open nor close an issue.
+  report-status:
+    name: 'Report status'
+    needs: [gate, test-dependent-packages, test-documentation-build, test-julia-manual-build]
+    if: always() && github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v9
+        env:
+          FAILED: ${{ contains(needs.*.result, 'failure') }}
+        with:
+          script: |
+            const label = "Status: Regression Tests Failing";
+            const title = "Regression tests are failing on master";
+            const failed = process.env.FAILED === "true";
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}` +
+                           `/actions/runs/${context.runId}`;
+            const { owner, repo } = context.repo;
+
+            // A single label identifies the report issue, so that repeated
+            // failures update the existing issue instead of opening new ones.
+            const { data: open } = await github.rest.issues.listForRepo({
+              owner, repo, state: "open", labels: label
+            });
+            const issue = open[0];
+
+            if (!failed) {
+              if (!issue) {
+                console.log("Tests passed and no issue is open — nothing to do.");
+                return;
+              }
+
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issue.number,
+                body: `The regression tests [passed again](${runUrl}) on \`master\`. Closing.`
+              });
+              await github.rest.issues.update({
+                owner, repo, issue_number: issue.number, state: "closed"
+              });
+              console.log(`Closed #${issue.number}.`);
+              return;
+            }
+
+            if (issue) {
+              // A reminder on every failing merge would be noise, so only the
+              // weekly scheduled run nags about a failure that is still open.
+              if (context.eventName !== "schedule") {
+                console.log(`Failure already reported in #${issue.number}.`);
+                return;
+              }
+
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issue.number,
+                body: `Still [failing](${runUrl}) on \`master\` (${context.sha}).`
+              });
+              console.log(`Commented on existing #${issue.number}.`);
+              return;
+            }
+
+            // The label has to exist before it can be applied
+            try {
+              await github.rest.issues.createLabel({
+                owner, repo, name: label, color: "b60205",
+                description: "Automatically filed report of a regression test failure on master"
+              });
+            } catch (error) {
+              if (error.status !== 422) throw error; // 422 == label already exists
+            }
+
+            const { data: created } = await github.rest.issues.create({
+              owner, repo, title, labels: [label],
+              body: [
+                `The [regression tests](${runUrl}) failed on \`master\` (${context.sha}).`,
+                "",
+                "This issue was opened automatically and will be closed again as",
+                "soon as the regression tests pass on `master`.",
+              ].join("\n")
+            });
+            console.log(`Opened #${created.number}.`);


### PR DESCRIPTION
Follows #2967.

Two gaps today: regression tests only run when something is merged, and a
failure is only visible to whoever thinks to look at the workflow's run
history. Breakage in a downstream package can sit unnoticed for a long time,
and breakage introduced by a downstream package itself is never caught at all,
since nothing on our side triggers a run.

This adds:

- **A weekly scheduled run** (Mondays, 05:17 UTC). Scheduled runs always use
  `master`.
- **A `report-status` job** that opens an issue when the regression tests fail
  on `master`. The issue carries the label
  `Status: Regression Tests Failing`, which is how a later run finds it: a
  repeated failure updates the existing issue instead of opening a second one,
  and a passing run comments and closes it. The label is created on demand, so
  there is no repo setup step.

A failure that is still open gets a reminder comment only from the weekly
scheduled run — so a long-standing breakage nags once a week, rather than once
per merge.

All of this is restricted to `master` (`github.event_name != 'pull_request' &&
github.ref == 'refs/heads/master'`), so a pull request neither opens an issue
nor closes one that is already open.
