### PR TITLE
Fail `@contents`/`@index` blocks that do not parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+* An `@contents` or `@index` block whose body fails to parse is now left unexpanded instead of falling back to the defaults, which silently listed the whole document. ([#1140])
+
 ## Version [v1.19.0] - 2026-09-01
 
 ### Added
@@ -1794,6 +1800,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1119]: https://github.com/JuliaDocs/Documenter.jl/issues/1119
 [#1121]: https://github.com/JuliaDocs/Documenter.jl/issues/1121
 [#1137]: https://github.com/JuliaDocs/Documenter.jl/issues/1137
+[#1140]: https://github.com/JuliaDocs/Documenter.jl/issues/1140
 [#1144]: https://github.com/JuliaDocs/Documenter.jl/issues/1144
 [#1147]: https://github.com/JuliaDocs/Documenter.jl/issues/1147
 [#1148]: https://github.com/JuliaDocs/Documenter.jl/issues/1148

--- a/src/documents.jl
+++ b/src/documents.jl
@@ -1090,10 +1090,15 @@ function doctest_replace!(block::MarkdownAST.CodeBlock)
 end
 doctest_replace!(@nospecialize _) = nothing
 
+# Builds a ContentsNode or IndexNode from the settings assigned in `block`. Returns
+# `nothing` if the block does not parse -- a broken block must not silently fall back to
+# the defaults, which would list the whole document (issue #1140).
 function buildnode(T::Type, block, doc, page)
     mod = get(page.globals.meta, :CurrentModule, Main)
     dict = Dict{Symbol, Any}(:source => page.source, :build => page.build)
-    for (ex, str) in parseblock(block.code, doc, page)
+    exprs = parseblock(block.code, doc, page; parse_error_result = nothing)
+    exprs === nothing && return nothing
+    for (ex, str) in exprs
         if isassign(ex)
             cd(dirname(page.source)) do
                 dict[ex.args[1]] = Core.eval(mod, ex.args[2])

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -825,6 +825,8 @@ function Selectors.runner(::Type{Expanders.IndexBlocks}, node, page, doc)
     x = node.element
 
     indexnode = Documenter.buildnode(Documenter.IndexNode, x, doc, page)
+    # Leave a block that failed to parse unexpanded, as the code block it already is.
+    indexnode === nothing && return
     push!(doc.internal.indexnodes, indexnode)
     node.element = indexnode
     return
@@ -838,6 +840,8 @@ function Selectors.runner(::Type{Expanders.ContentsBlocks}, node, page, doc)
     x = node.element
 
     contentsnode = Documenter.buildnode(Documenter.ContentsNode, x, doc, page)
+    # Leave a block that failed to parse unexpanded, as the code block it already is.
+    contentsnode === nothing && return
     push!(doc.internal.contentsnodes, contentsnode)
     node.element = contentsnode
     return

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -206,6 +206,10 @@ If `raise=false` is passed, the `Meta.parse` does not raise an exception on pars
 but instead returns an expression that will raise an error when evaluated. `parseblock`
 returns this expression normally and it must be handled appropriately by the caller.
 
+On a parse error, `parseblock` reports the error and returns `parse_error_result`, which
+defaults to an empty vector. Callers that must distinguish a broken block from an empty one
+can pass e.g. `parse_error_result = nothing`.
+
 The `linenumbernode` can be passed as a `LineNumberNode` to give information about filename
 and starting line number of the block (requires Julia 1.6 or higher).
 
@@ -218,7 +222,8 @@ If not specified, the default parser is used. When both `syntax_version` and `mo
 """
 function parseblock(
         code::AbstractString, doc, file; skip = 0, keywords = true, raise = true,
-        linenumbernode = nothing, lines = nothing, syntax_version = nothing, mod = nothing
+        linenumbernode = nothing, lines = nothing, syntax_version = nothing, mod = nothing,
+        parse_error_result = []
     )
     # Drop `skip` leading lines from the code block. Needed for deprecated `{docs}` syntax.
     code = string(code, '\n')
@@ -252,7 +257,7 @@ function parseblock(
                 end
             catch err
                 @docerror(doc, :parse_error, "failed to parse code block in $(locrepr(file, lines))", exception = err)
-                return []
+                return parse_error_result
             end
         end
         str = SubString(code, cursor, prevind(code, ncursor))

--- a/test/pipeline.jl
+++ b/test/pipeline.jl
@@ -84,4 +84,49 @@ module HighlightSig
     end
 end
 
+# A `@contents`/`@index` block whose body does not parse must not fall back to the
+# default (whole-document) listing -- see issue #1140.
+@testset "Unparseable @contents/@index blocks" begin
+    import Documenter
+    import IOCapture
+
+    # `Pages` is missing a comma, so the whole assignment fails to parse.
+    broken_pages = """
+    Pages = [
+        "index.md"
+        "other.md",
+    ]
+    """
+
+    function build_doc(index_md; kwargs...)
+        tmp = mktempdir()
+        mkpath(joinpath(tmp, "src"))
+        write(joinpath(tmp, "src", "index.md"), index_md)
+        write(joinpath(tmp, "src", "other.md"), "# Other\n\n## Other section\n")
+        IOCapture.capture() do
+            Documenter.makedocs(;
+                root = tmp, sitename = "T", pages = ["index.md", "other.md"],
+                format = Documenter.HTML(edit_link = nothing, disable_git = true),
+                remotes = nothing, kwargs...,
+            )
+        end
+        return read(joinpath(tmp, "build", "index.html"), String)
+    end
+
+    for blocktype in ("@contents", "@index")
+        md = "# Top\n\n```$blocktype\n$broken_pages```\n\n## Section\n"
+        # The parse error is fatal unless it is explicitly downgraded to a warning.
+        @test_throws Exception build_doc(md)
+        # With `warnonly`, the block is left unexpanded rather than silently listing
+        # everything in the document.
+        html = build_doc(md; warnonly = true)
+        @test occursin("<pre><code", html)
+        @test !occursin("href=\"other/#Other-section\"", html)
+    end
+
+    # A well-formed block still expands.
+    html = build_doc("# Top\n\n```@contents\n```\n\n## Section\n")
+    @test occursin("href=\"#Section\"", html)
+end
+
 end

--- a/test/pipeline.jl
+++ b/test/pipeline.jl
@@ -86,7 +86,7 @@ end
 
 # A `@contents`/`@index` block whose body does not parse must not fall back to the
 # default (whole-document) listing -- see issue #1140.
-@testset "Unparseable @contents/@index blocks" begin
+@testset "Unparsable @contents/@index blocks" begin
     import Documenter
     import IOCapture
 


### PR DESCRIPTION
A syntax error in the block body was reported, but the block was still expanded using the default settings. For `@contents` that meant a table of contents listing the whole document, silently unrelated to what the `Pages` assignment was meant to select.

`parseblock` gains a `parse_error_result` keyword so callers can tell a broken block from an empty one; `buildnode` uses it to return `nothing`, and the two runners then leave the block as the code block it already is.

Fixes #1140

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>