### PR TITLE
Reorganize the hosting page around GitHub Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `doctest` now accepts a `meta` keyword, like `makedocs` does, so that a global `DocTestSetup` can be set for the doctests on manual pages when they are run through `doctest`. ([#2512], [#2697])
 
-### Changed
-
-* The "Hosting Documentation" manual page is now organized around GitHub Actions: the shared setup and versioning sections follow it directly, while Travis CI, Woodpecker CI and the custom deployment interface have moved into a new "Other CI systems" section at the end. The page also gained a table of contents. ([#2131])
 
 ## Version [v1.18.0] - 2026-08-28
 
@@ -2094,7 +2091,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2114]: https://github.com/JuliaDocs/Documenter.jl/issues/2114
 [#2128]: https://github.com/JuliaDocs/Documenter.jl/issues/2128
 [#2130]: https://github.com/JuliaDocs/Documenter.jl/issues/2130
-[#2131]: https://github.com/JuliaDocs/Documenter.jl/issues/2131
 [#2134]: https://github.com/JuliaDocs/Documenter.jl/issues/2134
 [#2141]: https://github.com/JuliaDocs/Documenter.jl/issues/2141
 [#2142]: https://github.com/JuliaDocs/Documenter.jl/issues/2142

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `doctest` now accepts a `meta` keyword, like `makedocs` does, so that a global `DocTestSetup` can be set for the doctests on manual pages when they are run through `doctest`. ([#2512], [#2697])
 
+### Changed
+
+* The "Hosting Documentation" manual page is now organized around GitHub Actions: the shared setup and versioning sections follow it directly, while Travis CI, Woodpecker CI and the custom deployment interface have moved into a new "Other CI systems" section at the end. The page also gained a table of contents. ([#2131])
 
 ## Version [v1.18.0] - 2026-08-28
 
@@ -2091,6 +2094,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2114]: https://github.com/JuliaDocs/Documenter.jl/issues/2114
 [#2128]: https://github.com/JuliaDocs/Documenter.jl/issues/2128
 [#2130]: https://github.com/JuliaDocs/Documenter.jl/issues/2130
+[#2131]: https://github.com/JuliaDocs/Documenter.jl/issues/2131
 [#2134]: https://github.com/JuliaDocs/Documenter.jl/issues/2134
 [#2141]: https://github.com/JuliaDocs/Documenter.jl/issues/2141
 [#2142]: https://github.com/JuliaDocs/Documenter.jl/issues/2142

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -296,81 +296,6 @@ are uploaded to Codecov:
       - uses: codecov/codecov-action@v7
 ```
 
-## Travis CI
-
-To tell Travis that we want a new build stage, we can add the following to an existing `.travis.yml`
-file. Note that the snippet below will not work by itself and must be accompanied by a complete Travis file.
-
-```yaml
-jobs:
-  include:
-    - stage: "Documentation"
-      julia: 1
-      os: linux
-      script:
-        - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
-                                               Pkg.instantiate()'
-        - julia --project=docs/ docs/make.jl
-      after_success: skip
-```
-
-where the `julia:` and `os:` entries decide the worker from which the docs are built and
-deployed. In the example above we will thus build and deploy the documentation from a linux
-worker running Julia 1 (the latest stable version). For more information on how to set up a build stage, see the Travis
-manual for [Build Stages](https://docs.travis-ci.com/user/build-stages).
-
-The three lines in the `script:` section do the following:
-
- 1. Instantiate the doc-building environment (i.e. `docs/Project.toml`, see below).
- 2. Install your package in the doc-build environment.
- 3. Run the docs/make.jl script, which builds and deploys the documentation.
-
-!!! note
-    If your package has a build script you should call
-    `Pkg.build("PackageName")` after the call to `Pkg.develop` to make
-    sure the package is built properly.
-
-!!! note "matrix: section in .travis.yml"
-
-    Travis CI used to use `matrix:` as the section to configure the build matrix in the config
-    file. This now appears to be a deprecated alias for `jobs:`. If you use both `matrix:` and
-    `jobs:` in your configuration, `matrix:` overrides the settings under `jobs:`.
-
-    If your `.travis.yml` file still uses `matrix:`, it should be replaced with a single
-    `jobs:` section.
-
-### [Authentication: SSH Deploy Keys (Travis CI)](@id travis-ssh)
-
-Travis CI also authenticates with an SSH deploy key. Generate the key pair with
-`DocumenterTools.genkeys` as described in the
-[SSH deploy key section](@ref ssh-deploy-keys) above. Only the private key is added
-elsewhere:
-
- 1. Add the public ssh key as a deploy key with write access on the
-    `https://github.com/USER/REPO/settings/keys` page of the GitHub repository.
-
- 2. Next add the long private key to the Travis settings page at
-    `https://app.travis-ci.com/USER/REPO/settings`.
-    Again note that you should include **no whitespace** when copying the key. In the **`Environment
-    Variables`** section add a key with the name `DOCUMENTER_KEY` and the value that was printed
-    out. **Do not** set the variable to be displayed in the build log. Then click **`Add`**.
-
-    !!! warning "Security warning"
-
-        To reiterate: make sure that this key is hidden. In particular, in the Travis CI settings
-        the "Display value in build log" option should be **OFF** for
-        the variable, so that it does not get printed when the tests run. This
-        base64-encoded string contains the *unencrypted* private key that gives full write
-        access to your repository, so it must be kept safe.  Also, make sure that you never
-        expose this variable in your tests, nor merge any code that does. You can read more
-        about Travis environment variables in [Travis User Documentation](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings).
-
-!!! note
-
-    There are more explicit instructions for adding the keys to Travis in the
-    [SSH Deploy Keys Walkthrough](@ref) section of the manual.
-
-
 ## `docs/Project.toml`
 
 The doc-build environment `docs/Project.toml` includes Documenter and other doc-build
@@ -499,55 +424,6 @@ The `permissions:` line above is described in the
 [GitHub Docs](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token#modifying-the-permissions-for-the-github_token);
 an alternative is to give GitHub workflows write permissions under the repo settings, e.g.,
 `https://github.com/<USER>/<REPO>.jl/settings/actions`.
-
-## Woodpecker CI
-
-To run a documentation build from Woodpecker CI, one should create an access token
-from their forge of choice: GitHub, GitLab, or Codeberg (or any Gitea instance).
-This access token should be added to Woodpecker CI as a secret named
-`project_access_token`. The case does not matter since this will be passed as
-an uppercase environment variable to your pipeline. Next, create a new pipeline
-configuration file called `.woodpecker.yml` with the following contents:
-
-- Woodpecker 0.15.x and pre-1.0.0
-
-  ```yaml
-  pipeline:
-      docs:
-      when:
-          branch: main  # update to match your development branch
-      image: julia
-      commands:
-          - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-          - julia --project=docs/ docs/make.jl
-      secrets: [ project_access_token ]  # access token is a secret
-
-  ```
-
-- Woodpecker 1.0.x and onwards
-
-  ```yaml
-  steps:
-      docs:
-      when:
-          branch: main  # update to match your development branch
-      image: julia
-      commands:
-          - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-          - julia --project=docs/ docs/make.jl
-      secrets: [ project_access_token ]  # access token is a secret
-
-  ```
-
-This will pull an image of julia from docker and run the following commands from
-`commands:` which instantiates the project for development and then runs the `make.jl`
-file and builds and deploys the documentation to a branch which defaults to `pages`
-which you can modify to something else e.g. GitHub → gh-pages, Codeberg → pages.
-
-!!! tip
-	The example above is a basic pipeline that suits most projects. Further information
-	on how to customize your pipelines can be found in the official woodpecker
-	documentation: [Woodpecker CI](https://woodpecker-ci.org/docs/intro).
 
 ## Documentation Versions
 
@@ -757,7 +633,137 @@ While they won't automatically reference one another, such referencing can be ad
 !!! warning
     When building multiple subpackages in the same repo, unique `dirname`s must be specified in each package's `deploydocs`; otherwise, only the most recently built package for a given version over the entire monorepo will be present at `https://USER_NAME.github.io/PACKAGE_NAME.jl/PackageB/vX.Y.Z`, and the rest of the subpackages' documentation will be unavailable.
 
-## Deployment systems
+## Other CI systems
+
+Documenter is not tied to GitHub Actions: everything from the `docs/Project.toml` section
+onwards applies wherever the build runs, and only the CI configuration file differs. The
+sections below cover the other services Documenter recognizes out of the box, and how to
+teach it about one it does not.
+
+### Travis CI
+
+To tell Travis that we want a new build stage, we can add the following to an existing `.travis.yml`
+file. Note that the snippet below will not work by itself and must be accompanied by a complete Travis file.
+
+```yaml
+jobs:
+  include:
+    - stage: "Documentation"
+      julia: 1
+      os: linux
+      script:
+        - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
+                                               Pkg.instantiate()'
+        - julia --project=docs/ docs/make.jl
+      after_success: skip
+```
+
+where the `julia:` and `os:` entries decide the worker from which the docs are built and
+deployed. In the example above we will thus build and deploy the documentation from a linux
+worker running Julia 1 (the latest stable version). For more information on how to set up a build stage, see the Travis
+manual for [Build Stages](https://docs.travis-ci.com/user/build-stages).
+
+The three lines in the `script:` section do the following:
+
+ 1. Instantiate the doc-building environment (i.e. `docs/Project.toml`, see below).
+ 2. Install your package in the doc-build environment.
+ 3. Run the docs/make.jl script, which builds and deploys the documentation.
+
+!!! note
+    If your package has a build script you should call
+    `Pkg.build("PackageName")` after the call to `Pkg.develop` to make
+    sure the package is built properly.
+
+!!! note "matrix: section in .travis.yml"
+
+    Travis CI used to use `matrix:` as the section to configure the build matrix in the config
+    file. This now appears to be a deprecated alias for `jobs:`. If you use both `matrix:` and
+    `jobs:` in your configuration, `matrix:` overrides the settings under `jobs:`.
+
+    If your `.travis.yml` file still uses `matrix:`, it should be replaced with a single
+    `jobs:` section.
+
+#### [Authentication: SSH Deploy Keys (Travis CI)](@id travis-ssh)
+
+Travis CI also authenticates with an SSH deploy key. Generate the key pair with
+`DocumenterTools.genkeys` as described in the
+[SSH deploy key section](@ref ssh-deploy-keys) above. Only the private key is added
+elsewhere:
+
+ 1. Add the public ssh key as a deploy key with write access on the
+    `https://github.com/USER/REPO/settings/keys` page of the GitHub repository.
+
+ 2. Next add the long private key to the Travis settings page at
+    `https://app.travis-ci.com/USER/REPO/settings`.
+    Again note that you should include **no whitespace** when copying the key. In the **`Environment
+    Variables`** section add a key with the name `DOCUMENTER_KEY` and the value that was printed
+    out. **Do not** set the variable to be displayed in the build log. Then click **`Add`**.
+
+    !!! warning "Security warning"
+
+        To reiterate: make sure that this key is hidden. In particular, in the Travis CI settings
+        the "Display value in build log" option should be **OFF** for
+        the variable, so that it does not get printed when the tests run. This
+        base64-encoded string contains the *unencrypted* private key that gives full write
+        access to your repository, so it must be kept safe.  Also, make sure that you never
+        expose this variable in your tests, nor merge any code that does. You can read more
+        about Travis environment variables in [Travis User Documentation](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings).
+
+!!! note
+
+    There are more explicit instructions for adding the keys to Travis in the
+    [SSH Deploy Keys Walkthrough](@ref) section of the manual.
+
+### Woodpecker CI
+
+To run a documentation build from Woodpecker CI, one should create an access token
+from their forge of choice: GitHub, GitLab, or Codeberg (or any Gitea instance).
+This access token should be added to Woodpecker CI as a secret named
+`project_access_token`. The case does not matter since this will be passed as
+an uppercase environment variable to your pipeline. Next, create a new pipeline
+configuration file called `.woodpecker.yml` with the following contents:
+
+- Woodpecker 0.15.x and pre-1.0.0
+
+  ```yaml
+  pipeline:
+      docs:
+      when:
+          branch: main  # update to match your development branch
+      image: julia
+      commands:
+          - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+          - julia --project=docs/ docs/make.jl
+      secrets: [ project_access_token ]  # access token is a secret
+
+  ```
+
+- Woodpecker 1.0.x and onwards
+
+  ```yaml
+  steps:
+      docs:
+      when:
+          branch: main  # update to match your development branch
+      image: julia
+      commands:
+          - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+          - julia --project=docs/ docs/make.jl
+      secrets: [ project_access_token ]  # access token is a secret
+
+  ```
+
+This will pull an image of julia from docker and run the following commands from
+`commands:` which instantiates the project for development and then runs the `make.jl`
+file and builds and deploys the documentation to a branch which defaults to `pages`
+which you can modify to something else e.g. GitHub → gh-pages, Codeberg → pages.
+
+!!! tip
+	The example above is a basic pipeline that suits most projects. Further information
+	on how to customize your pipelines can be found in the official woodpecker
+	documentation: [Woodpecker CI](https://woodpecker-ci.org/docs/intro).
+
+### Deployment systems
 
 It is possible to customize Documenter to use other systems than the ones described in
 the sections above. This is done by passing a configuration

--- a/docs/src/man/hosting.md
+++ b/docs/src/man/hosting.md
@@ -2,10 +2,9 @@
 
 After going through the [Package Guide](@ref) and [Doctests](@ref) page you will need to
 host the generated documentation somewhere for potential users to read. This guide will
-describe how to set up automatic updates for your package docs using either the Travis CI
-build service or GitHub Actions together with GitHub Pages for hosting the generated
-HTML files. This is the same approach used by this package to host its own docs --
-the docs you're currently reading.
+describe how to set up automatic updates for your package docs, using GitHub Actions to
+build them and GitHub Pages to host the generated HTML files. This is the same approach
+used by this package to host its own docs -- the docs you're currently reading.
 
 !!! note
 
@@ -14,34 +13,36 @@ the docs you're currently reading.
     proceed with the steps outlined here once you have successfully managed to build your
     documentation locally with Documenter.
 
-    This guide assumes that you already have [GitHub](https://github.com/) and
-    [Travis](https://www.travis-ci.com/) accounts set up. If not then go set those up first and
-    then return here.
+    This guide assumes that you already have a [GitHub](https://github.com/) account set
+    up. If not then go set that up first and then return here.
 
-    It is possible to deploy from other systems than Travis CI or GitHub Actions,
-    see the section on [Deployment systems](@ref).
+    Documenter can also deploy from other CI services, see [Other CI systems](@ref).
 
+```@contents
+Pages = ["hosting.md"]
+Depth = 2:3
+```
 
 ## Overview
 
 Once set up correctly, the following will happen each time you push new updates to your
 package repository:
 
-- Buildbots will start up and run your package tests in a "Test" stage.
-- After the Test stage completes, a single bot will run a new "Documentation" stage, which
-  will build the documentation.
-- If the documentation is built successfully, the bot will attempt to push the generated
+- Your CI service starts a job that builds the documentation, alongside the jobs that run
+  your package tests.
+- If the documentation is built successfully, that job will attempt to push the generated
   HTML pages back to GitHub.
 
 Note that the hosted documentation does not update when you (or other contributors)
 make pull requests; you see updates only when you merge to the trunk branch (typically,
 `master` or `main`) or push new tags.
 
-In the upcoming sections we describe how to configure the build service to run
-the documentation build stage. In general it is easiest to choose the same
-service as the one testing your package. If you don't explicitly select
-the service with the `deploy_config` keyword argument to `deploydocs`
-Documenter will try to automatically detect which system is running and use that.
+The next section describes how to configure [GitHub Actions](@ref) to run that job, and the
+sections after it cover the parts of the setup that are the same on every service. In
+general it is easiest to choose the same service as the one testing your package. If you
+don't explicitly select the service with the `deploy_config` keyword argument to
+`deploydocs` Documenter will try to automatically detect which system is running and use
+that.
 
 ## GitHub Actions
 
@@ -90,16 +91,19 @@ jobs:
 ```
 
 This will install Julia, checkout the correct commit of your repository, and run the
-build of the documentation. The `julia-version:`, `julia-arch:` and `os:` entries decide
-the environment from which the docs are built and deployed. The example above builds and deploys
-the documentation from an Ubuntu worker running Julia 1.
+build of the documentation. The `runs-on:` key and the `version:` input to
+`julia-actions/setup-julia` decide the environment from which the docs are built and
+deployed. The example above builds and deploys the documentation from an Ubuntu worker
+running Julia 1.
+
+The `Install dependencies` step instantiates the doc-build environment
+(`docs/Project.toml`) and installs your package into it in development mode. The
+`Build and deploy` step then runs `docs/make.jl`, which builds the documentation and
+deploys it to the `gh-pages` branch.
 
 !!! tip
     The example above is a basic workflow that should suit most projects. For more information on
     how to further customize your action, check out the [GitHub Actions manual](https://docs.github.com/en/actions).
-
-The commands in the lines in the `run:` section do the same as for Travis,
-see the previous section.
 
 !!! warning "TagBot & tagged versions"
 
@@ -140,7 +144,8 @@ When running from GitHub Actions it is possible to authenticate using
 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-to the configuration file, as shown in the [previous section](@ref GitHub-Actions).
+to the `env:` section of the configuration file, as shown in the
+[example workflow](@ref GitHub-Actions).
 
 !!! note
     You can only use `GITHUB_TOKEN` for authentication if the target repository
@@ -250,7 +255,7 @@ DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
 ```
 
 to the `env:` section of the configuration file, as shown in the
-[previous section](@ref GitHub-Actions). See GitHub's manual on
+[example workflow](@ref GitHub-Actions). See GitHub's manual on
 [using secrets in GitHub Actions](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets)
 for more information.
 
@@ -429,7 +434,7 @@ an alternative is to give GitHub workflows write permissions under the repo sett
 
 !!! note
     This section describes the default mode of deployment, which is by version.
-    See the following section on [Deploying without the versioning scheme](@ref)
+    See the section on [Deploying without the versioning scheme](@ref)
     if you want to deploy directly to the "root".
 
 By default the documentation is deployed as follows:
@@ -500,7 +505,7 @@ branches the CI runs on is broad enough etc).
 ### Deploying without the versioning scheme
 
 Documenter supports deployment directly to the website root ignoring any version
-subfolders as described in the previous section. This can be useful if you use
+subfolders as described in [Documentation Versions](@ref). This can be useful if you use
 Documenter for something that is not a versioned project, for example.
 To do this, pass `versions = nothing` to the [`deploydocs`](@ref) function.
 Now the pages should be found directly at
@@ -665,7 +670,8 @@ manual for [Build Stages](https://docs.travis-ci.com/user/build-stages).
 
 The three lines in the `script:` section do the following:
 
- 1. Instantiate the doc-building environment (i.e. `docs/Project.toml`, see below).
+ 1. Instantiate the doc-building environment, i.e. install the dependencies listed in
+    `docs/Project.toml`.
  2. Install your package in the doc-build environment.
  3. Run the docs/make.jl script, which builds and deploys the documentation.
 
@@ -765,13 +771,14 @@ which you can modify to something else e.g. GitHub → gh-pages, Codeberg → pa
 
 ### Deployment systems
 
-It is possible to customize Documenter to use other systems than the ones described in
-the sections above. This is done by passing a configuration
+It is possible to customize Documenter to use CI systems other than the ones described
+above. This is done by passing a configuration
 (a [`DeployConfig`](@ref `Documenter.DeployConfig`)) to `deploydocs` by the `deploy_config`
 keyword argument. Documenter supports [`Travis`](@ref `Documenter.Travis`),
-[`GitHubActions`](@ref `Documenter.GitHubActions`), [`GitLab`](@ref `Documenter.GitLab`), and
-[`Buildkite`](@ref `Documenter.Buildkite`) natively, but it is easy to define your own by
-following the simple interface described below.
+[`GitHubActions`](@ref `Documenter.GitHubActions`), [`GitLab`](@ref `Documenter.GitLab`),
+[`Buildkite`](@ref `Documenter.Buildkite`) and [`Woodpecker`](@ref `Documenter.Woodpecker`)
+natively, but it is easy to define your own by following the simple interface described
+below.
 
 ```@docs
 Documenter.DeployConfig


### PR DESCRIPTION
#2934 and #2968 already moved GitHub Actions to the top of the hosting page and gave it its own deploy key instructions. What was left of #2131 is the regrouping: `## Travis CI` still sat between GitHub Actions and the shared setup steps, and `## Woodpecker CI` between `gh-pages` and the versioning sections, so nobody could read the page top to bottom.

Group Travis CI, Woodpecker CI and Deployment systems under a new "Other CI systems" section at the end. The first commit is a pure move: only heading levels change, no heading text, so every inbound `@ref` still resolves.

The second commit drops the Travis framing. The GitHub Actions section explained its own workflow as "the same as for Travis, see the previous section", which also pointed the wrong way once Travis moved below it; it now describes its own steps. The introduction listed a Travis account as a prerequisite and the overview described the build in terms of buildbots and a "Documentation" stage.

Also adds a table of contents. The sidebar only lists level 1 and 2 headings, so the SSH deploy key instructions had no bullet.

Three drive-by fixes in text I was already editing: the sentence naming `julia-version:`, `julia-arch:` and `os:` as the keys that pick the build environment (the example workflow has used `runs-on:` and `setup-julia`'s `version:` for a while), four intra-page links naming the wrong section, and `Woodpecker` missing from the list of natively supported deploy configs.

Stacked on #2982, which edits the same lines. This PR here should be rebased once that one is merged.

Prepared with AI assistance (Claude Opus 5).

Resolves #2131.