### PR TITLE
Keep the global `meta` for crossref and rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* Default values supplied through the `meta` keyword of `makedocs` now also reach pages that carry no `@meta` block of their own. They used to be discarded before cross-referencing, so on such a page `@ref` lost `CurrentModule`, and `CollapsedDocStrings`, `Description`, `EditURL` and `IgnorePage` never reached the writer. ([#2512], [#2697], [#2987])
-
-
-### Fixed
-
 * Large code blocks, such as `@raw html` blocks embedding a plot, no longer abort the build with `PCRE compilation error: regular expression is too large`. Locating a code block in its source file now matches line by line instead of compiling the entire block into a regular expression, which also stops line numbers in error messages from pointing at an unrelated earlier line containing the same text. ([#2992], [#2912])
-
+* Default values supplied through the `meta` keyword of `makedocs` now also reach pages that carry no `@meta` block of their own. They used to be discarded before cross-referencing, so on such a page `@ref` lost `CurrentModule`, and `CollapsedDocStrings`, `Description`, `EditURL` and `IgnorePage` never reached the writer. ([#2512], [#2697], [#2987])
 
 ## Version [v1.18.0] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `doctest` now accepts a `meta` keyword, like `makedocs` does, so that a global `DocTestSetup` can be set for the doctests on manual pages when they are run through `doctest`. ([#2512], [#2697])
 
+### Fixed
+
+* Default values supplied through the `meta` keyword of `makedocs` now also reach pages that carry no `@meta` block of their own. They used to be discarded before cross-referencing, so on such a page `@ref` lost `CurrentModule`, and `CollapsedDocStrings`, `Description`, `EditURL` and `IgnorePage` never reached the writer. ([#2512], [#2697], [#2987])
+
 
 ## Version [v1.18.0] - 2026-08-28
 
@@ -2310,6 +2314,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2963]: https://github.com/JuliaDocs/Documenter.jl/issues/2963
 [#2973]: https://github.com/JuliaDocs/Documenter.jl/issues/2973
 [#2976]: https://github.com/JuliaDocs/Documenter.jl/issues/2976
+[#2987]: https://github.com/JuliaDocs/Documenter.jl/issues/2987
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/src/cross_references.jl
+++ b/src/cross_references.jl
@@ -13,7 +13,9 @@ references.
 """
 function crossref(doc::Documenter.Document)
     for (src, page) in doc.blueprint.pages
-        empty!(page.globals.meta)
+        # Seed with the global defaults, just like the expander does; page-local
+        # `@meta` blocks are re-applied on top while walking the AST below.
+        copy!(page.globals.meta, doc.user.meta)
         crossref(doc, page, page.mdast)
     end
     return

--- a/test/default_meta/src/nometa.md
+++ b/test/default_meta/src/nometa.md
@@ -1,0 +1,9 @@
+# No `@meta` block
+
+This page deliberately has no `@meta` block, so `CurrentModule` and `CollapsedDocStrings` can only reach it through the `meta` keyword of `makedocs`. The `@ref` below resolves only if `CurrentModule` survives into the cross-reference stage, and the docstring below is marked as collapsed only if `CollapsedDocStrings` survives into the HTML writer.
+
+See [`unexported_function`](@ref).
+
+```@docs
+unexported_function
+```

--- a/test/default_meta/tests.jl
+++ b/test/default_meta/tests.jl
@@ -1,13 +1,24 @@
 using Documenter
 using Test
 
+module DefaultMetaTestModule
+    "A function that is not exported, and hence only findable via `CurrentModule`."
+    function unexported_function end
+end
+
 const pages = [
     "Home" => "index.md",
+    "No meta" => "nometa.md",
 ]
 
 makedocs(
     sitename = "Test", pages = pages, doctest = true,
-    meta = Dict(:DocTestSetup => :(x = 42))
+    modules = [DefaultMetaTestModule],
+    meta = Dict(
+        :DocTestSetup => :(x = 42),
+        :CurrentModule => DefaultMetaTestModule,
+        :CollapsedDocStrings => true,
+    )
 )
 
 # `doctest` builds its own document, so it needs to forward `meta` itself.
@@ -17,4 +28,12 @@ doctest(
     meta = Dict(:DocTestSetup => :(x = 42)),
 )
 
-# the test is passing the doctest
+# index.md passing its doctest covers `DocTestSetup`, and nometa.md resolving
+# its `@ref` covers `CurrentModule`; both would have errored above. What is left
+# to check is that `CollapsedDocStrings` reaches the HTML writer.
+@testset "default meta reaches the writer" begin
+    build = joinpath(@__DIR__, "build")
+    file = joinpath(build, "nometa", "index.html")
+    isfile(file) || (file = joinpath(build, "nometa.html"))
+    @test occursin("data-docstringscollapsed", read(file, String))
+end


### PR DESCRIPTION
The `meta` keyword of `makedocs` supplies default values for the `@meta` blocks of every page, but the cross-reference stage started each page by emptying `page.globals.meta`. The defaults were then only restored from `@meta` blocks already in the page — that is, they survived only on pages carrying the very block whose repetition `meta` exists to avoid.

On a page without one, `CurrentModule` was missing while resolving `@ref`, and `CollapsedDocStrings`, `Description`, `EditURL` and `IgnorePage` were missing at render time.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Meant to unblock https://github.com/oscar-system/Oscar.jl/pull/4978 together with PR #2988 (CC @lgoettgens)