### PR TITLE
Add a `meta` keyword to `doctest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+* `doctest` now accepts a `meta` keyword, like `makedocs` does, so that a global `DocTestSetup` can be set for the doctests on manual pages when they are run through `doctest`. ([#2512], [#2697])
+
+
 ## Version [v1.18.0] - 2026-08-28
 
 ### Added

--- a/src/doctest.jl
+++ b/src/doctest.jl
@@ -59,6 +59,11 @@ manual pages can be disabled if `source` is set to `nothing`.
 **`plugins`** is a list of [`Documenter.Plugin`](@ref) objects to be forwarded to
 [`makedocs`](@ref). Use as directed by the documentation of a third-party plugin.
 
+**`meta`** can be used to provide default values for the `@meta` blocks of every page, in
+the same way as the `meta` keyword of [`makedocs`](@ref). For example
+`meta = Dict(:DocTestSetup => :(using MyPackage))` sets `DocTestSetup` for every doctest,
+complementing [`DocMeta.setdocmeta!`](@ref) which only applies to docstrings.
+
 !!! warning
     When running `doctest(...; fix=true)`, Documenter will modify the Markdown and Julia
     source files. It is strongly recommended that you only run it on packages in Pkg's
@@ -73,6 +78,7 @@ function doctest(
         testset = "Doctests",
         doctestfilters = Regex[],
         plugins = Plugin[],
+        meta::Dict{Symbol} = Dict{Symbol, Any}(),
     )
     function all_doctests()
         dir = mktempdir()
@@ -93,6 +99,7 @@ function doctest(
                 # related to determining the remote repositories for edit URLs and such
                 remotes = nothing,
                 plugins = plugins,
+                meta = meta,
             )
             return true
         catch err

--- a/test/default_meta/tests.jl
+++ b/test/default_meta/tests.jl
@@ -10,4 +10,11 @@ makedocs(
     meta = Dict(:DocTestSetup => :(x = 42))
 )
 
+# `doctest` builds its own document, so it needs to forward `meta` itself.
+doctest(
+    joinpath(@__DIR__, "src"), Module[];
+    testset = "Doctests: default meta",
+    meta = Dict(:DocTestSetup => :(x = 42)),
+)
+
 # the test is passing the doctest


### PR DESCRIPTION
`makedocs` gained a `meta` keyword to supply default values for the `@meta` blocks of every page, but the standalone `doctest` builds its own document and did not forward it. Packages that run their doctests through `doctest` rather than `makedocs` therefore had no way to set a global `DocTestSetup` for the doctests on their manual pages; `setdocmeta!` only reaches docstrings.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Meant to unblock https://github.com/oscar-system/Oscar.jl/pull/4978 together with PR #2987 (CC @lgoettgens)