### PR TITLE
Support named anchors on admonitions titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+* Admonitions can now carry a named anchor in their title with the `!!! note "[title](@id name)"` syntax, mirroring named headers. The anchor resolves via `@ref`, is written to the `objects.inv` inventory as a `std:label` entry, and becomes the HTML `id` of the admonition element (which is otherwise derived from a hash of the admonition's content, and hence changes whenever the admonition is edited). ([#745])
+
 ## Version [v1.18.0] - 2026-08-28
 
 ### Added

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -311,6 +311,21 @@ to:
 ... see [Figure 1](@ref figure-1) ...
 ````
 
+An `@id` anchor may also wrap the title of an admonition, making the admonition itself the
+link target:
+
+````markdown
+!!! note "[Named note](@id note-anchor)"
+    ...
+
+... see [the note above](@ref note-anchor) ...
+````
+
+As with headers, the Markdown link is dropped from the rendered title. The anchor name
+(after slugification) also becomes the HTML `id` of the admonition element, so its permalink
+points at `#note-anchor`. Without an `@id` anchor the id is instead derived from a hash of
+the admonition's content, and hence changes whenever the admonition is edited.
+
 Ids are slugified, so `[x](@id My Anchor)` defines the anchor `My-Anchor`.
 
 Header and non-header anchors share a single id namespace, so a duplicate id is

--- a/src/documents.jl
+++ b/src/documents.jl
@@ -1119,6 +1119,18 @@ struct AnchoredHeader <: AbstractDocumenterBlock
 end
 MarkdownAST.iscontainer(::AnchoredHeader) = true
 
+"""
+Represents a named anchor attached to a block element via the `[title](@id name)` syntax in
+the title of an admonition. Unlike [`AnchoredHeader`](@ref), which wraps the anchored node,
+this element replaces the block's own element in the tree (keeping the block's children in
+place, mirroring [`AnchoredInline`](@ref)), with the original element stored in `.block`.
+"""
+struct AnchoredBlock <: AbstractDocumenterBlock
+    anchor::Anchor
+    block::MarkdownAST.AbstractBlock
+end
+MarkdownAST.iscontainer(::AnchoredBlock) = true
+
 # A DocsNodesBlock corresponds to one @docs (or @autodocs) code block, and contains
 # a list of docstrings, which are represented as child nodes of type DocsNode.
 # In addition, the child node can also be an Admonition in case there was an error
@@ -1148,6 +1160,7 @@ end
 # Extend MDFlatten.mdflatten to support the Documenter-specific elements
 MDFlatten.mdflatten(io, node::MarkdownAST.Node, ::AnchoredHeader) = MDFlatten.mdflatten(io, node.children)
 MDFlatten.mdflatten(io, node::MarkdownAST.Node, ::AnchoredInline) = MDFlatten.mdflatten(io, node.children)
+MDFlatten.mdflatten(io, node::MarkdownAST.Node, e::AnchoredBlock) = MDFlatten.mdflatten(io, node, e.block)
 MDFlatten.mdflatten(io, node::MarkdownAST.Node, e::SetupNode) = MDFlatten.mdflatten(io, node, MarkdownAST.CodeBlock(e.name, e.code))
 MDFlatten.mdflatten(io, node::MarkdownAST.Node, e::RawNode) = MDFlatten.mdflatten(io, node, MarkdownAST.CodeBlock("@raw $(e.name)", e.text))
 MDFlatten.mdflatten(io, node::MarkdownAST.Node, e::AbstractDocumenterBlock) = MDFlatten.mdflatten(io, node, e.codeblock)

--- a/src/expander_pipeline.jl
+++ b/src/expander_pipeline.jl
@@ -60,7 +60,8 @@ function expand(doc::Documenter.Document)
             Selectors.dispatch(Expanders.ExpanderPipeline, node, page, doc)
             expand_recursively(node, page, doc)
         end
-        # Register arbitrary `[content](@id name)` anchors. This runs after the per-node
+        # Register arbitrary `[content](@id name)` anchors, on inline content as well as in
+        # admonition titles. This runs after the per-node
         # expansion above (so header `@id` links have already been consumed by TrackHeaders)
         # and, crucially, before the CrossReferences pipeline stage, so that `@ref`s to these
         # anchors — including forward references to later pages — can be resolved.
@@ -1127,6 +1128,26 @@ iscode(x, lang) = false
 # collect_named_anchors!).
 const NAMED_ANCHOR_REGEX = r"^@id (.+)$"
 
+# Detects an admonition title of the form `[title](@id name)`, i.e. the whole title being a
+# single `@id` link, mirroring named headers. Since `MarkdownAST.Admonition.title` is a
+# plain string (admonition titles are never parsed as markdown), the title is parsed here,
+# and the anchor is accepted under the same conditions as `namedheader`: the parse must
+# yield a single paragraph whose only child is a link with an `@id` destination. Returns
+# `(title = <plain title text>, name = <anchor name>)`, or `nothing` if the title does not
+# carry an anchor.
+function admonition_title_anchor(title::AbstractString)
+    mdast = convert(MarkdownAST.Node, Markdown.parse(title))
+    length(mdast.children) == 1 || return nothing
+    paragraph = first(mdast.children)
+    paragraph.element isa MarkdownAST.Paragraph || return nothing
+    length(paragraph.children) == 1 || return nothing
+    link = first(paragraph.children)
+    link.element isa MarkdownAST.Link || return nothing
+    m = match(NAMED_ANCHOR_REGEX, link.element.destination)
+    isnothing(m) && return nothing
+    return (title = MDFlatten.mdflatten(link), name = String(m[1]))
+end
+
 function namedheader(node::Node)
     @assert node.element isa MarkdownAST.Heading
     if length(node.children) == 1 && first(node.children).element isa MarkdownAST.Link
@@ -1138,32 +1159,48 @@ function namedheader(node::Node)
 end
 
 # Walk the whole page tree and turn every `[content](@id name)` link on non-header content
-# into an `AnchoredInline`, registering the anchor in `doc.internal.anchors`. Sharing that
+# into an `AnchoredInline`, and every admonition with a `[title](@id name)` title into an
+# `AnchoredBlock`, registering the anchors in `doc.internal.anchors`. Sharing that
 # AnchorMap with headers gives all `@id` anchors a single id namespace (so collisions are
 # caught by the existing uniqueness checks), lets them resolve through the existing `@ref`
 # header pipeline, and gets them written to the `objects.inv` inventory automatically.
 function collect_named_anchors!(page, doc)
     for node in AbstractTrees.PreOrderDFS(page.mdast)
-        node.element isa MarkdownAST.Link || continue
-        m = match(NAMED_ANCHOR_REGEX, node.element.destination)
-        isnothing(m) && continue
-        # Links that are the sole child of a Heading are header anchors, handled (and removed
-        # from the tree) by TrackHeaders; guard against re-registering one here.
-        parent = node.parent
-        if !isnothing(parent) && parent.element isa MarkdownAST.Heading && length(parent.children) == 1
-            continue
+        if node.element isa MarkdownAST.Link
+            m = match(NAMED_ANCHOR_REGEX, node.element.destination)
+            isnothing(m) && continue
+            # Links that are the sole child of a Heading are header anchors, handled (and removed
+            # from the tree) by TrackHeaders; guard against re-registering one here.
+            parent = node.parent
+            if !isnothing(parent) && parent.element isa MarkdownAST.Heading && length(parent.children) == 1
+                continue
+            end
+            # Slugify the id exactly as TrackHeaders does for named headers, so that inline and
+            # header `@id` anchors share identical id semantics (and never emit an invalid HTML
+            # id, e.g. one containing spaces).
+            id = Documenter.slugify(String(m[1]))
+            # The anchor and the element carrying it are mutually referential, so the anchor is
+            # registered with no object and told about the AnchoredInline once that exists.
+            anchor = Documenter.anchor_add!(doc.internal.anchors, nothing, id, page.build)
+            element = Documenter.AnchoredInline(anchor)
+            anchor.object = element
+            node.element = element
+            anchor.node = node
+        elseif node.element isa MarkdownAST.Admonition
+            admonition = node.element
+            title_anchor = admonition_title_anchor(admonition.title)
+            isnothing(title_anchor) && continue
+            # Strip the `@id` link from the title, leaving just the title text, so that the
+            # title renders exactly as it would without the anchor (mirroring named headers).
+            admonition.title = title_anchor.title
+            id = Documenter.slugify(title_anchor.name)
+            # The Admonition element is stored as the anchor's object so that consumers can
+            # distinguish block anchors from header and inline ones (e.g. `@contents` skips
+            # them, and the inventory uses the admonition title as the display name).
+            anchor = Documenter.anchor_add!(doc.internal.anchors, admonition, id, page.build)
+            node.element = Documenter.AnchoredBlock(anchor, admonition)
+            anchor.node = node
         end
-        # Slugify the id exactly as TrackHeaders does for named headers, so that inline and
-        # header `@id` anchors share identical id semantics (and never emit an invalid HTML
-        # id, e.g. one containing spaces).
-        id = Documenter.slugify(String(m[1]))
-        # The anchor and the element carrying it are mutually referential, so the anchor is
-        # registered with no object and told about the AnchoredInline once that exists.
-        anchor = Documenter.anchor_add!(doc.internal.anchors, nothing, id, page.build)
-        element = Documenter.AnchoredInline(anchor)
-        anchor.object = element
-        node.element = element
-        anchor.node = node
     end
     return
 end

--- a/src/html/HTMLWriter.jl
+++ b/src/html/HTMLWriter.jl
@@ -2509,7 +2509,16 @@ function domify(dctx::DCtx, node::Node, f::MarkdownAST.FootnoteDefinition)
     return DOM.Node[]
 end
 
-function domify(dctx::DCtx, node::Node, a::MarkdownAST.Admonition)
+# An admonition with a `[title](@id name)` title: the anchor's label becomes the HTML id of
+# the admonition element itself (instead of the content-hash based one), so the permalink is
+# stable and matches what `@ref`/`objects.inv` links point at.
+function domify(dctx::DCtx, node::Node, ab::Documenter.AnchoredBlock)
+    @assert ab.block isa MarkdownAST.Admonition # currently the only block that can carry an anchor
+    id = lstrip(Documenter.anchor_fragment(ab.anchor), '#')
+    return domify(dctx, node, ab.block; id = id)
+end
+
+function domify(dctx::DCtx, node::Node, a::MarkdownAST.Admonition; id::Union{AbstractString, Nothing} = nothing)
     @tags header div details summary
     colorclass =
         (a.category == "danger") ? ".is-danger" :
@@ -2539,13 +2548,19 @@ function domify(dctx::DCtx, node::Node, a::MarkdownAST.Admonition)
             # apply a class
             isempty(cat_sanitized) ? "" : ".is-category-$(cat_sanitized)"
         end
-    node_repr = strip(mdflatten(node))
-    content_hash = string(hash(node_repr), base = 16)
-    admonition_id = if !isempty(a.title)
-        base_id = Documenter.slugify(a.title)
-        "$(base_id)-$(content_hash)"
+    admonition_id = if !isnothing(id)
+        id
     else
-        "$(a.category)-$(content_hash)"
+        # Without an explicit `@id` anchor in the title, the id is derived from a hash of
+        # the admonition's content (so it changes whenever the content is edited).
+        node_repr = strip(mdflatten(node))
+        content_hash = string(hash(node_repr), base = 16)
+        if !isempty(a.title)
+            base_id = Documenter.slugify(a.title)
+            "$(base_id)-$(content_hash)"
+        else
+            "$(a.category)-$(content_hash)"
+        end
     end
     anchor_link = DOM.Tag(:a)[".admonition-anchor", :href => "#$(admonition_id)", :title => "Permalink"]()
     inner_div = div[".admonition-body"](domify(dctx, node.children))

--- a/src/html/write_inventory.jl
+++ b/src/html/write_inventory.jl
@@ -134,7 +134,9 @@ end
 
 # dispname for :std:label
 function _get_inventory_dispname(doc, ctx, name::AbstractString, anchor::Documenter.Anchor)
-    dispname = mdflatten(anchor.node)
+    # For an anchored admonition (`AnchoredBlock`) the display name is its title; flattening
+    # `anchor.node` would also pull in the entire admonition body.
+    dispname = anchor.object isa MarkdownAST.Admonition ? anchor.object.title : mdflatten(anchor.node)
     # `-` is the inventory convention for "display name is the same as the name". Empty
     # content (e.g. `[](@id name)`) has no display name, so use `-` rather than emitting a
     # trailing-empty field.

--- a/src/latex/LaTeXWriter.jl
+++ b/src/latex/LaTeXWriter.jl
@@ -373,6 +373,15 @@ function latex(io::Context, node::Node, ai::Documenter.AnchoredInline)
     return
 end
 
+function latex(io::Context, node::Node, ab::Documenter.AnchoredBlock)
+    id = _hash(Documenter.anchor_label(ab.anchor))
+    # An empty `\hypertarget` just before the anchored block (currently always an
+    # admonition), so that `\hyperlinkref` jumps to the top of the block.
+    _println(io, "\\hypertarget{", id, "}{}")
+    latex(io, node, ab.block)
+    return
+end
+
 ## Documentation Nodes.
 
 function latex(io::Context, node::Node, ::Documenter.DocsNodesBlock)

--- a/test/crossreferences.jl
+++ b/test/crossreferences.jl
@@ -57,37 +57,38 @@ end
         (kind = :explicit_header_id, target = "DocsReferencingMain.g", slug = "DocsReferencingMain.g")
 end
 
+# Helpers for the `@id` anchor testsets below, which each build small standalone docs.
+using CodecZlib: ZlibDecompressor, transcode
+import IOCapture
+
+function build_doc(files::Vector{Pair{String, String}}; kwargs...)
+    tmp = mktempdir()
+    src = joinpath(tmp, "src")
+    mkpath(joinpath(src, "assets"))
+    write(joinpath(src, "assets", "logo.png"), "\x89PNG\r\n\x1a\n")
+    for (name, content) in files
+        write(joinpath(src, name), content)
+    end
+    # Captured so that the many builds below do not drown the test log; errors still
+    # propagate, which the `@test_throws` cases below rely on.
+    IOCapture.capture() do
+        Documenter.makedocs(;
+            root = tmp, sitename = "T", pages = [f.first for f in files],
+            format = Documenter.HTML(edit_link = nothing, disable_git = true, inventory_version = "1.0"),
+            remotes = nothing, kwargs...,
+        )
+    end
+    return tmp
+end
+
+function read_inventory(tmp)
+    bytes = read(joinpath(tmp, "build", "objects.inv"))
+    hdrend = findlast(codeunits("zlib.\n"), bytes)
+    return String(transcode(ZlibDecompressor, bytes[(last(hdrend) + 1):end]))
+end
+
 # Arbitrary anchors on inline content via `[content](@id name)` (issue #745).
 @testset "Inline @id anchors" begin
-    using CodecZlib: ZlibDecompressor, transcode
-    import IOCapture
-
-    function build_doc(files::Vector{Pair{String, String}}; kwargs...)
-        tmp = mktempdir()
-        src = joinpath(tmp, "src")
-        mkpath(joinpath(src, "assets"))
-        write(joinpath(src, "assets", "logo.png"), "\x89PNG\r\n\x1a\n")
-        for (name, content) in files
-            write(joinpath(src, name), content)
-        end
-        # Captured so that the many builds below do not drown the test log; errors still
-        # propagate, which the `@test_throws` cases below rely on.
-        IOCapture.capture() do
-            Documenter.makedocs(;
-                root = tmp, sitename = "T", pages = [f.first for f in files],
-                format = Documenter.HTML(edit_link = nothing, disable_git = true, inventory_version = "1.0"),
-                remotes = nothing, kwargs...,
-            )
-        end
-        return tmp
-    end
-
-    function read_inventory(tmp)
-        bytes = read(joinpath(tmp, "build", "objects.inv"))
-        hdrend = findlast(codeunits("zlib.\n"), bytes)
-        return String(transcode(ZlibDecompressor, bytes[(last(hdrend) + 1):end]))
-    end
-
     # Happy path: inline text anchor + a thumbnail-image anchor, both referenced.
     tmp = build_doc(
         [
@@ -168,6 +169,129 @@ end
     # An empty-content anchor `[](@id name)` uses `-` as its inventory display name.
     tmp = build_doc(["index.md" => "# H\n\n[](@id empty1)\n\nRef [r](@ref empty1).\n"])
     @test any(l -> startswith(l, "empty1 std:label -1 ") && endswith(strip(l), " -"), split(read_inventory(tmp), '\n'))
+end
+
+# Named anchors on admonitions via a `!!! note "[title](@id name)"` title.
+@testset "Admonition @id anchors" begin
+    # Happy path: the link is stripped from the rendered title, the anchor id becomes the
+    # HTML id of the admonition element itself (and its permalink target) instead of the
+    # content-hash based one, and `@ref`s resolve to it.
+    tmp = build_doc(
+        [
+            "index.md" => """
+                # Header
+
+                !!! note "[Named note](@id note-anchor)"
+                    Note content.
+
+                Ref: [see the note](@ref note-anchor).
+                """,
+        ]
+    )
+    html = read(joinpath(tmp, "build", "index.html"), String)
+    @test occursin(Regex("<div class=\"admonition is-info\"[^>]*\\bid=\"note-anchor\""), html)
+    @test occursin("href=\"#note-anchor\"", html)
+    @test occursin(">Named note<", html)
+    @test !occursin("[Named note]", html)
+    @test occursin(">see the note</a>", html)
+    # The anchor is written to the inventory as a std:label entry, with the admonition
+    # title (not its whole content) as the display name.
+    inv = read_inventory(tmp)
+    @test any(l -> startswith(l, "note-anchor std:label -1 ") && endswith(strip(l), " Named note"), split(inv, '\n'))
+
+    # `!!! details` admonitions render as a <details> element; the id transfers there too.
+    tmp = build_doc(
+        [
+            "index.md" => """
+                # H
+
+                !!! details "[Show more](@id details-anchor)"
+                    Hidden content.
+
+                Ref: [more](@ref details-anchor).
+                """,
+        ]
+    )
+    html = read(joinpath(tmp, "build", "index.html"), String)
+    @test occursin(Regex("<details class=\"admonition is-details\"[^>]*\\bid=\"details-anchor\""), html)
+    @test occursin("href=\"#details-anchor\"", html)
+
+    # The id is slugified exactly like a header `@id`, and an admonition without an `@id`
+    # anchor keeps the content-hash based id. The title is parsed as markdown, so inline
+    # markup inside the `@id` link is flattened to plain text (admonition titles are plain
+    # strings), and a title that is a regular link (not `@id`) is left alone.
+    tmp = build_doc(
+        [
+            "index.md" => """
+                # H
+
+                !!! warning "[Slug me](@id My Adm Id)"
+                    Content.
+
+                !!! note "Plain title"
+                    Content.
+
+                !!! tip "[**Bold** `code` title](@id markup-adm)"
+                    Content.
+
+                !!! note "[link](https://example.com)"
+                    Content.
+
+                Refs: [x](@ref My-Adm-Id) and [y](@ref markup-adm).
+                """,
+        ]
+    )
+    html = read(joinpath(tmp, "build", "index.html"), String)
+    @test occursin("id=\"My-Adm-Id\"", html)
+    @test !occursin("id=\"My Adm Id\"", html)
+    @test occursin(r"id=\"Plain-title-[0-9a-f]+\"", html)
+    @test occursin("id=\"markup-adm\"", html)
+    @test occursin(">Bold code title<", html)
+    @test occursin("[link](https://example.com)", html)
+
+    # Forward/cross-page reference to an admonition anchor defined on a later page.
+    tmp = build_doc(
+        [
+            "a.md" => "# A\n\nSee [the note](@ref adm-cross).\n",
+            "b.md" => "# B\n\n!!! note \"[Target note](@id adm-cross)\"\n    Content.\n",
+        ]
+    )
+    @test occursin("href=\"../b/#adm-cross\"", read(joinpath(tmp, "build", "a", "index.html"), String))
+
+    # Nested admonitions are found too.
+    tmp = build_doc(
+        [
+            "index.md" => """
+                # H
+
+                !!! warning "[Outer](@id outer-adm)"
+                    !!! tip "[Inner](@id inner-adm)"
+                        Content.
+
+                Refs: [x](@ref outer-adm) and [y](@ref inner-adm).
+                """,
+        ]
+    )
+    html = read(joinpath(tmp, "build", "index.html"), String)
+    @test occursin("id=\"outer-adm\"", html)
+    @test occursin("id=\"inner-adm\"", html)
+
+    # Admonition anchors share the id namespace with headers and inline anchors, so a
+    # referenced duplicate id is an error, not a silent pick.
+    @test_throws Exception build_doc(
+        [
+            "index.md" => "# Foo\n\n!!! note \"[x](@id Foo)\"\n    Content.\n\nRef: [r](@ref Foo).\n",
+        ]
+    )
+
+    # `@contents` must not trip over admonition anchors sharing the header AnchorMap.
+    @test (build_doc(["index.md" => "# Top\n\n```@contents\n```\n\n## Sec\n\n!!! note \"[T](@id adm-a)\"\n    C.\n"]); true)
+
+    # An empty title `!!! note "[](@id name)"` keeps the title empty and uses `-` as the
+    # inventory display name.
+    tmp = build_doc(["index.md" => "# H\n\n!!! note \"[](@id adm-empty)\"\n    Content.\n\nRef [r](@ref adm-empty).\n"])
+    @test occursin("id=\"adm-empty\"", read(joinpath(tmp, "build", "index.html"), String))
+    @test any(l -> startswith(l, "adm-empty std:label -1 ") && endswith(strip(l), " -"), split(read_inventory(tmp), '\n'))
 end
 
 end

--- a/test/examples/src/xrefs.md
+++ b/test/examples/src/xrefs.md
@@ -12,8 +12,12 @@ Named x-refs:
 * [docstring target via backticks](@ref `Mod.func`)
 * [string target](@ref "X-ref target")
 * [inline anchor target](@ref inline-anchor-target)
+* [admonition anchor target](@ref admonition-anchor-target)
 
 Inline anchor on arbitrary (non-header) content: [an anchored phrase](@id inline-anchor-target).
+
+!!! note "[An anchored note](@id admonition-anchor-target)"
+    An admonition with an anchor in its title.
 
 ## X-ref target
 

--- a/test/examples/tests.jl
+++ b/test/examples/tests.jl
@@ -240,6 +240,14 @@ end
                             @test item.dispname == "an anchored phrase"
                             @test DocInventories.uri(item) == "xrefs/#inline-anchor-target"
                         end
+                        # `[title](@id name)` anchor in an admonition title
+                        item = inv[":std:label:`admonition-anchor-target`"]
+                        @test !isnothing(item)
+                        if !isnothing(item)
+                            @test item.name == "admonition-anchor-target"
+                            @test item.dispname == "An anchored note"
+                            @test DocInventories.uri(item) == "xrefs/#admonition-anchor-target"
+                        end
                         item = inv[":std:label:`Markdown-files-with-spaces`"]
                         @test !isnothing(item)
                         if !isnothing(item)

--- a/test/latexwriter.jl
+++ b/test/latexwriter.jl
@@ -128,6 +128,27 @@ end
     @test _node_to_latex(heading) == "\\part{Title content}\n\n\\label{$(id)}{}\n\n"
 end
 
+@testset "admonition @id anchors" begin
+    anchor = Documenter.Anchor(nothing)
+    anchor.id = "note-anchor"
+    admonition = Documenter.MarkdownAST.Admonition("note", "Named note")
+    node = Documenter.MarkdownAST.Node(Documenter.AnchoredBlock(anchor, admonition))
+    push!(
+        node.children, Documenter.MarkdownAST.@ast Documenter.MarkdownAST.Paragraph() do
+            Documenter.MarkdownAST.Text("content")
+        end
+    )
+    id = LaTeXWriter._hash(Documenter.anchor_label(anchor))
+
+    # An empty \hypertarget right before the admonition, which otherwise renders as usual
+    # (with the @id link already stripped from the title by the expander).
+    out = _node_to_latex(node)
+    @test startswith(out, "\\hypertarget{$(id)}{}\n\\begin{tcolorbox}")
+    @test occursin("title=\\textbf{Named note}", out)
+    @test occursin("content", out)
+    @test endswith(out, "\\end{tcolorbox}\n")
+end
+
 # `nrows` includes the header row, matching how the writer counts.
 function _md_table(nrows)
     io = IOBuffer()


### PR DESCRIPTION
An admonition title of the form `!!! note "[title](at-id name)"` now registers a named anchor, mirroring named headers. The `at-id` link is stripped from the rendered title, the anchor resolves via `at-ref` (also across pages), is written to the `objects.inv` inventory as a `std:label` entry, and its slug becomes the HTML `id` (and permalink target) of the admonition element itself, instead of the content-hash based id that changes whenever the admonition is edited. Admonitions without an `at-id` anchor keep the hash-based id.

Since `MarkdownAST.Admonition.title` is a plain string, the title is matched textually in `collect_named_anchors!` (next to the inline anchors from #2948), and the element is replaced in place with a new `Documenter.AnchoredBlock` that holds the anchor and the original admonition. The anchors share the id namespace and duplicate checks with header and inline `at-id` anchors.
