### PR TITLE
Keep Biome out of nested checkouts

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -11,6 +11,10 @@
     "ignoreUnknown": false,
     "includes": [
       "biome.jsonc",
+      // Claude Code puts additional checkouts of this repo here. Biome treats
+      // every biome.jsonc it walks into as a config and rejects the nested
+      // ones; a negated pattern is what stops it descending in the first place.
+      "!.claude/worktrees",
       "assets/html/**",
       "!!assets/html/themes",
       "!!assets/html/scss/highlightjs"


### PR DESCRIPTION
Any checkouts of this repo in a nested git worktree under `.claude/worktrees` carry a copy of `biome.jsonc`. Biome treats every such file it walks into as a configuration and aborts with "Found a nested root configuration", so any Biome run from the main checkout fails while a worktree exists.

Negated patterns prune the directory walk, unlike the include patterns, which only select what gets formatted. Excluding the directory therefore stops the discovery without changing the set of formatted files.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

This is the "controversial" part of PR #2978.

I'd love a user specific fix that I could keep local and not annoy other people with, but I couldn't find one short of patching the config file, or bypassing `Makefile`.

But I think this may affect other people than me anyway, and I can't think of any downsides to this. What's the harm?