### PR TITLE
Locate code blocks without building a giant regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `doctest` now accepts a `meta` keyword, like `makedocs` does, so that a global `DocTestSetup` can be set for the doctests on manual pages when they are run through `doctest`. ([#2512], [#2697])
 
 
+### Fixed
+
+* Large code blocks, such as `@raw html` blocks embedding a plot, no longer abort the build with `PCRE compilation error: regular expression is too large`. Locating a code block in its source file now matches line by line instead of compiling the entire block into a regular expression, which also stops line numbers in error messages from pointing at an unrelated earlier line containing the same text. ([#2992], [#2912])
+
+
 ## Version [v1.18.0] - 2026-08-28
 
 ### Added
@@ -2301,6 +2306,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2889]: https://github.com/JuliaDocs/Documenter.jl/issues/2889
 [#2894]: https://github.com/JuliaDocs/Documenter.jl/issues/2894
 [#2905]: https://github.com/JuliaDocs/Documenter.jl/issues/2905
+[#2912]: https://github.com/JuliaDocs/Documenter.jl/issues/2912
 [#2925]: https://github.com/JuliaDocs/Documenter.jl/issues/2925
 [#2953]: https://github.com/JuliaDocs/Documenter.jl/issues/2953
 [#2956]: https://github.com/JuliaDocs/Documenter.jl/issues/2956
@@ -2310,6 +2316,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2963]: https://github.com/JuliaDocs/Documenter.jl/issues/2963
 [#2973]: https://github.com/JuliaDocs/Documenter.jl/issues/2973
 [#2976]: https://github.com/JuliaDocs/Documenter.jl/issues/2976
+[#2992]: https://github.com/JuliaDocs/Documenter.jl/issues/2992
 [JuliaLang/julia#36953]: https://github.com/JuliaLang/julia/issues/36953
 [JuliaLang/julia#38054]: https://github.com/JuliaLang/julia/issues/38054
 [JuliaLang/julia#39841]: https://github.com/JuliaLang/julia/issues/39841

--- a/src/doctests.jl
+++ b/src/doctests.jl
@@ -548,7 +548,16 @@ function fix_doctest(result::Result, str, doc::Documenter.Document; prefix::Muta
     for i in 1:(first(block) - 1)
         write(io, lines[i], '\n')
     end
-    write(io, replace(newcode, r"^(.+)$"m => Base.SubstitutionString(indent * "\\1")))
+
+    # A blank line includes the prefix but removes any trailing whitespace.
+    # Standard indentation should not result in trailing spaces. However, a
+    # block quote marker must remain on the line, because a blank line that
+    # lacks the marker will terminate the quote.
+    blank_indent = rstrip(indent)
+    for (i, line) in enumerate(split(newcode, '\n'))
+        i == 1 || write(io, '\n')
+        write(io, isempty(line) ? blank_indent : indent * line)
+    end
     for i in (last(block) + 1):length(lines)
         write(io, '\n', lines[i])
     end

--- a/src/doctests.jl
+++ b/src/doctests.jl
@@ -494,36 +494,31 @@ function fix_doctest(result::Result, str, doc::Documenter.Document; prefix::Muta
     filename = Base.find_source_file(result.file)
     # read the file containing the code block
     content = read(filename, String)
-    # output stream
-    io = IOBuffer(sizehint = sizeof(content))
+    lines = split(content, '\n')
+    codelines = split(code, '\n')
+
     # first look for the entire code block
-    # make a regex of the code that matches leading whitespace
-    rcode = "(\\h*)" * replace(Documenter.regex_escape(code), "\\n" => "\\n\\h*")
-    r = Regex(rcode)
-    codeidx = findfirst(r, content)
-    if codeidx === nothing
+    block = Documenter.find_block_lines(lines, code)
+    if block === nothing
         @warn "could not find code block in source file $filename"
         return
     end
-    # use the capture group to identify indentation
-    indent = match(r, content).captures[1]
-    # write everything up until the code block
-    data = content[1:prevind(content, first(codeidx))]
-    write(io, data)
+    # the prefix the Markdown parser stripped off the block, restored when writing it back
+    firstline = lines[first(block)]
+    indent = SubString(firstline, 1, Documenter.block_line_prefix_length(firstline, codelines[1]))
+
     # next look for the particular input string in the given code block
-    # make a regex of the input that matches leading whitespace (for multiline input)
     composed = prefix.content * result.raw_input
-    rinput = replace(Documenter.regex_escape(composed), "\\n" => "\\n\\h*")
-    r = Regex(rinput)
-    inputidx = findfirst(r, code)
-    if inputidx === nothing
-        startline = count("\n", data)
-        @warn "could not find input line in code block in $filename:$startline"
+    inputlines = Documenter.find_block_lines(codelines, composed)
+    if inputlines === nothing
+        @warn "could not find input line in code block in $filename:$(first(block) - 1)"
         return
     end
     # construct the new code-snippet (without indent)
-    # first part: everything up until the last index of the input string
-    newcode = code[1:last(inputidx)]
+    # first part: everything up until the last line of the input string
+    newcode = join(view(codelines, 1:last(inputlines)), '\n')
+    rest = last(inputlines) < length(codelines) ?
+        "\n" * join(view(codelines, (last(inputlines) + 1):length(codelines)), '\n') : ""
     prefix.content = newcode * "\n"
     if str != ""
         prefix.content *= str * "\n"
@@ -535,23 +530,28 @@ function fix_doctest(result::Result, str, doc::Documenter.Document; prefix::Muta
         # This works around a regression in Julia 1.5.0 (https://github.com/JuliaLang/julia/issues/36953)
         # Technically, it is only necessary if VERSION >= v"1.5.0-DEV.826"
         newcode *= str
-        newcode *= code[nextind(code, last(inputidx)):end]
+        newcode *= rest
     else
         if str == ""
-            newcode *= replace(code[nextind(code, last(inputidx)):end], result.output * "\n" => str, count = 1)
+            newcode *= replace(rest, result.output * "\n" => str, count = 1)
         else
-            newcode *= replace(code[nextind(code, last(inputidx)):end], result.output => str, count = 1)
+            newcode *= replace(rest, result.output => str, count = 1)
         end
     end
     # replace internal code block with the non-indented new code, needed if we come back
     # looking to replace output in the same code block later
     result.block.code = newcode
-    # write the new code snippet to the stream, with indent
-    newcode = replace(newcode, r"^(.+)$"m => Base.SubstitutionString(indent * "\\1"))
-    write(io, newcode)
-    # write rest of the file
-    write(io, content[nextind(content, last(codeidx)):end])
-    # write to file
+
+    # write the file back out: everything before the block, the new code snippet
+    # with the indent restored, and everything after the block
+    io = IOBuffer(sizehint = sizeof(content))
+    for i in 1:(first(block) - 1)
+        write(io, lines[i], '\n')
+    end
+    write(io, replace(newcode, r"^(.+)$"m => Base.SubstitutionString(indent * "\\1")))
+    for i in (last(block) + 1):length(lines)
+        write(io, '\n', lines[i])
+    end
     write(filename, seekstart(io))
     return
 end

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -52,8 +52,63 @@ macro docerror(doc, tag, msg, exs...)
     end
 end
 
-# escape characters that has a meaning in regex
-regex_escape(str) = sprint(escape_string, str, "\\^\$.|?*+()[{")
+# Locating fenced code blocks in their source file.
+#
+# The Markdown AST carries no source positions, so the only way to report where a
+# code block came from is to search the file for its body. The parser strips the
+# indentation and block quote markers of nested blocks, so the body shows up
+# prefixed in the file:
+#
+#     > - a list item
+#     >
+#     >   ```julia      <- opening fence
+#     >   f(x) = 2x     <- block body, i.e. `code`
+#     >   ```           <- closing fence
+#
+# Matching line by line keeps this working for blocks of any size. Compiling the
+# body into a single regex does not: PCRE rejects patterns beyond ~64 kB, which
+# `@raw html` blocks easily exceed (issue #2992).
+
+const BLOCK_PREFIX_CHARS = (UInt8(' '), UInt8('\t'), UInt8('>'))
+
+rstrip_hspace(str::AbstractString) = rstrip(c -> c == ' ' || c == '\t', str)
+
+"""
+    block_line_prefix_length(line, codeline)
+
+Number of code units that `line` prepends to `codeline`, or `nothing` if `line` is
+not `codeline` preceded by `BLOCK_PREFIX_CHARS` only. Trailing spaces and
+tabs are ignored on both sides.
+"""
+function block_line_prefix_length(line::AbstractString, codeline::AbstractString)
+    line, codeline = rstrip_hspace(line), rstrip_hspace(codeline)
+    n = ncodeunits(line) - ncodeunits(codeline)
+    n < 0 && return nothing
+    for i in 1:n
+        codeunit(line, i) in BLOCK_PREFIX_CHARS || return nothing
+    end
+    return SubString(line, n + 1) == codeline ? n : nothing
+end
+
+"""
+    find_block_lines(lines, code)
+
+Range of indices into `lines` occupied by the body of the code block `code`, or
+`nothing` if the block does not occur in `lines`.
+"""
+function find_block_lines(lines::AbstractVector{<:AbstractString}, code::AbstractString)
+    isempty(code) && return nothing
+    codelines = split(chomp(code), '\n')
+    for start in 1:(length(lines) - length(codelines) + 1)
+        block = start:(start + length(codelines) - 1)
+        matches = all(
+            block_line_prefix_length(lines[i], codelines[j]) !== nothing
+                for (j, i) in enumerate(block)
+        )
+        matches && return block
+    end
+    return nothing
+end
 
 # helper to display linerange for error printing
 function find_block_in_file(code, file)
@@ -62,13 +117,10 @@ function find_block_in_file(code, file)
     isfile(source_file) || return nothing
     content = read(source_file, String)
     content = replace(content, "\r\n" => "\n")
-    # make a regex of the code that matches leading whitespace
-    rcode = "\\h*" * replace(regex_escape(code), "\\n" => "\\n\\h*")
-    blockidx = findfirst(Regex(rcode), content)
-    blockidx === nothing && return nothing
-    startline = countlines(IOBuffer(content[1:prevind(content, first(blockidx))]))
-    endline = startline + countlines(IOBuffer(code)) + 1 # +1 to include the closing ```
-    return startline => endline
+    block = find_block_lines(split(content, '\n'), code)
+    block === nothing && return nothing
+    # report the fences rather than the body
+    return (first(block) - 1) => (last(block) + 1)
 end
 
 # Pretty-printing locations

--- a/test/doctests/fix/broken.md
+++ b/test/doctests/fix/broken.md
@@ -120,3 +120,16 @@ julia> :a / :b
 ERROR: MethodError: no method matching /(::Symbol, ::Symbol)
 [...]
 ```
+
+Blocks nested in a list are indented in the source file:
+
+- a list item
+
+  ```jldoctest
+  julia> Main.DocTestFixArray_2468
+  4-element Array{Int64,1}:
+   1
+   2
+   3
+   4
+  ```

--- a/test/doctests/fix/broken.md
+++ b/test/doctests/fix/broken.md
@@ -133,3 +133,21 @@ Blocks nested in a list are indented in the source file:
    3
    4
   ```
+
+Blocks in a block quote carry a `>` marker, blank lines included:
+
+> ```jldoctest
+> julia> Main.DocTestFixArray_2468
+> 4-element Array{Int64,1}:
+>  1
+>  2
+>  3
+>  4
+>
+> julia> Main.DocTestFixArray_1234
+> 4-element Array{Int64,1}:
+>  1
+>  2
+>  3
+>  4
+> ```

--- a/test/doctests/fix/fixed.md
+++ b/test/doctests/fix/fixed.md
@@ -138,3 +138,17 @@ julia> :a / :b
 ERROR: MethodError: no method matching /(::Symbol, ::Symbol)
 [...]
 ```
+
+Blocks nested in a list are indented in the source file:
+
+- a list item
+
+  ```jldoctest
+  julia> Main.DocTestFixArray_2468
+  4×1×1 Array{Int64,3}:
+  [:, :, 1] =
+   2
+   4
+   6
+   8
+  ```

--- a/test/doctests/fix/fixed.md
+++ b/test/doctests/fix/fixed.md
@@ -152,3 +152,23 @@ Blocks nested in a list are indented in the source file:
    6
    8
   ```
+
+Blocks in a block quote carry a `>` marker, blank lines included:
+
+> ```jldoctest
+> julia> Main.DocTestFixArray_2468
+> 4×1×1 Array{Int64,3}:
+> [:, :, 1] =
+>  2
+>  4
+>  6
+>  8
+>
+> julia> Main.DocTestFixArray_1234
+> 4×1×1 Array{Int64,3}:
+> [:, :, 1] =
+>  1
+>  2
+>  3
+>  4
+> ```

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -605,6 +605,58 @@ end
         end
     end
 
+    @testset "find_block_in_file" begin
+        # The Markdown parser hands over the block body without the surrounding
+        # fences and with the indentation of nested blocks stripped.
+        markdown = """
+        # Title
+
+        ```julia
+        f(x) = 2x
+        ```
+
+        - a list item
+
+          ```@example
+          g(y) = y
+          h(z) = z
+          ```
+
+        > ```@repl
+        > k = 1
+        > ```
+
+        !!! note
+            ```@raw html
+            <p>hi</p>
+            ```
+        """
+        mktempdir() do dir
+            file = joinpath(dir, "index.md")
+            write(file, markdown)
+
+            # the returned range covers the fences, not the body
+            @test Documenter.find_block_in_file("f(x) = 2x", file) == (3 => 5)
+            @test Documenter.find_block_in_file("g(y) = y\nh(z) = z", file) == (9 => 12)
+            @test Documenter.find_block_in_file("k = 1", file) == (14 => 16)
+            @test Documenter.find_block_in_file("<p>hi</p>", file) == (19 => 21)
+
+            @test Documenter.find_block_in_file("not in the file", file) === nothing
+            @test Documenter.find_block_in_file("", file) === nothing
+            @test Documenter.find_block_in_file("f(x) = 2x", joinpath(dir, "nope.md")) === nothing
+
+            crlf = joinpath(dir, "crlf.md")
+            write(crlf, replace(markdown, "\n" => "\r\n"))
+            @test Documenter.find_block_in_file("f(x) = 2x", crlf) == (3 => 5)
+
+            # a block far too large to compile into a regex (issue #2992)
+            huge = join(("<div>line $(i)</div>" for i in 1:5000), "\n")
+            hugefile = joinpath(dir, "huge.md")
+            write(hugefile, "# Title\n\n```@raw html\n$(huge)\n```\n")
+            @test Documenter.find_block_in_file(huge, hugefile) == (3 => 5004)
+        end
+    end
+
     @testset "codelang" begin
         @test Documenter.codelang("") == ""
         @test Documenter.codelang(" ") == ""


### PR DESCRIPTION
`find_block_in_file` escaped a code block's entire body into a regular expression. PCRE refuses patterns beyond ~64 kB, so blocks over roughly 30 kB aborted the build with "regular expression is too large". Since v1.18 every expander resolves a block's location up front for its error messages, `@raw` included, and `@raw` html blocks are routinely larger than that.

Match the block line by line instead: a source line belongs to the block when it is the corresponding body line preceded only by indentation or block quote markers. That also anchors the search to whole lines, so a body line occurring mid-sentence elsewhere in the file no longer wins the match and reports a wrong location; 22 of the 703 blocks in this repository were being reported at the wrong line.

`fix_doctest` built the same kind of regex and now shares the helper.

Fixes #2992

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

CC @giordano 