### PR TITLE
Change guide for Julia v1.12+

### DIFF
--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -37,6 +37,13 @@ $ julia --project=docs
 This will create a `Project.toml` file in the `docs/` subdirectory and add `Documenter` and the top-level package as available packages.
 See also the [Pkg.jl](https://github.com/JuliaLang/Pkg.jl/) documentation on working with [project workspaces](https://pkgdocs.julialang.org/v1/toml-files/#The-[workspace]-section) and [environments](https://pkgdocs.julialang.org/v1/environments/).
 
+For Julia v1.12, one should also manually add
+```
+[sources]
+PkgName = {path = ".."}
+```
+to the `docs/Project.toml` file. This is done automatically in Julia v1.13.
+
 ### Julia v1.11 and earlier
 For Julia versions v1.11 and earlier, creating a separate project in `docs/` is the standard approach.
 To do this, navigate to your package's root folder and do

--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -30,7 +30,8 @@ Next, open up a Julia REPL in the `docs` subdirectory, enter `pkg>` mode with th
 
 ```
 $ julia --project=docs
-(PkgName/docs) pkg> add Documenter PkgName
+(PkgName/docs) pkg> add Documenter
+(PkgName/docs) pkg> dev ..
 ```
 
 This will create a `Project.toml` file in the `docs/` subdirectory and add `Documenter` and the top-level package as available packages.

--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -31,7 +31,7 @@ Next, open up a Julia REPL in the `docs` subdirectory, enter `pkg>` mode with th
 ```
 $ julia --project=docs
 (PkgName/docs) pkg> add Documenter
-(PkgName/docs) pkg> dev ..
+(PkgName/docs) pkg> dev .
 ```
 
 This will create a `Project.toml` file in the `docs/` subdirectory and add `Documenter` and the top-level package as available packages.


### PR DESCRIPTION
Currently, the guide for Julia v1.12+ suggests adding the package to the docs environment as `add PkgName`. As far as I understand, it will tie the docs to the latest registered version of the package and won't even work if the package is not yet registered.
I think we want the docs environment to point to the parent package, so we should `dev ..` instead, as explained in [Pkg.jl docs](https://pkgdocs.julialang.org/v1/creating-packages/#adding-tests-to-packages).